### PR TITLE
fix(localization): Fix `Hindi` translations.

### DIFF
--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,6 +1,18 @@
 ## Upcoming
 
-* Added support for [Spanish](https://github.com/GetStream/stream-chat-flutter/blob/master/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart) locale.
+✅ Added
+
+* Added support
+  for [Spanish](https://github.com/GetStream/stream-chat-flutter/blob/master/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart)
+  locale.
+
+🔄 Changed
+
+* Some of the `Hindi` translations have been updated/changed for better understanding.
+    - 'रिप्लाई' -> 'जवाब दें'
+    - 'तस्वीरें' -> 'फ़ोटोज'
+    - 'बिता हुआ कल' -> 'कल'
+    - 'चैनल मौन है' -> 'चैनल म्यूट है'
 
 ## 1.0.2
 

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -197,7 +197,7 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
       'कार्रवाई पूरी नहीं की जा सकी.';
 
   @override
-  String get replyLabel => 'रिप्लाई';
+  String get replyLabel => 'जवाब दें';
 
   @override
   String togglePinUnpinText({required bool pinned}) {
@@ -224,7 +224,7 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   }
 
   @override
-  String get photosLabel => 'तस्वीरें';
+  String get photosLabel => 'फ़ोटोज';
 
   String _getDay(DateTime dateTime) {
     final now = DateTime.now();
@@ -250,10 +250,10 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   String get todayLabel => 'आज';
 
   @override
-  String get yesterdayLabel => 'बिता हुआ कल';
+  String get yesterdayLabel => 'कल';
 
   @override
-  String get channelIsMutedText => 'चैनल मौन है';
+  String get channelIsMutedText => 'चैनल म्यूट है';
 
   @override
   String get noTitleText => 'कोई शीर्षक नहीं';


### PR DESCRIPTION
fixes: #611 

* Some of the `Hindi` translations have been updated/changed for better understanding.
    - 'रिप्लाई' -> 'जवाब दें'
    - 'तस्वीरें' -> 'फ़ोटोज'
    - 'बिता हुआ कल' -> 'कल'
    - 'चैनल मौन है' -> 'चैनल म्यूट है'