### PR TITLE
Hotfix/channels bloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.20+2
+
+- Added `shouldAddChannel` to ChannelsBloc in order to check if a channel has to be added to the list when a new message arrives
+
 ## 0.2.20+1
 
 - Fixed bug that caused video attachment to show the same preview

--- a/lib/src/channels_bloc.dart
+++ b/lib/src/channels_bloc.dart
@@ -17,12 +17,16 @@ class ChannelsBloc extends StatefulWidget {
   /// Comparator used to sort the channels when a message.new event is received
   final Comparator<Channel> channelsComparator;
 
+  /// Function used to evaluate if a channel should be added to the list when a message.new event is received
+  final bool Function(Event) shouldAddChannel;
+
   /// Instantiate a new ChannelsBloc
   const ChannelsBloc({
     Key key,
     this.child,
     this.lockChannelsOrder = false,
     this.channelsComparator,
+    this.shouldAddChannel,
   }) : super(key: key);
 
   @override
@@ -128,7 +132,8 @@ class ChannelsBlocState extends State<ChannelsBloc>
             final channel = newChannels.removeAt(index);
             newChannels.insert(0, channel);
           }
-        } else {
+        } else if (widget.shouldAddChannel != null &&
+            widget.shouldAddChannel(e)) {
           final hiddenIndex = _hiddenChannels.indexWhere((c) => c.cid == e.cid);
           if (hiddenIndex > -1) {
             newChannels.insert(0, _hiddenChannels[hiddenIndex]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 0.2.20+1
+version: 0.2.20+2
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The problem is that if we have the channel in memory we just add it, but it may happen that the channel is being used in another list.
Using `shouldAddChannel` the user can filter in the channels they want to add when a new message arrives.
This will probably be removed if we manage to create a filter system that is able to do such a thing.
