### PR TITLE
fix: use inactive as a foreground state

### DIFF
--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -159,7 +159,10 @@ class StreamChatCoreState extends State<StreamChatCore>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    _isInForeground = state == AppLifecycleState.resumed;
+    _isInForeground = [
+      AppLifecycleState.resumed,
+      AppLifecycleState.inactive,
+    ].contains(state);
     if (user != null) {
       if (_isInForeground) {
         _onForeground();

--- a/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
@@ -273,6 +273,144 @@ void main() {
       });
     },
   );
+  testWidgets(
+    'didChangeAppLifecycleState should cancel the backgroundKeepAlive timer '
+    'if it is currently running in case the widget lifestyle changes to '
+    'AppLifecycleState.inactive',
+    (tester) async {
+      await tester.runAsync(() async {
+        final mockClient = MockClient();
+        final mockOnBackgroundEventReceived = MockOnBackgroundEventReceived();
+        const backgroundKeepAlive = const Duration(seconds: 3);
+        const streamChatCoreKey = Key('streamChatCore');
+        const childKey = Key('child');
+        final streamChatCore = StreamChatCore(
+          key: streamChatCoreKey,
+          client: mockClient,
+          child: Offstage(key: childKey),
+          onBackgroundEventReceived: mockOnBackgroundEventReceived,
+          backgroundKeepAlive: backgroundKeepAlive,
+        );
+
+        await tester.pumpWidget(streamChatCore);
+
+        expect(find.byKey(streamChatCoreKey), findsOneWidget);
+        expect(find.byKey(childKey), findsOneWidget);
+
+        final event = Event(type: EventType.any);
+        when(() => mockClient.on()).thenAnswer((_) => Stream.value(event));
+
+        final streamChatCoreState = tester.state<StreamChatCoreState>(
+          find.byKey(streamChatCoreKey),
+        );
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        await untilCalled(() => mockOnBackgroundEventReceived.call(event));
+
+        verify(() => mockOnBackgroundEventReceived.call(event)).called(1);
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.inactive);
+
+        verifyNever(() => mockOnBackgroundEventReceived.call(event));
+      });
+    },
+  );
+
+  testWidgets(
+    'didChangeAppLifecycleState should call client.connect() '
+    'if the connectionStatus is ConnectionStatus.disconnected in case the '
+    'widget lifestyle changes to AppLifecycleState.inactive',
+    (tester) async {
+      await tester.runAsync(() async {
+        final mockClient = MockClient();
+        const streamChatCoreKey = Key('streamChatCore');
+        const childKey = Key('child');
+        final streamChatCore = StreamChatCore(
+          key: streamChatCoreKey,
+          client: mockClient,
+          child: Offstage(key: childKey),
+          connectivityStream: Stream.value(ConnectivityResult.mobile),
+        );
+
+        await tester.pumpWidget(streamChatCore);
+
+        expect(find.byKey(streamChatCoreKey), findsOneWidget);
+        expect(find.byKey(childKey), findsOneWidget);
+
+        final event = Event(type: EventType.any);
+        when(() => mockClient.on()).thenAnswer((_) => Stream.value(event));
+        when(() => mockClient.openConnection())
+            .thenAnswer((_) async => OwnUser(id: 'test'));
+        when(() => mockClient.closeConnection()).thenAnswer((_) async => null);
+        when(() => mockClient.wsConnectionStatus)
+            .thenReturn(ConnectionStatus.disconnected);
+
+        final streamChatCoreState = tester.state<StreamChatCoreState>(
+          find.byKey(streamChatCoreKey),
+        );
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        await Future.delayed(const Duration(seconds: 1));
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.inactive);
+
+        verify(() => mockClient.openConnection()).called(1);
+      });
+    },
+  );
+
+  testWidgets(
+    'didChangeAppLifecycleState should not call client.openConnection() '
+    'if connection is not available in case the '
+    'widget lifestyle changes to AppLifecycleState.inactive',
+    (tester) async {
+      await tester.runAsync(() async {
+        final mockClient = MockClient();
+        const streamChatCoreKey = Key('streamChatCore');
+        const childKey = Key('child');
+
+        final event = Event();
+        when(() => mockClient.on()).thenAnswer((_) => Stream.value(event));
+        when(() => mockClient.openConnection())
+            .thenAnswer((_) async => OwnUser(id: 'test'));
+        when(() => mockClient.closeConnection()).thenAnswer((_) async => null);
+        when(() => mockClient.wsConnectionStatus)
+            .thenReturn(ConnectionStatus.disconnected);
+
+        final streamChatCore = StreamChatCore(
+          key: streamChatCoreKey,
+          client: mockClient,
+          child: Offstage(key: childKey),
+          connectivityStream: Stream.value(ConnectivityResult.none),
+        );
+
+        await tester.pumpWidget(streamChatCore);
+
+        expect(find.byKey(streamChatCoreKey), findsOneWidget);
+        expect(find.byKey(childKey), findsOneWidget);
+
+        final streamChatCoreState = tester.state<StreamChatCoreState>(
+          find.byKey(streamChatCoreKey),
+        );
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        await Future.delayed(const Duration(seconds: 1));
+
+        streamChatCoreState
+            .didChangeAppLifecycleState(AppLifecycleState.inactive);
+
+        verifyNever(() => mockClient.openConnection());
+      });
+    },
+  );
 
   testWidgets(
     'streamChatCoreState.userStream should emit all the user events '


### PR DESCRIPTION
we used `AppLifecycleState.resumed` as the only foreground state
that caused the client to disconnect in certain situations (for example system dialogs)

this should fix #524 