### PR TITLE
Feature/message input actions

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,7 +67,6 @@ void main() async {
   final client = Client(
     's2dxdhpxd94g',
     logLevel: Level.INFO,
-    persistenceEnabled: false,
     showLocalNotification: Platform.isAndroid ? showLocalNotification : null,
   );
 

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -139,10 +139,7 @@ class MessageInput extends StatefulWidget {
   final Map<String, AttachmentThumbnailBuilder> attachmentThumbnailBuilder;
 
   @override
-  MessageInputState createState() => MessageInputState(
-        doFileUploadRequest: doFileUploadRequest,
-        doImageUploadRequest: doImageUploadRequest,
-      );
+  MessageInputState createState() => MessageInputState();
 
   /// Use this method to get the current [StreamChatState] instance
   static MessageInputState of(BuildContext context) {
@@ -163,22 +160,14 @@ class MessageInputState extends State<MessageInput> {
   final List<_SendingAttachment> _attachments = [];
   final _focusNode = FocusNode();
   final List<User> _mentionedUsers = [];
-  FileUploader doImageUploadRequest;
-  FileUploader doFileUploadRequest;
 
-  TextEditingController textEditingController;
   bool _inputEnabled = true;
   bool _messageIsPresent = false;
   bool _typingStarted = false;
   OverlayEntry _commandsOverlay, _mentionsOverlay;
 
-  MessageInputState({
-    this.doImageUploadRequest,
-    this.doFileUploadRequest,
-  }) {
-    doImageUploadRequest ??= _uploadImage;
-    doFileUploadRequest ??= _uploadFile;
-  }
+  /// The editing controller passed to the input TextField
+  TextEditingController textEditingController;
 
   @override
   Widget build(BuildContext context) {
@@ -613,6 +602,7 @@ class MessageInputState extends State<MessageInput> {
     );
   }
 
+  /// Show the attachment modal, making the user choose where to pick a media from
   void showAttachmentModal() {
     if (_focusNode.hasFocus) {
       _focusNode.unfocus();
@@ -778,9 +768,17 @@ class MessageInputState extends State<MessageInput> {
   ) async {
     String url;
     if (type == DefaultAttachmentTypes.image) {
-      url = await doImageUploadRequest(file, channel);
+      if (widget.doImageUploadRequest != null) {
+        url = await widget.doImageUploadRequest(file, channel);
+      } else {
+        url = await _uploadImage(file, channel);
+      }
     } else {
-      url = await doFileUploadRequest(file, channel);
+      if (widget.doFileUploadRequest != null) {
+        url = await widget.doFileUploadRequest(file, channel);
+      } else {
+        url = await _uploadFile(file, channel);
+      }
     }
     return url;
   }

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -547,6 +547,9 @@ class MessageInputState extends State<MessageInput> {
   }
 
   Widget _buildAttachment(_SendingAttachment attachment) {
+    print('attachment.attachment.toJson(): ${attachment.attachment.toJson()}');
+    print(
+        'widget.attachmentThumbnailBuilder: ${widget.attachmentThumbnailBuilder}');
     if (widget.attachmentThumbnailBuilder
             ?.containsKey(attachment.attachment.type) ==
         true) {
@@ -944,8 +947,7 @@ class MessageInputState extends State<MessageInput> {
     textEditingController =
         widget.textEditingController ?? TextEditingController();
     if (widget.editMessage != null || widget.initialMessage != null) {
-      _parseExistingMessage(
-          widget.editMessage ?? widget.initialMessage != null);
+      _parseExistingMessage(widget.editMessage ?? widget.initialMessage);
     }
   }
 
@@ -956,6 +958,7 @@ class MessageInputState extends State<MessageInput> {
     _messageIsPresent = true;
 
     message.attachments?.forEach((attachment) {
+      print('attachment: ${attachment.toJson()}');
       _attachments.add(_SendingAttachment(
         attachment: attachment,
         uploaded: true,

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -92,7 +92,7 @@ class MessageInput extends StatefulWidget {
     this.textEditingController,
     this.actions,
     this.actionsLocation = ActionsLocation.left,
-    this.attachmentThumbnailBuilder,
+    this.attachmentThumbnailBuilders,
   }) : super(key: key);
 
   /// Message to edit
@@ -135,8 +135,8 @@ class MessageInput extends StatefulWidget {
   /// The location of the custom actions
   final ActionsLocation actionsLocation;
 
-  /// Map that defines a builder for an attachment type
-  final Map<String, AttachmentThumbnailBuilder> attachmentThumbnailBuilder;
+  /// Map that defines a thumbnail builder for an attachment type
+  final Map<String, AttachmentThumbnailBuilder> attachmentThumbnailBuilders;
 
   @override
   MessageInputState createState() => MessageInputState();
@@ -547,13 +547,10 @@ class MessageInputState extends State<MessageInput> {
   }
 
   Widget _buildAttachment(_SendingAttachment attachment) {
-    print('attachment.attachment.toJson(): ${attachment.attachment.toJson()}');
-    print(
-        'widget.attachmentThumbnailBuilder: ${widget.attachmentThumbnailBuilder}');
-    if (widget.attachmentThumbnailBuilder
+    if (widget.attachmentThumbnailBuilders
             ?.containsKey(attachment.attachment.type) ==
         true) {
-      return widget.attachmentThumbnailBuilder[attachment.attachment.type](
+      return widget.attachmentThumbnailBuilders[attachment.attachment.type](
         context,
         attachment,
       );
@@ -897,6 +894,10 @@ class MessageInputState extends State<MessageInput> {
     return sendingFuture.whenComplete(() {
       if (widget.onMessageSent != null) {
         widget.onMessageSent(message);
+      } else {
+        if (widget.editMessage != null) {
+          Navigator.pop(context);
+        }
       }
     });
   }
@@ -958,7 +959,6 @@ class MessageInputState extends State<MessageInput> {
     _messageIsPresent = true;
 
     message.attachments?.forEach((attachment) {
-      print('attachment: ${attachment.toJson()}');
       _attachments.add(_SendingAttachment(
         attachment: attachment,
         uploaded: true,

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -604,7 +604,7 @@ class MessageInputState extends State<MessageInput> {
       color: Colors.transparent,
       child: IconButton(
         onPressed: () {
-          _showAttachmentModal();
+          showAttachmentModal();
         },
         icon: Icon(
           Icons.add_circle_outline,
@@ -613,7 +613,7 @@ class MessageInputState extends State<MessageInput> {
     );
   }
 
-  void _showAttachmentModal() {
+  void showAttachmentModal() {
     if (_focusNode.hasFocus) {
       _focusNode.unfocus();
     }

--- a/lib/src/message_list_view.dart
+++ b/lib/src/message_list_view.dart
@@ -73,6 +73,7 @@ class MessageListView extends StatefulWidget {
     this.attachmentBuilders,
     this.dateDividerBuilder,
     this.showAvatar = true,
+    this.editMessageInputBuilder,
   }) : super(key: key);
 
   /// Function used to build a custom message widget
@@ -114,6 +115,9 @@ class MessageListView extends StatefulWidget {
 
   /// if true shows the user avatar
   final bool showAvatar;
+
+  /// Builder used to build the message input to edit a message
+  final Widget Function(BuildContext, Message) editMessageInputBuilder;
 
   @override
   _MessageListViewState createState() => _MessageListViewState();
@@ -177,6 +181,7 @@ class _MessageListViewState extends State<MessageListView> {
                         onMessageActions: widget.onMessageActions,
                         attachmentBuilders: widget.attachmentBuilders,
                         showAvatar: widget.showAvatar,
+                        editMessageInputBuilder: widget.editMessageInputBuilder,
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -243,6 +248,7 @@ class _MessageListViewState extends State<MessageListView> {
                   onMessageActions: widget.onMessageActions,
                   attachmentBuilders: widget.attachmentBuilders,
                   showAvatar: widget.showAvatar,
+                  editMessageInputBuilder: widget.editMessageInputBuilder,
                 );
               }
             }
@@ -337,6 +343,7 @@ class _MessageListViewState extends State<MessageListView> {
         onMessageActions: widget.onMessageActions,
         attachmentBuilders: widget.attachmentBuilders,
         showAvatar: widget.showAvatar,
+        editMessageInputBuilder: widget.editMessageInputBuilder,
       );
     }
 
@@ -379,6 +386,7 @@ class _MessageListViewState extends State<MessageListView> {
         onMessageActions: widget.onMessageActions,
         attachmentBuilders: widget.attachmentBuilders,
         showAvatar: widget.showAvatar,
+        editMessageInputBuilder: widget.editMessageInputBuilder,
       );
     }
 

--- a/lib/src/message_widget.dart
+++ b/lib/src/message_widget.dart
@@ -712,10 +712,6 @@ class _MessageWidgetState extends State<MessageWidget>
                           child: Icon(
                             Icons.close,
                             size: 15,
-                            color:
-                                Theme.of(context).brightness == Brightness.dark
-                                    ? Colors.white
-                                    : Colors.black,
                           ),
                         ),
                       ),

--- a/lib/src/message_widget.dart
+++ b/lib/src/message_widget.dart
@@ -51,6 +51,7 @@ class MessageWidget extends StatefulWidget {
     this.showVideoFullScreen = true,
     this.attachmentBuilders,
     this.showAvatar = true,
+    this.editMessageInputBuilder,
   }) : super(key: key);
 
   /// Function called on mention tap
@@ -88,6 +89,9 @@ class MessageWidget extends StatefulWidget {
 
   /// if true shows the user avatar
   final bool showAvatar;
+
+  /// Builder used to build the message input to edit a message
+  final Widget Function(BuildContext, Message) editMessageInputBuilder;
 
   @override
   _MessageWidgetState createState() => _MessageWidgetState();
@@ -723,21 +727,23 @@ class _MessageWidgetState extends State<MessageWidget>
                 padding: EdgeInsets.only(
                   bottom: MediaQuery.of(context).viewInsets.bottom,
                 ),
-                child: MessageInput(
-                  editMessage: widget.message,
-                  parentMessage: widget.isParent
-                      ? StreamChannel.of(context)
-                          .channel
-                          .state
-                          .messages
-                          .firstWhere((message) =>
-                              message.id == widget.message.parentId)
-                      : null,
-                  onMessageSent: (_) {
-                    FocusScope.of(context).unfocus();
-                    Navigator.pop(context);
-                  },
-                ),
+                child: widget.editMessageInputBuilder != null
+                    ? widget.editMessageInputBuilder(context, widget.message)
+                    : MessageInput(
+                        editMessage: widget.message,
+                        parentMessage: widget.isParent
+                            ? StreamChannel.of(context)
+                                .channel
+                                .state
+                                .messages
+                                .firstWhere((message) =>
+                                    message.id == widget.message.parentId)
+                            : null,
+                        onMessageSent: (_) {
+                          FocusScope.of(context).unfocus();
+                          Navigator.pop(context);
+                        },
+                      ),
               ),
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   file_picker: ^1.6.3+2
   image_picker: ^0.6.5
   flutter_keyboard_visibility: ^2.0.0
-  stream_chat: ^0.2.0-alpha+6
+  stream_chat: ^0.2.0-alpha+8
   mime: ^0.9.6+3
   visibility_detector: ^0.1.4
   http_parser: ^3.1.4


### PR DESCRIPTION
## MessageInput
- add `actions` parameter
- add `textEditingController` parameter
- add `actionsLocation` (RIGHT or LEFT) parameter
- add `attachmentThumbnailBuilders`
- add `editMessageInputBuilder` to customize the `MessageInput` while editing messages
- expose `MessageInputState`

Using `attachmentThumbnailBuilders` it's possible to render custom attachment thumbnails both for standard and custom attachment types

Using `MessageInput.of` or a `GlobalKey<MessageInputState>` it's possible to call these methods:
- `sendMessage` to send the message
- `pickFile` to open the gallery/camera to pick a file
-  `addAttachment` to add a custom attachment to the message
- `showAttachmentModal` to show the modal (that's the behaviour of the attachmentButton)