### PR TITLE
fix(ui): Clicking on Avatar in ChannelPreview should go to Channel route by default

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [[#888]](https://github.com/GetStream/stream-chat-flutter/issues/888) Fix `unban` command not working in `MessageInput`.
 - [[#805]](https://github.com/GetStream/stream-chat-flutter/issues/805) Updated chewie dependency version to 1.3.0
 - Fix `showScrollToBottom` in `MessageListView` not respecting false value.
+- Fix default `Channel` route not opening from `ChannelListView` when `ChannelAvatar` is tapped
 
 ## 3.4.0
 - Updated `stream_chat_flutter_core` dependency to [`3.4.0`](https://pub.dev/packages/stream_chat_flutter_core/changelog).

--- a/packages/stream_chat_flutter/lib/src/channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/channel_list_view.dart
@@ -614,7 +614,7 @@ class _ChannelListViewState extends State<ChannelListView> {
     if (widget.onChannelTap != null) {
       onTap = widget.onChannelTap!;
     } else {
-      onTap = (client, _) {
+      onTap = (channel, _) {
         if (widget.channelWidget == null) {
           return;
         }
@@ -622,7 +622,7 @@ class _ChannelListViewState extends State<ChannelListView> {
           context,
           MaterialPageRoute(
             builder: (context) => StreamChannel(
-              channel: client,
+              channel: channel,
               child: widget.channelWidget!,
             ),
           ),

--- a/packages/stream_chat_flutter/lib/src/channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/channel_list_view.dart
@@ -599,7 +599,9 @@ class _ChannelListViewState extends State<ChannelListView> {
               child: ChannelPreview(
                 onLongPress: widget.onChannelLongPress,
                 channel: channel,
-                onImageTap: () => widget.onImageTap?.call(channel),
+                onImageTap: widget.onImageTap != null
+                    ? () => widget.onImageTap!(channel)
+                    : null,
                 onTap: (channel) => onTap(channel, widget.channelWidget),
               ),
             ),


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform)
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

If a custom `onImageTap` function is not passed to `ChannelListView` then the default behaviour on tapping the `ChannelAvatar` in the `ChannelPreview` should be to take the user to the default `Channel` route.

This has been achieved by passing null to `ChannelAvatar` onTap when no custom function is passed, so that the tap action is ignored by the avatar and captured by the `ChannelPreview` widget instead.