### PR TITLE
Update Stream Chat Flutter Dependencies 

### DIFF
--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  cached_network_image: ^3.0.0
+  cached_network_image: ^3.1.0
   characters: ^1.1.0
-  chewie: ^1.2.0
+  chewie: ^1.2.2
   collection: ^1.15.0
   dio: ^4.0.0
   ezanimation: ^0.5.0
-  file_picker: ^3.0.1
+  file_picker: ^4.0.1
   flutter:
     sdk: flutter
   flutter_keyboard_visibility: ^5.0.1
@@ -28,7 +28,7 @@ dependencies:
   image_gallery_saver: ^1.6.9
   image_picker: ^0.8.2
   jiffy: ^4.1.0
-  lottie: ^1.0.1
+  lottie: ^1.1.0
   meta: ^1.3.0
   path_provider: ^2.0.1
   photo_manager: ^1.2.6+1
@@ -42,7 +42,7 @@ dependencies:
   synchronized: ^3.0.0
   url_launcher: ^6.0.3
   video_compress: ^3.0.0
-  video_player: ^2.1.0
+  video_player: ^2.1.14
   video_thumbnail: ^0.3.3
   visibility_detector: ^0.2.0
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
 dependencies:
   cached_network_image: ^3.1.0
   characters: ^1.1.0
-  chewie: ^1.2.2
   collection: ^1.15.0
   dio: ^4.0.0
   ezanimation: ^0.5.0
@@ -45,6 +44,9 @@ dependencies:
   video_player: ^2.1.14
   video_thumbnail: ^0.3.3
   visibility_detector: ^0.2.0
+  chewie:
+    git:
+      url: https://github.com/rlee1990/chewie.git
 
 flutter:
   assets:


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The pull request updates the dependencies to resolve the below errors:

```
Because no versions of giphy_get match >2.0.3 <3.0.0 and giphy_get 2.0.3 depends on provider ^6.0.0, giphy_get ^2.0.3 requires provider ^6.0.0.

And because stream_chat_flutter >=2.0.0-nullsafety.5 depends on chewie ^1.2.0 which depends on provider ^5.0.0, giphy_get ^2.0.3 is incompatible with stream_chat_flutter >=2.0.0-nullsafety.5.
So, because depends on both stream_chat_flutter ^2.2.1 and giphy_get ^2.0.3, version solving failed.

pub get failed (1; So, because depends on both stream_chat_flutter ^2.2.1 and giphy_get ^2.0.3, version solving failed.)
exit code 1
```
