### PR TITLE
fix(llc): Connecting user without providing `name` uses `id` instead for setting `user.name`.

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -16,13 +16,16 @@
 - Added support for `next`, `previous` value pagination in `client.search`
   , [read more.](https://getstream.io/chat/docs/other-rest/search/#pagination)
 - `Attachment` class now has a `fileSize` and `mimeType` property. Setting a `file` will also set the `file_size`
-  , `mime_type` key on `extraData`, so `attachment.fileSize`, `attachment.mimetype` and `attachment.extraData['file_size']`
+  , `mime_type` key on `extraData`, so `attachment.fileSize`, `attachment.mimetype`
+  and `attachment.extraData['file_size']`
   , `attachment.extraData['mime_type]` is same respectively.
 
 🐞 Fixed
 
 - [[#659]](https://github.com/GetStream/stream-chat-flutter/issues/659) Fixed unread count not updating correctly.
 - Fix `Filter.empty()` json encoding.
+- [[#700]](https://github.com/GetStream/stream-chat-flutter/issues/700) Connecting user without providing `name`
+  uses `id` instead for setting `user.name`.
 
 ## 2.2.1
 

--- a/packages/stream_chat/lib/src/core/models/own_user.dart
+++ b/packages/stream_chat/lib/src/core/models/own_user.dart
@@ -54,8 +54,6 @@ class OwnUser extends User {
   factory OwnUser.fromUser(User user) => OwnUser(
         id: user.id,
         role: user.role,
-        name: user.name,
-        image: user.image,
         createdAt: user.createdAt,
         updatedAt: user.updatedAt,
         lastActive: user.lastActive,
@@ -116,8 +114,6 @@ class OwnUser extends User {
     return copyWith(
       id: other.id,
       role: other.role,
-      name: other.name,
-      image: other.image,
       banned: other.banned,
       channelMutes: other.channelMutes,
       createdAt: other.createdAt,

--- a/packages/stream_chat/test/src/core/models/own_user_test.dart
+++ b/packages/stream_chat/test/src/core/models/own_user_test.dart
@@ -175,5 +175,26 @@ void main() {
       expect(newUser.teams, ['team1', 'team2']);
       expect(newUser.language, 'fr');
     });
+
+    test(
+      'fromUser should not override name with id if not available in extraData',
+      () {
+        final user = User(id: 'test-id');
+        expect(user.id, 'test-id');
+        expect(user.name, 'test-id');
+
+        final encodedUser = user.toJson();
+        expect(encodedUser['id'], 'test-id');
+        expect(encodedUser['name'], null);
+
+        final ownUser = OwnUser.fromUser(user);
+        expect(user.id, 'test-id');
+        expect(user.name, 'test-id');
+
+        final encodedOwnUser = ownUser.toJson();
+        expect(encodedOwnUser['id'], 'test-id');
+        expect(encodedOwnUser['name'], null);
+      },
+    );
   });
 }


### PR DESCRIPTION
fixes: #700 