### PR TITLE
refactor(core, ui)!: Refactor BetterStreamBuilder.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -42,9 +42,12 @@ breakdown:
 * `MessageTheme` is now `MessageThemeData`
 * `UserListViewTheme` is now `UserListViewThemeData`
 
+- Updated core dependency.
+
 🐞 Fixed
 
-- Fixed `MessageInput` textField case where `input` is not enabled if the file picked from the camera is null.
+- Fixed `MessageInput` textField case where `input` is not enabled if the file picked from the
+  camera is null.
 - Fixed date dividers position/alignment in non reversed `MessageListView`.
 
 ## 2.1.2

--- a/packages/stream_chat_flutter/lib/src/channel_preview.dart
+++ b/packages/stream_chat_flutter/lib/src/channel_preview.dart
@@ -94,13 +94,13 @@ class ChannelPreview extends StatelessWidget {
                             textStyle: channelPreviewTheme.titleStyle,
                           ),
                     ),
-                    BetterStreamBuilder<List<Member>?>(
+                    BetterStreamBuilder<List<Member>>(
                       stream: channel.state?.membersStream,
                       initialData: channel.state?.members,
                       comparator: const ListEquality().equals,
                       builder: (context, members) {
-                        if (members?.isEmpty == true ||
-                            members?.any((Member e) =>
+                        if (members.isEmpty ||
+                            members.any((Member e) =>
                                     e.user!.id ==
                                     channel.client.state.currentUser?.id) !=
                                 true) {
@@ -153,13 +153,10 @@ class ChannelPreview extends StatelessWidget {
             ));
   }
 
-  Widget _buildDate(BuildContext context) => BetterStreamBuilder<DateTime?>(
+  Widget _buildDate(BuildContext context) => BetterStreamBuilder<DateTime>(
         stream: channel.lastMessageAtStream,
         initialData: channel.lastMessageAt,
         builder: (context, data) {
-          if (data == null) {
-            return const Offstage();
-          }
           final lastMessageAt = data.toLocal();
 
           String stringDate;
@@ -213,12 +210,12 @@ class ChannelPreview extends StatelessWidget {
 
   Widget _buildLastMessage(BuildContext context) => Align(
         alignment: Alignment.centerLeft,
-        child: BetterStreamBuilder<List<Message>?>(
+        child: BetterStreamBuilder<List<Message>>(
           stream: channel.state!.messagesStream,
           initialData: channel.state!.messages,
           builder: (context, data) {
-            final lastMessage = data
-                ?.lastWhereOrNull((m) => m.shadowed != true && !m.isDeleted);
+            final lastMessage =
+                data.lastWhereOrNull((m) => !m.shadowed && !m.isDeleted);
             if (lastMessage == null) {
               return const SizedBox();
             }

--- a/packages/stream_chat_flutter/lib/src/connection_status_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/connection_status_builder.dart
@@ -38,7 +38,7 @@ class ConnectionStatusBuilder extends StatelessWidget {
     return BetterStreamBuilder<ConnectionStatus>(
       initialData: client.wsConnectionStatus,
       stream: stream,
-      loadingBuilder: loadingBuilder,
+      noDataBuilder: loadingBuilder,
       errorBuilder: (context, error) {
         if (errorBuilder != null) {
           return errorBuilder!(context, error);

--- a/packages/stream_chat_flutter/lib/src/unread_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/unread_indicator.dart
@@ -17,7 +17,7 @@ class UnreadIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     final client = StreamChat.of(context).client;
     return IgnorePointer(
-      child: BetterStreamBuilder<int?>(
+      child: BetterStreamBuilder<int>(
         stream: cid != null
             ? client.state.channels[cid]?.state?.unreadCountStream
             : client.state.totalUnreadCountStream,
@@ -25,7 +25,7 @@ class UnreadIndicator extends StatelessWidget {
             ? client.state.channels[cid]?.state?.unreadCount
             : client.state.totalUnreadCount,
         builder: (context, data) {
-          if (data == null || data == 0) {
+          if (data == 0) {
             return const Offstage();
           }
           return Material(

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Upcoming
 
+🛑️ Breaking Changes from `2.1.1`
+- Renamed `BetterStreamBuilder.loadingBuilder` to `.noDataBuilder`
+
+🔄 Changed
+- `BetterStreamBuilder.initialData` is now nullable/not-required.
+
 🐞 Fixed
 - [#612](https://github.com/GetStream/stream-chat-flutter/issues/612) `ChannelListView` pagination doesn't work after refresh
 

--- a/packages/stream_chat_flutter_core/lib/src/better_stream_builder.dart
+++ b/packages/stream_chat_flutter_core/lib/src/better_stream_builder.dart
@@ -6,23 +6,23 @@ import 'package:flutter/widgets.dart';
 /// It requires [initialData] and will rebuild
 /// only when the new data is different than the current data
 /// The [comparator] is used to check if the new data is different
-class BetterStreamBuilder<T> extends StatefulWidget {
+class BetterStreamBuilder<T extends Object> extends StatefulWidget {
   /// Creates a new BetterStreamBuilder
   const BetterStreamBuilder({
     required this.stream,
-    required this.initialData,
     required this.builder,
-    this.loadingBuilder,
+    this.initialData,
+    this.noDataBuilder,
     this.errorBuilder,
     this.comparator,
     Key? key,
   }) : super(key: key);
 
   /// The stream to listen to
-  final Stream<T>? stream;
+  final Stream<T?>? stream;
 
   /// The initial data available
-  final T initialData;
+  final T? initialData;
 
   /// Comparator used to check if the new data is different than the last one
   final bool Function(T?, T?)? comparator;
@@ -31,7 +31,7 @@ class BetterStreamBuilder<T> extends StatefulWidget {
   final Widget Function(BuildContext context, T data) builder;
 
   /// Builder that builds when the data is null
-  final Widget Function(BuildContext context)? loadingBuilder;
+  final Widget Function(BuildContext context)? noDataBuilder;
 
   /// Builder used when there is an error
   final Widget Function(BuildContext context, Object error)? errorBuilder;
@@ -40,21 +40,26 @@ class BetterStreamBuilder<T> extends StatefulWidget {
   _BetterStreamBuilderState createState() => _BetterStreamBuilderState<T>();
 }
 
-class _BetterStreamBuilderState<T> extends State<BetterStreamBuilder<T>> {
+class _BetterStreamBuilderState<T extends Object>
+    extends State<BetterStreamBuilder<T>> {
   T? _lastEvent;
-  StreamSubscription? _subscription;
+  StreamSubscription<T?>? _subscription;
   Object? _lastError;
 
   @override
   Widget build(BuildContext context) {
-    if (_lastError != null) {
-      return widget.errorBuilder!(context, _lastError!);
+    final error = _lastError;
+    if (error != null) {
+      final errorBuilder = widget.errorBuilder;
+      if (errorBuilder != null) {
+        return errorBuilder(context, error);
+      }
     }
-
-    if (_lastEvent == null) {
-      return widget.loadingBuilder?.call(context) ?? const Offstage();
+    final event = _lastEvent;
+    if (event == null) {
+      return widget.noDataBuilder?.call(context) ?? const Offstage();
     }
-    return widget.builder(context, _lastEvent ?? widget.initialData);
+    return widget.builder(context, event);
   }
 
   @override
@@ -87,22 +92,22 @@ class _BetterStreamBuilderState<T> extends State<BetterStreamBuilder<T>> {
 
   void _onError(error) {
     if (widget.errorBuilder != null && error != _lastError) {
+      _lastError = error;
       if (mounted) {
         setState(() {});
       }
-      _lastError = error;
     }
   }
 
-  void _onEvent(T event) {
+  void _onEvent(T? event) {
     _lastError = null;
     final isEqual =
         widget.comparator?.call(_lastEvent, event) ?? event == _lastEvent;
     if (!isEqual) {
+      _lastEvent = event;
       if (mounted) {
         setState(() {});
       }
-      _lastEvent = event;
     }
   }
 }

--- a/packages/stream_chat_flutter_core/lib/src/channel_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/channel_list_core.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_flutter_core/src/better_stream_builder.dart';
 import 'package:stream_chat_flutter_core/src/channels_bloc.dart';
 import 'package:stream_chat_flutter_core/src/stream_chat_core.dart';
 import 'package:stream_chat_flutter_core/src/typedef.dart';
@@ -137,19 +138,14 @@ class ChannelListCoreState extends State<ChannelListCore> {
   @override
   Widget build(BuildContext context) => _buildListView(_channelsBloc);
 
-  StreamBuilder<List<Channel>> _buildListView(
+  BetterStreamBuilder<List<Channel>> _buildListView(
     ChannelsBlocState channelsBlocState,
   ) =>
-      StreamBuilder<List<Channel>>(
+      BetterStreamBuilder<List<Channel>>(
         stream: channelsBlocState.channelsStream,
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return widget.errorBuilder(context, snapshot.error!);
-          }
-          if (!snapshot.hasData) {
-            return widget.loadingBuilder(context);
-          }
-          final channels = snapshot.data!;
+        errorBuilder: widget.errorBuilder,
+        noDataBuilder: widget.loadingBuilder,
+        builder: (context, channels) {
           if (channels.isEmpty) {
             return widget.emptyBuilder(context);
           }

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -138,7 +138,7 @@ class MessageListCoreState extends State<MessageListCore> {
       return true;
     }
 
-    return BetterStreamBuilder<List<Message>?>(
+    return BetterStreamBuilder<List<Message>>(
       initialData: initialData,
       comparator: const ListEquality().equals,
       stream: messagesStream!.map(
@@ -148,9 +148,9 @@ class MessageListCoreState extends State<MessageListCore> {
                 ),
       ),
       errorBuilder: widget.errorBuilder,
-      loadingBuilder: widget.loadingBuilder,
+      noDataBuilder: widget.loadingBuilder,
       builder: (context, data) {
-        final messageList = data?.reversed.toList(growable: false) ?? [];
+        final messageList = data.reversed.toList(growable: false);
         if (messageList.isEmpty && !_isThreadConversation) {
           if (_upToDate) {
             return widget.emptyBuilder(context);

--- a/packages/stream_chat_flutter_core/lib/src/message_search_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_search_list_core.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_flutter_core/src/better_stream_builder.dart';
 import 'package:stream_chat_flutter_core/src/message_search_bloc.dart';
 import 'package:stream_chat_flutter_core/src/typedef.dart';
 
@@ -132,16 +133,11 @@ class MessageSearchListCoreState extends State<MessageSearchListCore> {
   Widget build(BuildContext context) => _buildListView(_messageSearchBloc!);
 
   Widget _buildListView(MessageSearchBlocState messageSearchBloc) =>
-      StreamBuilder<List<GetMessageResponse>>(
+      BetterStreamBuilder<List<GetMessageResponse>>(
         stream: messageSearchBloc.messagesStream,
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return widget.errorBuilder(context, snapshot.error!);
-          }
-          if (!snapshot.hasData) {
-            return widget.loadingBuilder(context);
-          }
-          final items = snapshot.data!;
+        errorBuilder: widget.errorBuilder,
+        noDataBuilder: widget.loadingBuilder,
+        builder: (context, items) {
           if (items.isEmpty) {
             return widget.emptyBuilder(context);
           }

--- a/packages/stream_chat_flutter_core/lib/src/user_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/user_list_core.dart
@@ -176,16 +176,11 @@ class UserListCoreState extends State<UserListCore>
         },
       );
 
-  StreamBuilder<List<ListItem>> _buildListView() => StreamBuilder(
+  BetterStreamBuilder<List<ListItem>> _buildListView() => BetterStreamBuilder(
         stream: _buildUserStream(),
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return widget.errorBuilder(context, snapshot.error!);
-          }
-          if (!snapshot.hasData) {
-            return widget.loadingBuilder(context);
-          }
-          final items = snapshot.data!;
+        errorBuilder: widget.errorBuilder,
+        noDataBuilder: widget.loadingBuilder,
+        builder: (context, items) {
           if (items.isEmpty) {
             return widget.emptyBuilder(context);
           }


### PR DESCRIPTION
1. BREAKING: Renamed `BetterStreamBuilder.loadingBuilder` to `.noDataBuilder`.
2. BREAKING: Added non-null constraint on `BetterStreamBuilder<T extends Object>`.
2. `BetterStreamBuilder.initialData` is now nullable/not-required.