### PR TITLE
feat(repo): Fix the wrong call on Emoji.byShortName and add hashCode and equals override to Emoji class.

### DIFF
--- a/packages/stream_chat_flutter/lib/src/emoji/emoji.dart
+++ b/packages/stream_chat_flutter/lib/src/emoji/emoji.dart
@@ -26,7 +26,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import 'package:collection/collection.dart' show IterableExtension;
+import 'package:collection/collection.dart'
+    show IterableExtension, ListEquality;
 
 /// All Groups
 enum EmojiGroup {
@@ -114240,7 +114241,6 @@ final emojiRegex = RegExp(
 class Emoji {
   static const variationSelector16 = 65039;
   static const ZWJ = 8205;
-
   final String? name;
   final String? char;
   final String? shortName;
@@ -114252,14 +114252,39 @@ class Emoji {
 
   /// Emoji class.
   /// [name] of emoji. [char] and character of emoji. [shortName] and a digest name of emoji, [emojiGroup] is emoji's group and [emojiSubgroup] is emoji's subgroup. [keywords] list of keywords for emoji. [modifiable] `true` if emoji has skin.
-  Emoji(
-      {this.name,
-      this.char,
-      this.shortName,
-      this.emojiGroup,
-      this.emojiSubgroup,
-      this.keywords = const [],
-      this.modifiable = false});
+  Emoji({
+    this.name,
+    this.char,
+    this.shortName,
+    this.emojiGroup,
+    this.emojiSubgroup,
+    this.keywords = const [],
+    this.modifiable = false,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Emoji &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          char == other.char &&
+          shortName == other.shortName &&
+          emojiGroup == other.emojiGroup &&
+          emojiSubgroup == other.emojiSubgroup &&
+          const ListEquality().equals(keywords, other.keywords) &&
+          modifiable == other.modifiable;
+
+  @override
+  int get hashCode => Object.hash(
+        name.hashCode,
+        char.hashCode,
+        shortName.hashCode,
+        emojiGroup.hashCode,
+        emojiSubgroup.hashCode,
+        keywords.hashCode,
+        modifiable.hashCode,
+      );
 
   /// Runes of Emoji Character
   List<int> get charRunes {
@@ -114339,9 +114364,11 @@ class Emoji {
     return _emojis.firstWhereOrNull((Emoji emoji) => emoji.name == name);
   }
 
-  /// Returns Emoji by [name] as short name.
-  static Emoji? byShortName(String name) {
-    return _emojis.firstWhereOrNull((Emoji emoji) => emoji.char == name);
+  /// Returns Emoji by [shortName] as short name.
+  static Emoji? byShortName(String shortName) {
+    return _emojis.firstWhereOrNull(
+      (Emoji emoji) => emoji.shortName == shortName,
+    );
   }
 
   /// Returns list of Emojis in a same [group]

--- a/packages/stream_chat_flutter/test/src/emoji_test.dart
+++ b/packages/stream_chat_flutter/test/src/emoji_test.dart
@@ -1,0 +1,79 @@
+import 'package:stream_chat_flutter/src/emoji/emoji.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('src/emoji', () {
+    test('${Emoji.byShortName} should bring the correct emoji', () {
+      final resultEmoji = Emoji.byShortName('smiley');
+      expect(resultEmoji, _mockEmoji);
+    });
+  });
+}
+
+final _mockEmoji = Emoji(
+    name: 'grinning face with big eyes',
+    char: '\u{1F603}',
+    shortName: 'smiley',
+    emojiGroup: EmojiGroup.smileysEmotion,
+    emojiSubgroup: EmojiSubgroup.faceSmiling,
+    keywords: [
+      'face',
+      'mouth',
+      'open',
+      'smile',
+      'uc6',
+      'smiley',
+      'happy',
+      'silly',
+      'laugh',
+      'good',
+      'smile',
+      'teeth',
+      'fun',
+      'smileys',
+      'mood',
+      'emotion',
+      'emotions',
+      'emotional',
+      'hooray',
+      'cheek',
+      'cheeky',
+      'excited',
+      'feliz',
+      'heureux',
+      'cheerful',
+      'delighted',
+      'ecstatic',
+      'elated',
+      'glad',
+      'joy',
+      'merry',
+      'funny',
+      'laughing',
+      'lol',
+      'rofl',
+      'lmao',
+      'lmfao',
+      'hilarious',
+      'ha',
+      'haha',
+      'chuckle',
+      'comedy',
+      'giggle',
+      'hehe',
+      'joyful',
+      'laugh out loud',
+      'rire',
+      'tee hee',
+      'jaja',
+      'good job',
+      'nice',
+      'well done',
+      'bravo',
+      'congratulations',
+      'congrats',
+      'smiles',
+      'dentist',
+      ':-D',
+      '=D'
+    ]);


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This fixes the Emoji.byShortName function to do the research with shortName instead of just name. Also, this adds hashCode and equals override to the Emoji class. 
