### PR TITLE
fix(llc): include `message.user` while saving users in persistence.

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+🐞 Fixed
+
+- [[#748]](https://github.com/GetStream/stream-chat-flutter/issues/748) `Message.user` are now also included while saving users in persistence.
+
 🔄 Changed
 
 - `client.location` is now deprecated in favor of the new [edge server](https://getstream.io/blog/chat-edge-infrastructure) and will be removed in v4.0.0.

--- a/packages/stream_chat/lib/src/db/chat_persistence_client.dart
+++ b/packages/stream_chat/lib/src/db/chat_persistence_client.dart
@@ -253,6 +253,7 @@ abstract class ChatPersistenceClient {
 
         users.addAll([
           channel.createdBy,
+          ...messages.map((it) => it.user),
           ...reads.map((it) => it.user),
           ...members.map((it) => it.user),
           ...reactions.map((it) => it.user),


### PR DESCRIPTION
Fixes: #748 