### PR TITLE
fix(llc): support for `int` user Ids in JWT tokens

### DIFF
--- a/packages/stream_chat/lib/src/core/http/token.dart
+++ b/packages/stream_chat/lib/src/core/http/token.dart
@@ -46,12 +46,12 @@ class Token extends Equatable {
   /// Creates a [Token] instance from the provided [rawValue] if it's valid.
   factory Token.fromRawValue(String rawValue) {
     final jwtBody = JsonWebToken.unverified(rawValue);
-    final userId = jwtBody.claims.getTyped<String>('user_id');
+    final userId = jwtBody.claims.getTyped('user_id');
     assert(
       userId != null,
       'Invalid `token`, It should contain `user_id`',
     );
-    return Token._(rawValue: rawValue, userId: userId!, authType: AuthType.jwt);
+    return Token._(rawValue: rawValue, userId: userId!.toString(), authType: AuthType.jwt);
   }
 
   /// The token which can be used during the development.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

We were using our database user id in client JWT token. In `2.0.0-nullsafety.4` it was working properly but since we upgraded to  `2.2.1` client is failing with following error.

References #710 