### PR TITLE
Expose builder for empty channel state

### DIFF
--- a/lib/src/channel_list_view.dart
+++ b/lib/src/channel_list_view.dart
@@ -63,12 +63,16 @@ class ChannelListView extends StatefulWidget {
     this.channelPreviewBuilder,
     this.separatorBuilder,
     this.errorBuilder,
+    this.emptyBuilder,
     this.onImageTap,
     this.pullToRefresh = true,
   }) : super(key: key);
 
   /// The builder that will be used in case of error
   final Widget Function(Error error) errorBuilder;
+
+  /// The builder used when the channel list is empty.
+  final  WidgetBuilder emptyBuilder;
 
   /// The query filters to use.
   /// You can query on any of the custom fields you've defined on the [Channel].
@@ -231,7 +235,11 @@ class _ChannelListViewState extends State<ChannelListView>
 
           final channels = snapshot.data;
 
-          if (channels.isEmpty) {
+          if (channels.isEmpty && widget.emptyBuilder != null) {
+              return widget.emptyBuilder(context);
+          } 
+
+          if (channels.isEmpty && widget.emptyBuilder == null) {
             return LayoutBuilder(
               builder: (context, viewportConstraints) {
                 return SingleChildScrollView(


### PR DESCRIPTION
## The Problem
The widget `ChannelListView` allows for various levels of customization through builders. Notably, it does not allow a user to customize messages or layouts for empty channels. 

## The Solution 
This PR adds a new builder `emptyBuilder` to handle instances where a channel list might be empty. This builder can be null and in instances where this is true, it defaults to the pre-configured error message previously shown. 

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)


