### PR TITLE
chore: v2.0.0 nullsafety.8

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -11,9 +11,11 @@
   - `StreamWebSocketError` -> for user websocket related errors.
   - `StreamChatNetworkError` -> for network related errors.
 - `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
-  - `option.state` -> bool state
-  - `option.watch` -> bool watch
-  - `option.presence` -> bool presence
+  - `options.state` -> bool state
+  - `options.watch` -> bool watch
+  - `options.presence` -> bool presence
+- `client.queryUsers()` options param is removed in favor of individual params
+  - `options.presence` -> bool presence
 
 ✅ Added
 - New `Location` enum is introduced for easily changing the client location/baseUrl.

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 2.0.0-nullsafety.7
+
+🛑️ Breaking Changes from `2.0.0-nullsafety.6`
+- `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
+- `client.disconnect()` is now divided into two different functions 
+  - `client.closeConnection()` -> for closing user websocket connection.
+  - `client.disconnectUser()` -> for disconnecting user and resetting client state.
+- `client.devToken()` now returns a `Token` model instead of `String`.
+- `ApiError` is removed in favor of `StreamChatError`
+  - `StreamChatError` -> parent type for all the stream errors.
+  - `StreamWebSocketError` -> for user websocket related errors.
+  - `StreamChatNetworkError` -> for network related errors.
+- `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
+  - `option.state` -> bool state
+  - `option.watch` -> bool watch
+  - `option.presence` -> bool presence
+
+✅ Added
+- New `Location` enum is introduced for easily changing the client location/baseUrl.
+- New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.
+
+🔄 Changed
+- `baseURL` is now deprecated in favor of using `Location` to change data location.
+
+🐞 Fixed
+- Client does not return without internet connection [#369](https://github.com/GetStream/stream-chat-flutter/issues/369)
+
+## 2.0.0-nullsafety.6
+
+- Fix thread reply not working with attachments
+- Minor fixes
+
 ## 2.0.0-nullsafety.6
 
 - Fix thread reply not working with attachments
@@ -57,7 +89,8 @@
 - Save pinned messages in offline storage
 - Minor fixes
 - `StreamClient.QueryChannels` now returns a Stream and fetches the channels from storage before calling the api
-- Added `StreamClient.QueryChannelsOnline` and `StreamClient.QueryChannelsOffline` to fetch channels only from online or offline
+- Added `StreamClient.QueryChannelsOnline` and `StreamClient.QueryChannelsOffline` to fetch channels only from online or
+  offline
 
 ## 1.2.0-beta
 
@@ -68,7 +101,8 @@
 ## 1.1.0-beta
 
 - Fixed minor bugs
-- Add support for custom attachment upload [docs here](https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart)
+- Add support for custom attachment
+  upload [docs here](https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart)
 - Add support for asynchronous attachment upload
 
 ## 1.0.3-beta
@@ -78,7 +112,8 @@
 
 ## 1.0.2-beta
 
-- Deprecated `setUser`, `setGuestUser`, `setUserWithProvider` in favor of `connectUser`, `connectGuestUser`, `connectUserWithProvider`
+- Deprecated `setUser`, `setGuestUser`, `setUserWithProvider` in favor of `connectUser`, `connectGuestUser`
+  , `connectUserWithProvider`
 - Optimised reaction updates - i.e., Update first call Api later.
 
 ## 1.0.1-beta
@@ -88,9 +123,11 @@
 ## 1.0.0-beta
 
 - 🛑 **BREAKING** Renamed `Client` to less generic `StreamChatClient`
-- 🛑 **BREAKING** Segregated the persistence layer into separate package [stream_chat_persistence](https://pub.dev/packages/stream_chat_persistence)
+- 🛑 **BREAKING** Segregated the persistence layer into separate
+  package [stream_chat_persistence](https://pub.dev/packages/stream_chat_persistence)
 - 🛑 **BREAKING** Moved `Client.backgroundKeepAlive` to [core package](https://pub.dev/packages/stream_chat_core)
-- 🛑 **BREAKING** Moved `Client.showLocalNotification` to [core package](https://pub.dev/packages/stream_chat_core) and renamed it to `StreamChatCore.onBackgroundEventReceived`
+- 🛑 **BREAKING** Moved `Client.showLocalNotification` to [core package](https://pub.dev/packages/stream_chat_core) and
+  renamed it to `StreamChatCore.onBackgroundEventReceived`
 - Removed `flutter` dependency. This is now a pure Dart package 🥳
 - Minor improvements and bugfixes
 
@@ -145,7 +182,8 @@
 
 ## 0.2.20
 
-- Return offline data only if the backend is unreachable. This avoids the glitch of  the ChannelListView because we cannot sort by custom properties.
+- Return offline data only if the backend is unreachable. This avoids the glitch of the ChannelListView because we
+  cannot sort by custom properties.
 
 ## 0.2.19
 
@@ -159,7 +197,7 @@
 
 ## 0.2.17+1
 
-- Do not retry messages when server returns error 
+- Do not retry messages when server returns error
 
 ## 0.2.17
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-nullsafety.7
 
-🛑️ Breaking Changes from `2.0.0-nullsafety.6`
+🛑️  Breaking Changes from `2.0.0-nullsafety.6`
 - `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
 - `client.disconnect()` is now divided into two different functions 
   - `client.closeConnection()` -> for closing user websocket connection.
