### PR TITLE
fix(llc): Fix `channelState.copyWith` with respect to pinnedMessages.

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[#890]](https://github.com/GetStream/stream-chat-flutter/pull/890) Fixed Reactions not updating on thread messages.
   Thanks [bstolinski](https://github.com/bstolinski).
 - [[#897]](https://github.com/GetStream/stream-chat-flutter/issues/897) Fixed error type mis-match in `AuthInterceptor`.
+- Fix `channelState.copyWith` with respect to pinnedMessages.
 
 ## 3.4.0
 

--- a/packages/stream_chat/lib/src/core/models/channel_state.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_state.dart
@@ -67,9 +67,10 @@ class ChannelState {
         members: members ?? this.members,
         // Hack to avoid using the default value in case nothing is provided.
         // FIXME: Use non-nullable by default instead of empty list.
-        pinnedMessages: pinnedMessages == _emptyPinnedMessages
-            ? this.pinnedMessages
-            : pinnedMessages ?? _emptyPinnedMessages,
+        pinnedMessages:
+            pinnedMessages == null || pinnedMessages == _emptyPinnedMessages
+                ? this.pinnedMessages
+                : pinnedMessages,
         watcherCount: watcherCount ?? this.watcherCount,
         watchers: watchers ?? this.watchers,
         read: read ?? this.read,


### PR DESCRIPTION
Fixes: https://getstream.zendesk.com/agent/tickets/19022