### PR TITLE
Pass in SendMessageResponse to onMessageSent callback, instead of mos…

### DIFF
--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -909,9 +909,9 @@ class MessageInputState extends State<MessageInput> {
           );
     }
 
-    return sendingFuture.whenComplete(() {
+    return sendingFuture.then((resp) {
       if (widget.onMessageSent != null) {
-        widget.onMessageSent(message);
+        widget.onMessageSent(resp.message);
       } else {
         if (widget.editMessage != null) {
           Navigator.pop(context);


### PR DESCRIPTION
…tly empty Message object.

When a message is sent, there's a callback called `onMessageSent`; right now it passes in the `Message` object before it's sent, so if we do something like modify the message in a presend hook, we have no way to get the message response and check for something like an error type. This change passes in the `Message` object that is returned from the API. 

# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
