### PR TITLE
fix: Method being called during build

### DIFF
--- a/packages/stream_chat_flutter/lib/src/channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/channel_list_view.dart
@@ -553,7 +553,7 @@ class _ChannelListViewState extends State<ChannelListView> {
                     ChannelPreview(
                       onLongPress: widget.onChannelLongPress,
                       channel: channel,
-                      onImageTap: ()=> widget.onImageTap?.call(channel),
+                      onImageTap: () => widget.onImageTap?.call(channel),
                       onTap: (channel) => onTap(channel, widget.channelWidget),
                     ),
               ),

--- a/packages/stream_chat_flutter/lib/src/channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/channel_list_view.dart
@@ -553,7 +553,7 @@ class _ChannelListViewState extends State<ChannelListView> {
                     ChannelPreview(
                       onLongPress: widget.onChannelLongPress,
                       channel: channel,
-                      onImageTap: widget.onImageTap?.call(channel),
+                      onImageTap: ()=> widget.onImageTap?.call(channel),
                       onTap: (channel) => onTap(channel, widget.channelWidget),
                     ),
               ),


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)
- [x] Added/Updated documentation where applicable 

## Description of the pull request
### Bug 
As reported:  "When we use ChannelListView and we override the onImageTap trying to push our own view, it throws an error. `onImageTap` is called when the widget is building."

### Fix 
Add lambda which calls `widget.onImageTap` when pressed.

