### PR TITLE
[Dart-LLC] Create enum for Push Providers 

### DIFF
--- a/packages/dart_client/lib/src/client.dart
+++ b/packages/dart_client/lib/src/client.dart
@@ -46,6 +46,26 @@ const String KEY_TOKEN = 'KEY_TOKEN';
 /// The key used to save the apiKey to sharedPreferences
 const String KEY_API_KEY = 'KEY_API_KEY';
 
+/// Provider used to send push notifications.
+enum PushProvider {
+  /// Send notifications using Google's Firebase Cloud Messaging
+  firebase,
+
+  /// Send notifications using Apple's Push Notification service
+  apn
+}
+
+extension on PushProvider {
+  /// Returns the string notion for [PushProvider].
+  String get name {
+    if (this == PushProvider.apn) {
+      return 'apn';
+    } else {
+      return 'firebase';
+    }
+  }
+}
+
 /// The official Dart client for Stream Chat,
 /// a service for building chat applications.
 /// This library can be used on any Dart project and on both mobile and web apps with Flutter.
@@ -1002,10 +1022,10 @@ class Client {
   }
 
   /// Add a device for Push Notifications.
-  Future<EmptyResponse> addDevice(String id, String pushProvider) async {
+  Future<EmptyResponse> addDevice(String id, PushProvider pushProvider) async {
     final response = await post('/devices', data: {
       'id': id,
-      'push_provider': pushProvider,
+      'push_provider': pushProvider.name,
     });
     return decode<EmptyResponse>(response.data, EmptyResponse.fromJson);
   }

--- a/packages/dart_client/test/src/client_test.dart
+++ b/packages/dart_client/test/src/client_test.dart
@@ -266,13 +266,17 @@ void main() {
 
         when(mockDio.post<String>('/devices', data: {
           'id': 'test-id',
-          'push_provider': 'test',
+          'push_provider': 'firebase',
         })).thenAnswer((_) async => Response(data: '{}', statusCode: 200));
 
         await client.addDevice('test-id', PushProvider.firebase);
 
-        verify(mockDio.post<String>('/devices',
-            data: {'id': 'test-id', 'push_provider': 'test'})).called(1);
+        verify(
+          mockDio.post<String>(
+            '/devices',
+            data: {'id': 'test-id', 'push_provider': 'firebase'},
+          ),
+        ).called(1);
       });
 
       test('getDevices', () async {

--- a/packages/dart_client/test/src/client_test.dart
+++ b/packages/dart_client/test/src/client_test.dart
@@ -269,7 +269,7 @@ void main() {
           'push_provider': 'test',
         })).thenAnswer((_) async => Response(data: '{}', statusCode: 200));
 
-        await client.addDevice('test-id', 'test');
+        await client.addDevice('test-id', PushProvider.firebase);
 
         verify(mockDio.post<String>('/devices',
             data: {'id': 'test-id', 'push_provider': 'test'})).called(1);

--- a/packages/flutter_widgets/example/lib/notifications_service.dart
+++ b/packages/flutter_widgets/example/lib/notifications_service.dart
@@ -56,7 +56,7 @@ void initNotifications(Client client) {
     if (connector.token.value != null) {
       client.addDevice(
         connector.token.value,
-        Platform.isAndroid ? 'firebase' : 'apn',
+        Platform.isAndroid ? PushProvider.firebase : PushProvider.apn,
       );
     }
   });


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
- Replace push provider string with an enum. 
- Add document for added public API surface