@@ -11,21 +11,19 @@
   - `StreamWebSocketError` -> for user websocket related errors.
   - `StreamChatNetworkError` -> for network related errors.
 - `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
-  - `options.state` -> bool state
-  - `options.watch` -> bool watch
-  - `options.presence` -> bool presence
-- `client.queryUsers()` options param is removed in favor of individual params
-  - `options.presence` -> bool presence
+  - `option.state` -> bool state
+  - `option.watch` -> bool watch
+  - `option.presence` -> bool presence
 
-✅ Added
+✅  Added
 - New `Location` enum is introduced for easily changing the client location/baseUrl.
 - New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.
 
-🔄 Changed
+🔄  Changed
 - `baseURL` is now deprecated in favor of using `Location` to change data location.
 
-🐞 Fixed
-- Client does not return without internet connection [#369](https://github.com/GetStream/stream-chat-flutter/issues/369)
+🐞  Fixed
+- [#369](https://github.com/GetStream/stream-chat-flutter/issues/369): Client does not return without internet connection
 
 ## 2.0.0-nullsafety.6
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,29 +1,36 @@
 ## 2.0.0-nullsafety.7
 
-🛑️  Breaking Changes from `2.0.0-nullsafety.6`
+🛑️ Breaking Changes from `2.0.0-nullsafety.6`
+
 - `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
-- `client.disconnect()` is now divided into two different functions 
-  - `client.closeConnection()` -> for closing user websocket connection.
-  - `client.disconnectUser()` -> for disconnecting user and resetting client state.
+- `client.disconnect()` is now divided into two different functions
+    - `client.closeConnection()` -> for closing user websocket connection.
+    - `client.disconnectUser()` -> for disconnecting user and resetting client state.
 - `client.devToken()` now returns a `Token` model instead of `String`.
 - `ApiError` is removed in favor of `StreamChatError`
