### PR TITLE
MessageWidget now has user's name in the timestamp (like advertised design)

### DIFF
--- a/lib/src/message_widget.dart
+++ b/lib/src/message_widget.dart
@@ -980,12 +980,23 @@ class _MessageWidgetState extends State<MessageWidget>
   Widget _buildTimestamp(Alignment alignment) {
     return Padding(
       padding: const EdgeInsets.only(top: 5.0),
-      child: widget.message.createdAt != null
-          ? Text(
-              Jiffy(widget.message.createdAt.toLocal()).format('HH:mm'),
-              style: _messageTheme.createdAt,
-            )
-          : SizedBox(),
+      child: RichText(
+        text: TextSpan(
+          style: _messageTheme.createdAt,
+          children: <TextSpan>[
+            if (!_isMyMessage)
+              TextSpan(
+                text: widget.message.user.name,
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            if (widget.message.createdAt != null)
+              TextSpan(
+                text:
+                    Jiffy(widget.message.createdAt.toLocal()).format(' HH:mm'),
+              ),
+          ],
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Added User's name on the timestamp for the message_widget as advertised on the [website](https://getstream.io/chat/flutter/tutorial/)

Android:
![Screenshot_1586272937](https://user-images.githubusercontent.com/6027290/78688753-927f6600-78c3-11ea-838c-aef254771c90.png)

iOS:
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-07 at 11 19 40](https://user-images.githubusercontent.com/6027290/78688774-97dcb080-78c3-11ea-9595-7a80497ad258.png)
