### PR TITLE
Expose ScrollViewKeyboardDismissBehavior to LIstView

### DIFF
--- a/lib/src/message_list_view.dart
+++ b/lib/src/message_list_view.dart
@@ -104,6 +104,7 @@ class MessageListView extends StatefulWidget {
     this.onThreadTap,
     this.dateDividerBuilder,
     this.scrollPhysics = const AlwaysScrollableScrollPhysics(),
+    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
   }) : super(key: key);
 
   /// Function used to build a custom message widget
@@ -127,6 +128,9 @@ class MessageListView extends StatefulWidget {
 
   /// The ScrollPhysics used by the ListView
   final ScrollPhysics scrollPhysics;
+
+  /// The [ScrollViewKeyboardDismissBehavior] used by the ListView
+  final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
 
   @override
   _MessageListViewState createState() => _MessageListViewState();
@@ -159,6 +163,7 @@ class _MessageListViewState extends State<MessageListView> {
       child: ListView.custom(
         key: Key('messageListView'),
         physics: widget.scrollPhysics,
+        keyboardDismissBehavior: widget.keyboardDismissBehavior,
         controller: _scrollController,
         reverse: true,
         childrenDelegate: SliverChildBuilderDelegate(


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Most chat apps have a notion of the keyboard dismissing when the user pulls down on the chat. Added the property to MessageListView and forward that to the ListView that's created inside