### PR TITLE
Feature/channel list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.17+2
+
+- Expose ChannelsBloc.channels setter
+
 ## 0.2.17+1
 
 - Fix mention tap bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.17+2
 
-- Expose ChannelsBloc.channels setter
+- Expose ChannelsBloc.channelsComparator to sort channels on message.new event
 
 ## 0.2.17+1
 

--- a/lib/src/channels_bloc.dart
+++ b/lib/src/channels_bloc.dart
@@ -58,6 +58,11 @@ class ChannelsBlocState extends State<ChannelsBloc>
 
   final BehaviorSubject<List<Channel>> _channelsController = BehaviorSubject();
 
+  /// Set the current channel list
+  set channels(List<Channel> newChannels) {
+    _channelsController.add(newChannels);
+  }
+
   /// The stream notifying the state of queryChannel call
   Stream<bool> get queryChannelsLoading =>
       _queryChannelsLoadingController.stream;

--- a/lib/src/channels_bloc.dart
+++ b/lib/src/channels_bloc.dart
@@ -14,11 +14,15 @@ class ChannelsBloc extends StatefulWidget {
   /// Set this to true to prevent channels to be brought to the top of the list when a new message arrives
   final bool lockChannelsOrder;
 
+  /// Function used to sort the channels when a message.new event is received
+  final List<Channel> Function(List<Channel>) sortChannels;
+
   /// Instantiate a new ChannelsBloc
   const ChannelsBloc({
     Key key,
     this.child,
     this.lockChannelsOrder = false,
+    this.sortChannels,
   }) : super(key: key);
 
   @override
@@ -57,11 +61,6 @@ class ChannelsBlocState extends State<ChannelsBloc>
       BehaviorSubject.seeded(false);
 
   final BehaviorSubject<List<Channel>> _channelsController = BehaviorSubject();
-
-  /// Set the current channel list
-  set channels(List<Channel> newChannels) {
-    _channelsController.add(newChannels);
-  }
 
   /// The stream notifying the state of queryChannel call
   Stream<bool> get queryChannelsLoading =>
@@ -146,7 +145,13 @@ class ChannelsBlocState extends State<ChannelsBloc>
             }
           }
         }
-        _channelsController.add(newChannels);
+
+        if (widget.sortChannels != null) {
+          final sortedChannels = widget.sortChannels(newChannels);
+          _channelsController.add(sortedChannels);
+        } else {
+          _channelsController.add(newChannels);
+        }
       }));
     }
 

--- a/lib/src/channels_bloc.dart
+++ b/lib/src/channels_bloc.dart
@@ -14,15 +14,15 @@ class ChannelsBloc extends StatefulWidget {
   /// Set this to true to prevent channels to be brought to the top of the list when a new message arrives
   final bool lockChannelsOrder;
 
-  /// Function used to sort the channels when a message.new event is received
-  final List<Channel> Function(List<Channel>) sortChannels;
+  /// Comparator used to sort the channels when a message.new event is received
+  final Comparator<Channel> channelsComparator;
 
   /// Instantiate a new ChannelsBloc
   const ChannelsBloc({
     Key key,
     this.child,
     this.lockChannelsOrder = false,
-    this.sortChannels,
+    this.channelsComparator,
   }) : super(key: key);
 
   @override
@@ -146,12 +146,10 @@ class ChannelsBlocState extends State<ChannelsBloc>
           }
         }
 
-        if (widget.sortChannels != null) {
-          final sortedChannels = widget.sortChannels(newChannels);
-          _channelsController.add(sortedChannels);
-        } else {
-          _channelsController.add(newChannels);
+        if (widget.channelsComparator != null) {
+          newChannels.sort(widget.channelsComparator);
         }
+        _channelsController.add(newChannels);
       }));
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 0.2.17+1
+version: 0.2.17+2
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 


### PR DESCRIPTION
sometimes users sort by custom property 
in that case it's good to not sort the channels on message.new events setting `lockChannelsOrder: true` and to listen to that event on your own
with this pr we expose the channels setter so that users can update it 