### PR TITLE
fix: Introduce `showFloatingDateDivider` in `MessageListView` on an older version too

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.3-beta
+
+- Introduce `showFloatingDateDivider` in `MessageListView`
+
 ## 2.0.0-nullsafety.2
 
 - Migrate this package to null safety

--- a/packages/stream_chat_flutter/lib/src/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view.dart
@@ -143,6 +143,7 @@ class MessageListView extends StatefulWidget {
     this.onAttachmentTap,
     this.textBuilder,
     this.onLinkTap,
+    this.showFloatingDateDivider = true,
   }) : super(key: key);
 
   /// Function used to build a custom message widget
@@ -204,6 +205,9 @@ class MessageListView extends StatefulWidget {
   final ShowMessageCallback? onShowMessage;
 
   final bool showConnectionStateTile;
+
+  /// Flag for showing the floating date divider
+  final bool showFloatingDateDivider;
 
   /// Function called when messages are fetched
   final Widget Function(BuildContext, List<Message>)? messageListBuilder;

--- a/packages/stream_chat_flutter/lib/src/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view.dart
@@ -557,39 +557,41 @@ class _MessageListViewState extends State<MessageListView> {
           },
         ),
         if (widget.showScrollToBottom) _buildScrollToBottom(),
-        Positioned(
-          top: 20.0,
-          child: ValueListenableBuilder<Iterable<ItemPosition>>(
-            valueListenable: _itemPositionListener.itemPositions,
-            builder: (context, values, _) {
-              final items = _itemPositionListener.itemPositions.value;
-              if (items.isEmpty || messages.isEmpty) {
-                return SizedBox();
-              }
-
-              var index = _getTopElement(values).index;
-
-              if (index > messages.length) {
-                return SizedBox();
-              }
-
-              if (index == messages.length) {
-                index = max(index - 1, 0);
-              }
-
-              return widget.dateDividerBuilder != null
-                  ? widget.dateDividerBuilder!(
-                      messages[index].createdAt.toLocal(),
-                    )
-                  : DateDivider(
-                      dateTime: messages[index].createdAt.toLocal(),
-                    );
-            },
-          ),
-        ),
+        if (widget.showFloatingDateDivider) _buildFloatingDateDivider(),
       ],
     );
   }
+
+  Positioned _buildFloatingDateDivider() => Positioned(
+        top: 20.0,
+        child: ValueListenableBuilder<Iterable<ItemPosition>>(
+          valueListenable: _itemPositionListener.itemPositions,
+          builder: (context, values, _) {
+            final items = _itemPositionListener.itemPositions.value;
+            if (items.isEmpty || messages.isEmpty) {
+              return SizedBox();
+            }
+
+            var index = _getTopElement(values).index;
+
+            if (index > messages.length) {
+              return SizedBox();
+            }
+
+            if (index == messages.length) {
+              index = max(index - 1, 0);
+            }
+
+            return widget.dateDividerBuilder != null
+                ? widget.dateDividerBuilder!(
+                    messages[index].createdAt.toLocal(),
+                  )
+                : DateDivider(
+                    dateTime: messages[index].createdAt.toLocal(),
+                  );
+          },
+        ),
+      );
 
   Future<void> _paginateData(
       StreamChannelState? channel, QueryDirection direction) {

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 2.0.0-nullsafety.2
+version: 2.0.0-nullsafety.3-beta
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable) [There are no tests]
 
## Description of the pull request
- Based on the conversation [here](https://github.com/GetStream/stream-chat-flutter/issues/842#issuecomment-1032767750), my project cannot upgrade to a more recent version of `stream_chat_flutter` due to a cyclic dependencies issue that I haven't fixed yet. We need this change to fix an issue on `stream_chat_flutter: ^2.0.0-nullsafety.2`. 
- I used the change from @imtoori as done [here](https://github.com/GetStream/stream-chat-flutter/commit/eb20b31c825ae430f1cdf367f40fe40e635a5cfc?diff=split) originally.