### PR TITLE
feat(llc): Exposed score as a param for sendReaction function in client & channel

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming
 
+✅ Added
+
 - You can now pass `score` to `client.sendReaction` and `channel.sendReaction` functions
 
 🐞 Fixed

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- You can now pass `score` to `client.sendReaction` and `channel.sendReaction` functions
+
 ## 3.4.0
 
 🐞 Fixed

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -7,7 +7,6 @@
 🐞 Fixed
 
 - [[#890]](https://github.com/GetStream/stream-chat-flutter/pull/890). Fixed Reactions not updating on thread messages. Thanks [bstolinski](https://github.com/bstolinski).
-- 
 ## 3.4.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -811,6 +811,7 @@ class Channel {
   Future<SendReactionResponse> sendReaction(
     Message message,
     String type, {
+    int? score,
     Map<String, Object?> extraData = const {},
     bool enforceUnique = false,
   }) async {
@@ -861,6 +862,13 @@ class Channel {
     );
 
     state?.addMessage(newMessage);
+
+    if (score != null) {
+      extraData.putIfAbsent(
+        'score',
+        () => score,
+      );
+    }
 
     try {
       final reactionResp = await _client.sendReaction(

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -811,7 +811,7 @@ class Channel {
   Future<SendReactionResponse> sendReaction(
     Message message,
     String type, {
-    int? score,
+    int score = 1,
     Map<String, Object?> extraData = const {},
     bool enforceUnique = false,
   }) async {
@@ -830,7 +830,7 @@ class Channel {
       createdAt: now,
       type: type,
       user: user,
-      score: 1,
+      score: score,
       extraData: extraData,
     );
 
@@ -863,17 +863,11 @@ class Channel {
 
     state?.addMessage(newMessage);
 
-    if (score != null) {
-      extraData.putIfAbsent(
-        'score',
-        () => score,
-      );
-    }
-
     try {
       final reactionResp = await _client.sendReaction(
         messageId,
         type,
+        score: score,
         extraData: extraData,
         enforceUnique: enforceUnique,
       );

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1157,15 +1157,22 @@ class StreamChatClient {
   Future<SendReactionResponse> sendReaction(
     String messageId,
     String reactionType, {
+    int score = 1,
     Map<String, Object?> extraData = const {},
     bool enforceUnique = false,
-  }) =>
-      _chatApi.message.sendReaction(
-        messageId,
-        reactionType,
-        extraData: extraData,
-        enforceUnique: enforceUnique,
-      );
+  }) {
+    extraData.putIfAbsent(
+      'score',
+      () => score,
+    );
+
+    return _chatApi.message.sendReaction(
+      messageId,
+      reactionType,
+      extraData: extraData,
+      enforceUnique: enforceUnique,
+    );
+  }
 
   /// Delete a [reactionType] from this [messageId]
   Future<EmptyResponse> deleteReaction(

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1161,15 +1161,15 @@ class StreamChatClient {
     Map<String, Object?> extraData = const {},
     bool enforceUnique = false,
   }) {
-    extraData.putIfAbsent(
-      'score',
-      () => score,
-    );
+    final _extraData = {
+      'score': score,
+      ...extraData,
+    };
 
     return _chatApi.message.sendReaction(
       messageId,
       reactionType,
-      extraData: extraData,
+      extraData: _extraData,
       enforceUnique: enforceUnique,
     );
   }

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1956,23 +1956,109 @@ void main() {
       verifyNoMoreInteractions(api.channel);
     });
 
-    test('`.sendReaction`', () async {
-      const messageId = 'test-message-id';
-      const reactionType = 'like';
+    group('`.sendReaction`', () {
+      test('`.sendReaction with default params`', () async {
+        const messageId = 'test-message-id';
+        const reactionType = 'like';
+        const extraData = {'score': 1};
 
-      when(() => api.message.sendReaction(messageId, reactionType))
-          .thenAnswer((_) async => SendReactionResponse()
-            ..message = Message(id: messageId)
-            ..reaction = Reaction(type: reactionType, messageId: messageId));
+        when(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).thenAnswer((_) async => SendReactionResponse()
+          ..message = Message(id: messageId)
+          ..reaction = Reaction(type: reactionType, messageId: messageId));
 
-      final res = await client.sendReaction(messageId, reactionType);
-      expect(res, isNotNull);
-      expect(res.message.id, messageId);
-      expect(res.reaction.type, reactionType);
-      expect(res.reaction.messageId, messageId);
+        final res = await client.sendReaction(messageId, reactionType);
+        expect(res, isNotNull);
+        expect(res.message.id, messageId);
+        expect(res.reaction.type, reactionType);
+        expect(res.reaction.messageId, messageId);
 
-      verify(() => api.message.sendReaction(messageId, reactionType)).called(1);
-      verifyNoMoreInteractions(api.message);
+        verify(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).called(1);
+        verifyNoMoreInteractions(api.message);
+      });
+
+      test('`.sendReaction with score`', () async {
+        const messageId = 'test-message-id';
+        const reactionType = 'like';
+        const score = 3;
+        const extraData = {'score': score};
+
+        when(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).thenAnswer((_) async => SendReactionResponse()
+          ..message = Message(id: messageId)
+          ..reaction = Reaction(
+            type: reactionType,
+            messageId: messageId,
+            score: score,
+          ));
+
+        final res = await client.sendReaction(
+          messageId,
+          reactionType,
+          score: score,
+        );
+        expect(res, isNotNull);
+        expect(res.message.id, messageId);
+        expect(res.reaction.type, reactionType);
+        expect(res.reaction.messageId, messageId);
+        expect(res.reaction.score, score);
+
+        verify(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).called(1);
+        verifyNoMoreInteractions(api.message);
+      });
+
+      test('`.sendReaction with score passed in extradata also`', () async {
+        const messageId = 'test-message-id';
+        const reactionType = 'like';
+        const score = 3;
+        const extraDataScore = 5;
+        const extraData = {'score': extraDataScore};
+
+        when(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).thenAnswer((_) async => SendReactionResponse()
+          ..message = Message(id: messageId)
+          ..reaction = Reaction(
+            type: reactionType,
+            messageId: messageId,
+            score: extraDataScore,
+          ));
+
+        final res = await client.sendReaction(
+          messageId,
+          reactionType,
+          score: score,
+          extraData: extraData,
+        );
+        expect(res, isNotNull);
+        expect(res.message.id, messageId);
+        expect(res.reaction.type, reactionType);
+        expect(res.reaction.messageId, messageId);
+        expect(res.reaction.score, extraDataScore);
+
+        verify(() => api.message.sendReaction(
+              messageId,
+              reactionType,
+              extraData: extraData,
+            )).called(1);
+        verifyNoMoreInteractions(api.message);
+      });
     });
 
     test('`.deleteReaction`', () async {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested

## Description of the pull request

There was already a provision to add reaction scores, via extraData in the sendReaction function at the client and channel level. While that is still possible and takes priority, I have added a named parameter named `score` so that developers can directly provide an integer score value to the sendReaction function and the SDK will handle its embedding into extraData.