-  - `StreamChatError` -> parent type for all the stream errors.
-  - `StreamWebSocketError` -> for user websocket related errors.
-  - `StreamChatNetworkError` -> for network related errors.
+    - `StreamChatError` -> parent type for all the stream errors.
+    - `StreamWebSocketError` -> for user websocket related errors.
+    - `StreamChatNetworkError` -> for network related errors.
 - `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
-  - `option.state` -> bool state
-  - `option.watch` -> bool watch
-  - `option.presence` -> bool presence
+    - `option.state` -> bool state
+    - `option.watch` -> bool watch
+    - `option.presence` -> bool presence
+- `client.queryUsers()` options param is removed in favor of individual params
+    - `option.presence` -> bool presence
 
-✅  Added
+✅ Added
+
 - New `Location` enum is introduced for easily changing the client location/baseUrl.
 - New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.
 
-🔄  Changed
+🔄 Changed
+
 - `baseURL` is now deprecated in favor of using `Location` to change data location.
 
-🐞  Fixed
-- [#369](https://github.com/GetStream/stream-chat-flutter/issues/369): Client does not return without internet connection
+🐞 Fixed
+
+- [#369](https://github.com/GetStream/stream-chat-flutter/issues/369): Client does not return without internet
+  connection
 
 ## 2.0.0-nullsafety.6
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -65,7 +65,7 @@ class StreamChatClient {
     LogHandlerFunction? logHandlerFunction,
     RetryPolicy? retryPolicy,
     Location? location,
-    String? baseURL,
+    @Deprecated('Use location to change baseUrl instead') String? baseURL,
     Duration connectTimeout = const Duration(seconds: 6),
     Duration receiveTimeout = const Duration(seconds: 6),
     StreamChatApi? chatApi,

--- a/packages/stream_chat/lib/version.dart
+++ b/packages/stream_chat/lib/version.dart
@@ -3,4 +3,4 @@ import 'package:stream_chat/src/client/client.dart';
 /// Current package version
 /// Used in [StreamChatClient] to build the `x-stream-client` header
 // ignore: constant_identifier_names
-const PACKAGE_VERSION = '2.0.0-nullsafety.6';
+const PACKAGE_VERSION = '2.0.0-nullsafety.7';

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat
 homepage: https://getstream.io/
 description: The official Dart client for Stream Chat, a service for building chat applications.
-version: 2.0.0-nullsafety.6
+version: 2.0.0-nullsafety.7
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,31 +1,37 @@
 ## 2.0.0-nullsafety.8
 
-🛑️  Breaking Changes from `2.0.0-nullsafety.7`
+🛑️ Breaking Changes from `2.0.0-nullsafety.7`
+
 - `ChannelListCore` options property is removed in favor of individual properties
     - `options.state` -> bool state
     - `options.watch` -> bool watch
     - `options.presence` -> bool presence
-- `UserListCore` options property is removed in favor of individual properties
+- `UserListView` options property is removed in favor of individual properties
     - `options.presence` -> bool presence
 - `MessageBuilder` and `ParentMessageBuilder` signature is now
+
 ```dart
 typedef MessageBuilder = Widget Function(
-  BuildContext,
-  MessageDetails,
-  List<Message>,
-  MessageWidget defaultMessageWidget,
-);
+    BuildContext,
+    MessageDetails,
+    List<Message>,
+    MessageWidget defaultMessageWidget,
+    );
 ```
+
 the last parameter is the default `MessageWidget`
 You can call `.copyWith` to customize just a subset of properties
 
-✅  Added
+✅ Added
+
 - TypingIndicator now has a property called `parentId` to show typing indicator specific to threads
 - [#493](https://github.com/GetStream/stream-chat-flutter/pull/493): add support for messageListView header/footer
 - `MessageWidget` accepts a `userAvatarBuilder`
 
-🐞  Fixed
-- [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing message
+🐞 Fixed
+
+- [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing
+  message
 - Modals are shown using the nearest `Navigator` to make using the SDK easier in a nested navigator use case
 - [#484](https://github.com/GetStream/stream-chat-flutter/issues/484): messages don't update without a reload
 - `MessageListView` not rendering if the user is not a member of the channel

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0-nullsafety.8
+
+🛑️ Breaking Changes from `2.0.0-nullsafety.7`
+- `ChannelListCore` options property is removed in favor of individual properties
+    - `options.state` -> bool state
+    - `options.watch` -> bool watch
+    - `options.presence` -> bool presence
+- `UserListCore` options property is removed in favor of individual properties
+    - `options.presence` -> bool presence
+
 ## 2.0.0-nullsafety.7
 
 - Minor fixes and improvements
@@ -139,7 +149,8 @@
 
 ## 0.2.20+2
 
-- Added `shouldAddChannel` to ChannelsBloc in order to check if a channel has to be added to the list when a new message arrives
+- Added `shouldAddChannel` to ChannelsBloc in order to check if a channel has to be added to the list when a new message
+  arrives
 
 ## 0.2.20+1
 
@@ -358,27 +369,27 @@
 
 ## 0.2.1-alpha+1
 
-- Removed the additional `Navigator` in `StreamChat` widget.
-    It was added to make the app have the `StreamChat` widget as ancestor in every route.
-    Now the recommended way to add `StreamChat` to your app is using the `builder` property of your `MaterialApp` widget.
-    Otherwise you can use it in the usual way, but you need to add a `StreamChat` widget to every route of your app.
-    Read [this issue](https://github.com/GetStream/stream-chat-flutter/issues/47) for more information.
+- Removed the additional `Navigator` in `StreamChat` widget. It was added to make the app have the `StreamChat` widget
+  as ancestor in every route. Now the recommended way to add `StreamChat` to your app is using the `builder` property of
+  your `MaterialApp` widget. Otherwise you can use it in the usual way, but you need to add a `StreamChat` widget to
+  every route of your app. Read [this issue](https://github.com/GetStream/stream-chat-flutter/issues/47) for more
+  information.
 
 ```dart
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ThemeData.light(),
-      darkTheme: ThemeData.dark(),
-      themeMode: ThemeMode.system,
-      builder: (context, widget) {
-        return StreamChat(
-          child: widget,
-          client: client,
-        );
-      },
-      home: ChannelListPage(),
-    );
+Widget build(BuildContext context) {
+  return MaterialApp(
+    theme: ThemeData.light(),
+    darkTheme: ThemeData.dark(),
+    themeMode: ThemeMode.system,
+    builder: (context, widget) {
+      return StreamChat(
+        child: widget,
+        client: client,
+      );
+    },
+    home: ChannelListPage(),
+  );
 ```
 
 - Fix reaction bubble going below previous message on iOS
@@ -462,7 +473,8 @@
 
 - Add gesture (vertical drag down) to close the keyboard
 
-- Add keyboard type parameters (set it to TextInputType.text to show the submit button that will even close the keyboard)
+- Add keyboard type parameters (set it to TextInputType.text to show the submit button that will even close the
+  keyboard)
 
 The property showVideoFullScreen was added mainly because of this issue brianegan/chewie#261
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,12 +1,32 @@
 ## 2.0.0-nullsafety.8
 
-🛑️ Breaking Changes from `2.0.0-nullsafety.7`
+🛑️  Breaking Changes from `2.0.0-nullsafety.7`
 - `ChannelListCore` options property is removed in favor of individual properties
     - `options.state` -> bool state
     - `options.watch` -> bool watch
     - `options.presence` -> bool presence
 - `UserListCore` options property is removed in favor of individual properties
     - `options.presence` -> bool presence
+- `MessageBuilder` and `ParentMessageBuilder` signature is now
+```dart
+typedef MessageBuilder = Widget Function(
+  BuildContext,
+  MessageDetails,
+  List<Message>,
+  MessageWidget defaultMessageWidget,
+);
+```
+the last parameter is the default `MessageWidget`
+You can call `.copyWith` to customize just a subset of properties
+
+✅  Added
+- TypingIndicator now has a property called `parentId` to show typing indicator specific to threads
+- [#493](https://github.com/GetStream/stream-chat-flutter/pull/493): add support for messageListView header/footer
+
+🐞  Fixed
+- [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing message
+- Modals are shown using the nearest `Navigator` to make using the SDK easier in a nested navigator use case
+- [#484](https://github.com/GetStream/stream-chat-flutter/issues/484): messages don't update without a reload
 
 ## 2.0.0-nullsafety.7
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -22,6 +22,7 @@ You can call `.copyWith` to customize just a subset of properties
 ✅  Added
 - TypingIndicator now has a property called `parentId` to show typing indicator specific to threads
 - [#493](https://github.com/GetStream/stream-chat-flutter/pull/493): add support for messageListView header/footer
+- `MessageWidget` accepts a `userAvatarBuilder`
 
 🐞  Fixed
 - [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing message

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -27,6 +27,7 @@ You can call `.copyWith` to customize just a subset of properties
 - [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing message
 - Modals are shown using the nearest `Navigator` to make using the SDK easier in a nested navigator use case
 - [#484](https://github.com/GetStream/stream-chat-flutter/issues/484): messages don't update without a reload
+- `MessageListView` not rendering if the user is not a member of the channel
 
 ## 2.0.0-nullsafety.7
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view.dart
@@ -368,7 +368,6 @@ class _MessageListViewState extends State<MessageListView> {
             (context, list) => _buildListView(list),
         messageListController: _messageListController,
         parentMessage: widget.parentMessage,
-        showScrollToBottom: widget.showScrollToBottom,
         errorWidgetBuilder: widget.errorWidgetBuilder ??
             (BuildContext context, Object error) => Center(
                   child: Text(

--- a/packages/stream_chat_flutter/lib/src/user_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/user_list_view.dart
@@ -83,7 +83,7 @@ class UserListView extends StatefulWidget {
   /// Direction can be ascending or descending.
   final List<SortOption>? sort;
 
-  ///
+  /// If true you’ll receive user presence updates via the websocket events
   final bool? presence;
 
   /// Pagination parameters

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 2.0.0-nullsafety.7
+version: 2.0.0-nullsafety.8
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -36,7 +36,7 @@ dependencies:
   scrollable_positioned_list: ^0.2.0-nullsafety.0
   share_plus: ^2.0.3
   shimmer: ^2.0.0
-  stream_chat_flutter_core: ^2.0.0-nullsafety.7
+  stream_chat_flutter_core: ^2.0.0-nullsafety.8
   substring_highlight: ^1.0.26
   synchronized: ^3.0.0
   url_launcher: ^6.0.3

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0-nullsafety.8
+
+🛑️ Breaking Changes from `2.0.0-nullsafety.7`
+- `channelsBloc.queryChannels()`, `ChannelListCore` options param/property is removed in favor of individual params/properties
+  - `options.state` -> bool state
+  - `options.watch` -> bool watch
+  - `options.presence` -> bool presence
+- `usersBloc.queryUsers()`, `UserListCore` options param/property is removed in favor of individual params/properties
+  - `options.presence` -> bool presence
+  
 ## 2.0.0-nullsafety.7
 
 * Fixed a bug with connectivity implementation

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,13 +1,15 @@
 ## 2.0.0-nullsafety.8
 
 🛑️ Breaking Changes from `2.0.0-nullsafety.7`
-- `channelsBloc.queryChannels()`, `ChannelListCore` options param/property is removed in favor of individual params/properties
-  - `options.state` -> bool state
-  - `options.watch` -> bool watch
-  - `options.presence` -> bool presence
+
+- `channelsBloc.queryChannels()`, `ChannelListCore` options param/property is removed in favor of individual
+  params/properties
+    - `options.state` -> bool state
+    - `options.watch` -> bool watch
+    - `options.presence` -> bool presence
 - `usersBloc.queryUsers()`, `UserListCore` options param/property is removed in favor of individual params/properties
-  - `options.presence` -> bool presence
-  
+    - `options.presence` -> bool presence
+
 ## 2.0.0-nullsafety.7
 
 * Fixed a bug with connectivity implementation

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -68,7 +68,6 @@ class MessageListCore extends StatefulWidget {
     required this.emptyBuilder,
     required this.messageListBuilder,
     required this.errorWidgetBuilder,
-    this.showScrollToBottom = true,
     this.parentMessage,
     this.messageListController,
     this.messageFilter,
@@ -93,10 +92,6 @@ class MessageListCore extends StatefulWidget {
   /// This parameter can be used to display an error message to users in the
   /// event of a connection failure.
   final ErrorBuilder errorWidgetBuilder;
-
-  /// If true will show a scroll to bottom message when there are new messages
-  /// and the scroll offset is not zero.
-  final bool showScrollToBottom;
 
   /// If the current message belongs to a `thread`, this property represents the
   /// first message or the parent of the conversation.

--- a/packages/stream_chat_flutter_core/lib/src/user_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/user_list_core.dart
@@ -98,7 +98,7 @@ class UserListCore extends StatefulWidget {
   /// created_at or member_count. Direction can be ascending or descending.
   final List<SortOption>? sort;
 
-  ///
+  /// If true you’ll receive user presence updates via the websocket events
   final bool? presence;
 
   /// Pagination parameters

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter_core
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK Core. Build your own chat experience using Dart and Flutter.
-version: 2.0.0-nullsafety.7
+version: 2.0.0-nullsafety.8
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   meta: ^1.3.0
   rxdart: ^0.27.0
-  stream_chat: ^2.0.0-nullsafety.6
+  stream_chat: ^2.0.0-nullsafety.7
 
 dev_dependencies:
   fake_async: ^1.2.0

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-nullsafety.7
+
+* Update llc dependency
+* Minor fixes and improvements
+
 ## 2.0.0-nullsafety.5
 
 * Update llc dependency

--- a/packages/stream_chat_persistence/pubspec.yaml
+++ b/packages/stream_chat_persistence/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_persistence
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Official Stream Chat Persistence library. Build your own chat experience using Dart and Flutter.
-version: 2.0.0-nullsafety.5
+version: 2.0.0-nullsafety.7
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -18,7 +18,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.1
   sqlite3_flutter_libs: ^0.5.0
-  stream_chat: ^2.0.0-nullsafety.5
+  stream_chat: ^2.0.0-nullsafety.7
 
 dev_dependencies:
   build_runner: ^2.0.1


### PR DESCRIPTION
# stream_chat
## 2.0.0-nullsafety.7

🛑️ Breaking Changes from `2.0.0-nullsafety.6`

- `ConnectUserWithProvider` now requires `tokenProvider` as a required param. (Removed from the constructor)
- `client.disconnect()` is now divided into two different functions
    - `client.closeConnection()` -> for closing user websocket connection.
    - `client.disconnectUser()` -> for disconnecting user and resetting client state.
- `client.devToken()` now returns a `Token` model instead of `String`.
- `ApiError` is removed in favor of `StreamChatError`
    - `StreamChatError` -> parent type for all the stream errors.
    - `StreamWebSocketError` -> for user websocket related errors.
    - `StreamChatNetworkError` -> for network related errors.
- `client.queryChannels()`, `channel.query()` options param is removed in favor of individual params
    - `option.state` -> bool state
    - `option.watch` -> bool watch
    - `option.presence` -> bool presence
- `client.queryUsers()` options param is removed in favor of individual params
    - `option.presence` -> bool presence

✅ Added

- New `Location` enum is introduced for easily changing the client location/baseUrl.
- New `client.openConnection()` and `client.closeConnection()` is introduced to connect/disconnect user ws connection.

🔄 Changed

- `baseURL` is now deprecated in favor of using `Location` to change data location.

🐞 Fixed

- [#369](https://github.com/GetStream/stream-chat-flutter/issues/369): Client does not return without internet
  connection

# stream_chat_flutter_core
## 2.0.0-nullsafety.8

🛑️ Breaking Changes from `2.0.0-nullsafety.7`

- `channelsBloc.queryChannels()`, `ChannelListCore` options param/property is removed in favor of individual
  params/properties
    - `options.state` -> bool state
    - `options.watch` -> bool watch
    - `options.presence` -> bool presence
- `usersBloc.queryUsers()`, `UserListCore` options param/property is removed in favor of individual params/properties
    - `options.presence` -> bool presence
  
# stream_chat_flutter
## 2.0.0-nullsafety.8

🛑️ Breaking Changes from `2.0.0-nullsafety.7`

- `ChannelListCore` options property is removed in favor of individual properties
    - `options.state` -> bool state
    - `options.watch` -> bool watch
    - `options.presence` -> bool presence
- `UserListView` options property is removed in favor of individual properties
    - `options.presence` -> bool presence
- `MessageBuilder` and `ParentMessageBuilder` signature is now

```dart
typedef MessageBuilder = Widget Function(
    BuildContext,
    MessageDetails,
    List<Message>,
    MessageWidget defaultMessageWidget,
    );
```

the last parameter is the default `MessageWidget`
You can call `.copyWith` to customize just a subset of properties

✅ Added

- TypingIndicator now has a property called `parentId` to show typing indicator specific to threads
- [#493](https://github.com/GetStream/stream-chat-flutter/pull/493): add support for messageListView header/footer
- `MessageWidget` accepts a `userAvatarBuilder`

🐞 Fixed

- [#483](https://github.com/GetStream/stream-chat-flutter/issues/483): Keyboard covers input text box when editing
  message
- Modals are shown using the nearest `Navigator` to make using the SDK easier in a nested navigator use case
- [#484](https://github.com/GetStream/stream-chat-flutter/issues/484): messages don't update without a reload
- `MessageListView` not rendering if the user is not a member of the channel
    
# stream_chat_persistence
## 2.0.0-nullsafety.7

* Update llc dependency
* Minor fixes and improvements