### PR TITLE
fix: remove notification badge logic from the sdk and move it to samp…

### DIFF
--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_app_badger/flutter_app_badger.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:stream_chat_flutter/src/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';

--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -121,15 +121,5 @@ class StreamChatState extends State<StreamChat> {
   @override
   void initState() {
     super.initState();
-
-    if (!kIsWeb) {
-      client.state?.totalUnreadCountStream?.listen((count) {
-        if (count > 0) {
-          FlutterAppBadger.updateBadgeCount(count);
-        } else {
-          FlutterAppBadger.removeBadge();
-        }
-      });
-    }
   }
 }

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
       url: https://github.com/GetStream/stream-chat-flutter.git
       ref: develop
       path: packages/stream_chat_flutter_core
-  flutter_app_badger: ^1.1.2
   photo_view: ^0.10.3
   rxdart: ^0.25.0
   scrollable_positioned_list: ^0.1.8


### PR DESCRIPTION
Remove the logic from the SDK and move it to the sample app

Why?
- we remove a dependency
- the package was asking the notification permissions right away and that's not always what our customers want