### PR TITLE
fix(ui): fix capitalize extension not working on empty strings

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -[[#687]](https://github.com/GetStream/stream-chat-flutter/issues/687): Fix Users losing their place in the conversation after replying in threads.
 - Fixed floating date stream subscription causing "Bad state: stream has already been listened.” error.
+- Fixed `String` capitalize extension not working on empty strings.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/extension.dart
+++ b/packages/stream_chat_flutter/lib/src/extension.dart
@@ -12,7 +12,7 @@ final _emojiChars = Emoji.chars();
 extension StringExtension on String {
   /// Returns the capitalized string
   String capitalize() =>
-      '${this[0].toUpperCase()}${substring(1).toLowerCase()}';
+      isNotEmpty ? '${this[0].toUpperCase()}${substring(1).toLowerCase()}' : '';
 
   /// Returns whether the string contains only emoji's or not.
   ///


### PR DESCRIPTION
# This broke our production app

Please quickly accept it and fix

## How to re-create the issue

During chat just type `www.google.com` and it will break the app

## Description of the pull request

I use `stream_chat_flutter` and I faced one problem while 

`RangeError (index): Invalid value: Valid value range is empty: 0`  

When I dig into the code then found that capitalize is written without considering the edge case.

Edge case: If the string is empty i.e `String host = "";` we will get this error here
`RangeError (index): Invalid value: Valid value range is empty: 0`  

I fixed it and made a pull request no more big change is there.
