### PR TITLE
fix(llc): fix ChannelState copyWith with respect to pinnedMessages default value.

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [[#871]](https://github.com/GetStream/stream-chat-flutter/issues/871) Fixed thread message deletion.
 - [[#846]](https://github.com/GetStream/stream-chat-flutter/issues/846) Fixed `message.ownReactions` getting truncated when receiving a reaction event.
 - Add check for invalid image URLs
+- Fix `channelState.pinnedMessagesStream` getting reset to `0` after a channel update.
 
 🔄 Changed
 

--- a/packages/stream_chat/lib/src/core/models/channel_state.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_state.dart
@@ -7,6 +7,8 @@ import 'package:stream_chat/src/core/models/user.dart';
 
 part 'channel_state.g.dart';
 
+const _emptyPinnedMessages = <Message>[];
+
 /// The class that contains the information about a channel
 @JsonSerializable()
 class ChannelState {
@@ -15,7 +17,7 @@ class ChannelState {
     this.channel,
     this.messages = const [],
     this.members = const [],
-    this.pinnedMessages = const [],
+    this.pinnedMessages = _emptyPinnedMessages,
     this.watcherCount,
     this.watchers = const [],
     this.read = const [],
@@ -63,7 +65,11 @@ class ChannelState {
         channel: channel ?? this.channel,
         messages: messages ?? this.messages,
         members: members ?? this.members,
-        pinnedMessages: pinnedMessages ?? this.pinnedMessages,
+        // Hack to avoid using the default value in case nothing is provided.
+        // FIXME: Use non-nullable by default instead of empty list.
+        pinnedMessages: pinnedMessages == _emptyPinnedMessages
+            ? this.pinnedMessages
+            : pinnedMessages ?? _emptyPinnedMessages,
         watcherCount: watcherCount ?? this.watcherCount,
         watchers: watchers ?? this.watchers,
         read: read ?? this.read,


### PR DESCRIPTION
Fixes: https://getstream.zendesk.com/agent/tickets/19022