### PR TITLE
chore: v2.0.0 nullsafety.8

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 2.0.0-nullsafety.7
+
+🛑️ Breaking Changes from `2.0.0-nullsafety.6`
+- `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
+- `client.disconnect()` is now divided into two different functions 
+  - `client.closeConnection()` -> for closing user websocket connection.
+  - `client.disconnectUser()` -> for disconnecting user and resetting client state.
+- `client.devToken()` now returns a `Token` model instead of `String`.
+- `ApiError` is removed in favor of `StreamChatError`
+  - `StreamChatError` -> parent type for all the stream errors.
+  - `StreamWebSocketError` -> for user websocket related errors.
+  - `StreamChatNetworkError` -> for network related errors.
+- `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
+  - `option.state` -> bool state
+  - `option.watch` -> bool watch
+  - `option.presence` -> bool presence
+
+✅ Added
+- New `Location` enum is introduced for easily changing the client location/baseUrl.
+- New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.
+
+🔄 Changed
+- `baseURL` is now deprecated in favor of using `Location` to change data location.
+
+🐞 Fixed
+- Client does not return without internet connection [#369](https://github.com/GetStream/stream-chat-flutter/issues/369)
+
+## 2.0.0-nullsafety.6
+
+- Fix thread reply not working with attachments
+- Minor fixes
+
 ## 2.0.0-nullsafety.6
 
 - Fix thread reply not working with attachments
@@ -57,7 +89,8 @@
 - Save pinned messages in offline storage
 - Minor fixes
 - `StreamClient.QueryChannels` now returns a Stream and fetches the channels from storage before calling the api
-- Added `StreamClient.QueryChannelsOnline` and `StreamClient.QueryChannelsOffline` to fetch channels only from online or offline
+- Added `StreamClient.QueryChannelsOnline` and `StreamClient.QueryChannelsOffline` to fetch channels only from online or
+  offline
 
 ## 1.2.0-beta
 
@@ -68,7 +101,8 @@
 ## 1.1.0-beta
 
 - Fixed minor bugs
-- Add support for custom attachment upload [docs here](https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart)
+- Add support for custom attachment
+  upload [docs here](https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart)
 - Add support for asynchronous attachment upload
 
 ## 1.0.3-beta
@@ -78,7 +112,8 @@
 
 ## 1.0.2-beta
 
-- Deprecated `setUser`, `setGuestUser`, `setUserWithProvider` in favor of `connectUser`, `connectGuestUser`, `connectUserWithProvider`
+- Deprecated `setUser`, `setGuestUser`, `setUserWithProvider` in favor of `connectUser`, `connectGuestUser`
+  , `connectUserWithProvider`
 - Optimised reaction updates - i.e., Update first call Api later.
 
 ## 1.0.1-beta
@@ -88,9 +123,11 @@
 ## 1.0.0-beta
 
 - 🛑 **BREAKING** Renamed `Client` to less generic `StreamChatClient`
-- 🛑 **BREAKING** Segregated the persistence layer into separate package [stream_chat_persistence](https://pub.dev/packages/stream_chat_persistence)
+- 🛑 **BREAKING** Segregated the persistence layer into separate
+  package [stream_chat_persistence](https://pub.dev/packages/stream_chat_persistence)
 - 🛑 **BREAKING** Moved `Client.backgroundKeepAlive` to [core package](https://pub.dev/packages/stream_chat_core)
-- 🛑 **BREAKING** Moved `Client.showLocalNotification` to [core package](https://pub.dev/packages/stream_chat_core) and renamed it to `StreamChatCore.onBackgroundEventReceived`
+- 🛑 **BREAKING** Moved `Client.showLocalNotification` to [core package](https://pub.dev/packages/stream_chat_core) and
+  renamed it to `StreamChatCore.onBackgroundEventReceived`
 - Removed `flutter` dependency. This is now a pure Dart package 🥳
 - Minor improvements and bugfixes
 
@@ -145,7 +182,8 @@
 
 ## 0.2.20
 
-- Return offline data only if the backend is unreachable. This avoids the glitch of  the ChannelListView because we cannot sort by custom properties.
+- Return offline data only if the backend is unreachable. This avoids the glitch of the ChannelListView because we
+  cannot sort by custom properties.
 
 ## 0.2.19
 
@@ -159,7 +197,7 @@
 
 ## 0.2.17+1
 
-- Do not retry messages when server returns error 
+- Do not retry messages when server returns error
 
 ## 0.2.17
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -65,7 +65,7 @@ class StreamChatClient {
     LogHandlerFunction? logHandlerFunction,
     RetryPolicy? retryPolicy,
     Location? location,
-    String? baseURL,
+    @Deprecated('Use location to change baseUrl instead') String? baseURL,
     Duration connectTimeout = const Duration(seconds: 6),
     Duration receiveTimeout = const Duration(seconds: 6),
     StreamChatApi? chatApi,

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat
 homepage: https://getstream.io/
 description: The official Dart client for Stream Chat, a service for building chat applications.
-version: 2.0.0-nullsafety.6
+version: 2.0.0-nullsafety.7
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view.dart
@@ -368,7 +368,6 @@ class _MessageListViewState extends State<MessageListView> {
             (context, list) => _buildListView(list),
         messageListController: _messageListController,
         parentMessage: widget.parentMessage,
-        showScrollToBottom: widget.showScrollToBottom,
         errorWidgetBuilder: widget.errorWidgetBuilder ??
             (BuildContext context, Object error) => Center(
                   child: Text(

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -68,7 +68,6 @@ class MessageListCore extends StatefulWidget {
     required this.emptyBuilder,
     required this.messageListBuilder,
     required this.errorWidgetBuilder,
-    this.showScrollToBottom = true,
     this.parentMessage,
     this.messageListController,
     this.messageFilter,
@@ -93,10 +92,6 @@ class MessageListCore extends StatefulWidget {
   /// This parameter can be used to display an error message to users in the
   /// event of a connection failure.
   final ErrorBuilder errorWidgetBuilder;
-
-  /// If true will show a scroll to bottom message when there are new messages
-  /// and the scroll offset is not zero.
-  final bool showScrollToBottom;
 
   /// If the current message belongs to a `thread`, this property represents the
   /// first message or the parent of the conversation.


### PR DESCRIPTION
# StreamChat
## 2.0.0-nullsafety.7

🛑️ Breaking Changes from `2.0.0-nullsafety.6`
- `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
- `client.disconnect()` is now divided into two different functions 
  - `client.closeConnection()` -> for closing user websocket connection.
  - `client.disconnectUser()` -> for disconnecting user and resetting client state.
- `client.devToken()` now returns a `Token` model instead of `String`.
- `ApiError` is removed in favor of `StreamChatError`
  - `StreamChatError` -> parent type for all the stream errors.
  - `StreamWebSocketError` -> for user websocket related errors.
  - `StreamChatNetworkError` -> for network related errors.
- `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
  - `option.state` -> bool state
  - `option.watch` -> bool watch
  - `option.presence` -> bool presence

✅ Added
- New `Location` enum is introduced for easily changing the client location/baseUrl.
- New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.

🔄 Changed
- `baseURL` is now deprecated in favor of using `Location` to change data location.

🐞 Fixed
- Client does not return without internet connection [#369](https://github.com/GetStream/stream-chat-flutter/issues/369)
