### PR TITLE
Hotfix/attachments

### DIFF
--- a/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -147,6 +147,7 @@ class _MessageInputState extends State<MessageInput> {
           onSubmitted: (_) {
             _sendMessage(context);
           },
+          keyboardType: TextInputType.text,
           controller: _textController,
           focusNode: _focusNode,
           onChanged: (s) {

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -90,6 +90,7 @@ class _MessageInputState extends State<MessageInput> {
   final List<User> _mentionedUsers = [];
 
   TextEditingController _textController;
+  bool _inputEnabled = true;
   bool _messageIsPresent = false;
   bool _typingStarted = false;
   OverlayEntry _commandsOverlay, _mentionsOverlay;
@@ -153,6 +154,7 @@ class _MessageInputState extends State<MessageInput> {
         maxHeight: widget.maxHeight,
         child: TextField(
           key: Key('messageInputText'),
+          enabled: _inputEnabled,
           minLines: null,
           maxLines: null,
           onSubmitted: (_) {
@@ -590,6 +592,10 @@ class _MessageInputState extends State<MessageInput> {
   }
 
   void _pickFile(FileType type, bool camera) async {
+    setState(() {
+      _inputEnabled = false;
+    });
+
     File file;
 
     if (camera) {
@@ -601,6 +607,10 @@ class _MessageInputState extends State<MessageInput> {
     } else {
       file = await FilePicker.getFile(type: type);
     }
+
+    setState(() {
+      _inputEnabled = true;
+    });
 
     if (file == null) {
       return;

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -62,6 +62,7 @@ class MessageInput extends StatefulWidget {
     this.parentMessage,
     this.editMessage,
     this.maxHeight = 150,
+    this.keyboardType = TextInputType.multiline,
   }) : super(key: key);
 
   /// Message to edit
@@ -75,6 +76,9 @@ class MessageInput extends StatefulWidget {
 
   /// Maximum Height for the TextField to grow before it starts scrolling
   final double maxHeight;
+
+  /// The keyboard type assigned to the TextField
+  final TextInputType keyboardType;
 
   @override
   _MessageInputState createState() => _MessageInputState();
@@ -93,20 +97,27 @@ class _MessageInputState extends State<MessageInput> {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Stack(
-          overflow: Overflow.visible,
-          children: <Widget>[
-            _buildBorder(context),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildAttachments(),
-                _buildTextField(context),
-              ],
-            ),
-          ],
+      child: GestureDetector(
+        onPanUpdate: (details) {
+          if (details.delta.dy > 0) {
+            _focusNode.unfocus();
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Stack(
+            overflow: Overflow.visible,
+            children: <Widget>[
+              _buildBorder(context),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildAttachments(),
+                  _buildTextField(context),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -147,7 +158,7 @@ class _MessageInputState extends State<MessageInput> {
           onSubmitted: (_) {
             _sendMessage(context);
           },
-          keyboardType: TextInputType.text,
+          keyboardType: widget.keyboardType,
           controller: _textController,
           focusNode: _focusNode,
           onChanged: (s) {

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -138,7 +138,8 @@ class _MessageInputState extends State<MessageInput> {
 
   AnimatedCrossFade _animateSendButton(BuildContext context) {
     return AnimatedCrossFade(
-      crossFadeState: (_messageIsPresent || _attachments.isNotEmpty)
+      crossFadeState: ((_messageIsPresent || _attachments.isNotEmpty) &&
+              _attachments.every((a) => a.uploaded == true))
           ? CrossFadeState.showFirst
           : CrossFadeState.showSecond,
       firstChild: _buildSendButton(context),

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -56,13 +56,13 @@ import 'stream_channel.dart';
 /// The widget renders the ui based on the first ancestor of type [StreamChatTheme].
 /// Modify it to change the widget appearance.
 class MessageInput extends StatefulWidget {
-  MessageInput(
-      {Key key,
-      this.onMessageSent,
-      this.parentMessage,
-      this.editMessage,
-      this.maxHeight = 150})
-      : super(key: key);
+  MessageInput({
+    Key key,
+    this.onMessageSent,
+    this.parentMessage,
+    this.editMessage,
+    this.maxHeight = 150,
+  }) : super(key: key);
 
   /// Message to edit
   final Message editMessage;
@@ -506,6 +506,10 @@ class _MessageInputState extends State<MessageInput> {
   }
 
   void _showAttachmentModal() {
+    if (_focusNode.hasFocus) {
+      _focusNode.unfocus();
+    }
+
     showModalBottomSheet(
         clipBehavior: Clip.hardEdge,
         shape: RoundedRectangleBorder(
@@ -548,7 +552,6 @@ class _MessageInputState extends State<MessageInput> {
                 leading: Icon(Icons.camera_alt),
                 title: Text('Photo from camera'),
                 onTap: () {
-                  ImagePicker.pickImage(source: ImageSource.camera);
                   _pickFile(FileType.image, true);
                   Navigator.pop(context);
                 },
@@ -585,6 +588,10 @@ class _MessageInputState extends State<MessageInput> {
       }
     } else {
       file = await FilePicker.getFile(type: type);
+    }
+
+    if (file == null) {
+      return;
     }
 
     final channel = StreamChannel.of(context).channel;

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -63,6 +63,7 @@ class MessageInput extends StatefulWidget {
     this.editMessage,
     this.maxHeight = 150,
     this.keyboardType = TextInputType.multiline,
+    this.disableAttachments = false,
   }) : super(key: key);
 
   /// Message to edit
@@ -79,6 +80,9 @@ class MessageInput extends StatefulWidget {
 
   /// The keyboard type assigned to the TextField
   final TextInputType keyboardType;
+
+  /// If true the attachments button will not be displayed
+  final bool disableAttachments;
 
   @override
   _MessageInputState createState() => _MessageInputState();
@@ -129,7 +133,7 @@ class _MessageInputState extends State<MessageInput> {
       direction: Axis.horizontal,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: <Widget>[
-        _buildAttachmentButton(),
+        if (!widget.disableAttachments) _buildAttachmentButton(),
         _buildTextInput(context),
         _animateSendButton(context),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,6 @@ dependencies:
   flutter:
     sdk: flutter
   rxdart: ^0.23.1
-
-
   jiffy: ^3.0.1
   cached_network_image: ^2.0.0
   flutter_markdown: ^0.3.4


### PR DESCRIPTION
- Fix video aspect ratio
- Add property to decide whether to enable video fullscreen
- Add property to hide the attachment button
- Do not show send button if an attachment is still uploading
- Unfocus and disable the TextField before opening the camera (workaround for https://github.com/flutter/flutter/issues/42417)
- Add gesture (vertical drag down) to close the keyboard
- Add keyboard type parameters (set it to `TextInputType.text` to show the submit button that will even close the keyboard)

The property showVideoFullScreen was added mainly because of this issue brianegan/chewie#261