### PR TITLE
Expose addition input styling options

### DIFF
--- a/lib/src/channel_list_view.dart
+++ b/lib/src/channel_list_view.dart
@@ -63,12 +63,16 @@ class ChannelListView extends StatefulWidget {
     this.channelPreviewBuilder,
     this.separatorBuilder,
     this.errorBuilder,
+    this.emptyBuilder,
     this.onImageTap,
     this.pullToRefresh = true,
   }) : super(key: key);
 
   /// The builder that will be used in case of error
   final Widget Function(Error error) errorBuilder;
+
+  /// The builder used when the channel list is empty.
+  final  WidgetBuilder emptyBuilder;
 
   /// The query filters to use.
   /// You can query on any of the custom fields you've defined on the [Channel].
@@ -231,7 +235,11 @@ class _ChannelListViewState extends State<ChannelListView>
 
           final channels = snapshot.data;
 
-          if (channels.isEmpty) {
+          if (channels.isEmpty && widget.emptyBuilder != null) {
+              return widget.emptyBuilder(context);
+          } 
+
+          if (channels.isEmpty && widget.emptyBuilder == null) {
             return LayoutBuilder(
               builder: (context, viewportConstraints) {
                 return SingleChildScrollView(

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -94,6 +94,7 @@ class MessageInput extends StatefulWidget {
     this.actionsLocation = ActionsLocation.left,
     this.attachmentThumbnailBuilders,
     this.inputTextStyle,
+    this.attachmentIconColor
   }) : super(key: key);
 
   /// Message to edit
@@ -142,6 +143,9 @@ class MessageInput extends StatefulWidget {
   /// Text style used in message text field. If null, [MessageInput] uses
   /// `Theme.of(context).textTheme.bodyText2`.
   final TextStyle inputTextStyle;
+
+  /// Color used for attachment icon.
+  final Color attachmentIconColor;
 
   @override
   MessageInputState createState() => MessageInputState();
@@ -622,6 +626,7 @@ class MessageInputState extends State<MessageInput> {
         },
         icon: Icon(
           Icons.add_circle_outline,
+          color: widget.attachmentIconColor,
         ),
       ),
     );

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -605,10 +605,10 @@ class MessageInputState extends State<MessageInput> {
   Material _buildAttachmentButton() {
     return Material(
       clipBehavior: Clip.hardEdge,
+      type: MaterialType.transparency,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(32),
       ),
-      color: Colors.transparent,
       child: IconButton(
         onPressed: () {
           showAttachmentModal();

--- a/lib/src/message_input.dart
+++ b/lib/src/message_input.dart
@@ -93,6 +93,7 @@ class MessageInput extends StatefulWidget {
     this.actions,
     this.actionsLocation = ActionsLocation.left,
     this.attachmentThumbnailBuilders,
+    this.inputTextStyle,
   }) : super(key: key);
 
   /// Message to edit
@@ -137,6 +138,10 @@ class MessageInput extends StatefulWidget {
 
   /// Map that defines a thumbnail builder for an attachment type
   final Map<String, AttachmentThumbnailBuilder> attachmentThumbnailBuilders;
+
+  /// Text style used in message text field. If null, [MessageInput] uses
+  /// `Theme.of(context).textTheme.bodyText2`.
+  final TextStyle inputTextStyle;
 
   @override
   MessageInputState createState() => MessageInputState();
@@ -276,10 +281,12 @@ class MessageInputState extends State<MessageInput> {
               _typingStarted = true;
             });
           },
-          style: Theme.of(context).textTheme.bodyText2,
+          style: widget.inputTextStyle ?? Theme.of(context).textTheme.bodyText2,
           autofocus: false,
           decoration: InputDecoration(
             hintText: 'Write a message',
+            hintStyle: widget.inputTextStyle ??
+                Theme.of(context).textTheme.bodyText2,
             prefixText: '   ',
             border: InputBorder.none,
           ),


### PR DESCRIPTION
## The problem
The input text style and icon used as part of `MessageInput` are not configurable in the constructor or via `StreamChatTheme`. 

## The Solution
This PR adds two additional options to `MessageInput`. 
- `inputTextStyle`: Text style used in message text field. If null, `MessageInput` uses `Theme.of(context).textTheme.bodyText2`.
- `attachmentIconColor`: Color used for the attachment icon. 

### Other changes 
- Remove `Colors.transparency` in favor of `MaterialType.transparency`. 


PR #135 should be merged first.

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)
