### PR TITLE
refactor(ui): move portal location to message list layer

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_portal/flutter_portal.dart';
 import 'package:stream_chat_flutter/scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:stream_chat_flutter/src/extension.dart';
 import 'package:stream_chat_flutter/src/swipeable.dart';
@@ -397,37 +398,39 @@ class _MessageListViewState extends State<MessageListView> {
       widget.messageListController ?? _defaultController;
 
   @override
-  Widget build(BuildContext context) => MessageListCore(
-        paginationLimit: widget.paginationLimit,
-        messageFilter: widget.messageFilter,
-        loadingBuilder: widget.loadingBuilder ??
-            (context) => const Center(
-                  child: CircularProgressIndicator(),
-                ),
-        emptyBuilder: widget.emptyBuilder ??
-            (context) => Center(
-                  child: Text(
-                    context.translations.emptyChatMessagesText,
-                    style: _streamTheme.textTheme.footnote.copyWith(
-                      color: _streamTheme.colorTheme.textHighEmphasis
-                          .withOpacity(0.5),
+  Widget build(BuildContext context) => Portal(
+        child: MessageListCore(
+          paginationLimit: widget.paginationLimit,
+          messageFilter: widget.messageFilter,
+          loadingBuilder: widget.loadingBuilder ??
+              (context) => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+          emptyBuilder: widget.emptyBuilder ??
+              (context) => Center(
+                    child: Text(
+                      context.translations.emptyChatMessagesText,
+                      style: _streamTheme.textTheme.footnote.copyWith(
+                        color: _streamTheme.colorTheme.textHighEmphasis
+                            .withOpacity(0.5),
+                      ),
                     ),
                   ),
-                ),
-        messageListBuilder: widget.messageListBuilder ??
-            (context, list) => _buildListView(list),
-        messageListController: _messageListController,
-        parentMessage: widget.parentMessage,
-        errorBuilder: widget.errorBuilder ??
-            (BuildContext context, Object error) => Center(
-                  child: Text(
-                    context.translations.genericErrorText,
-                    style: _streamTheme.textTheme.footnote.copyWith(
-                      color: _streamTheme.colorTheme.textHighEmphasis
-                          .withOpacity(0.5),
+          messageListBuilder: widget.messageListBuilder ??
+              (context, list) => _buildListView(list),
+          messageListController: _messageListController,
+          parentMessage: widget.parentMessage,
+          errorBuilder: widget.errorBuilder ??
+              (BuildContext context, Object error) => Center(
+                    child: Text(
+                      context.translations.genericErrorText,
+                      style: _streamTheme.textTheme.footnote.copyWith(
+                        color: _streamTheme.colorTheme.textHighEmphasis
+                            .withOpacity(0.5),
+                      ),
                     ),
                   ),
-                ),
+        ),
       );
 
   Widget _buildListView(List<Message> data) {

--- a/packages/stream_chat_flutter/lib/src/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget.dart
@@ -611,228 +611,218 @@ class _MessageWidgetState extends State<MessageWidget>
       color: widget.message.pinned && widget.showPinHighlight
           ? _streamChatTheme.colorTheme.highlight
           : null,
-      child: Portal(
-        child: InkWell(
-          onTap: () {
-            widget.onMessageTap!(widget.message);
-          },
-          onLongPress: widget.message.isDeleted && !isFailedState
-              ? null
-              : () => onLongPress(context),
-          child: Padding(
-            padding: widget.padding ?? const EdgeInsets.all(8),
-            child: FractionallySizedBox(
-              alignment:
-                  widget.reverse ? Alignment.centerRight : Alignment.centerLeft,
-              widthFactor: 0.78,
-              child: Column(
-                crossAxisAlignment: widget.reverse
-                    ? CrossAxisAlignment.end
-                    : CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  Stack(
-                    clipBehavior: Clip.none,
-                    alignment: widget.reverse
-                        ? AlignmentDirectional.bottomEnd
-                        : AlignmentDirectional.bottomStart,
-                    children: [
-                      Padding(
-                        padding: EdgeInsets.only(
-                          bottom:
-                              isPinned && widget.showPinHighlight ? 8.0 : 0.0,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: widget.reverse
-                              ? CrossAxisAlignment.end
-                              : CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (widget.message.pinned &&
-                                widget.message.pinnedBy != null &&
-                                widget.showPinHighlight)
-                              _buildPinnedMessage(widget.message),
-                            Row(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                if (!widget.reverse &&
-                                    widget.showUserAvatar ==
-                                        DisplayWidget.show &&
-                                    widget.message.user != null) ...[
-                                  _buildUserAvatar(),
-                                  const SizedBox(width: 4),
-                                ],
-                                if (widget.showUserAvatar == DisplayWidget.hide)
-                                  SizedBox(width: avatarWidth + 4),
-                                Flexible(
-                                  child: PortalEntry(
-                                    visible: showReactions,
-                                    portal: showReactions
-                                        ? Container(
-                                            transform:
-                                                Matrix4.translationValues(
-                                              widget.reverse ? 12 : -12,
-                                              0,
-                                              0,
-                                            ),
-                                            constraints: const BoxConstraints(
-                                              maxWidth: 22 * 6.0,
-                                            ),
-                                            child: _buildReactionIndicator(
-                                              context,
-                                            ),
-                                          )
-                                        : null,
-                                    portalAnchor:
-                                        Alignment(widget.reverse ? 1 : -1, -1),
-                                    childAnchor:
-                                        Alignment(widget.reverse ? -1 : 1, -1),
-                                    child: Stack(
-                                      clipBehavior: Clip.none,
-                                      children: [
-                                        Padding(
-                                          padding: widget.showReactions
-                                              ? EdgeInsets.only(
-                                                  top: widget
-                                                              .message
-                                                              .reactionCounts
-                                                              ?.isNotEmpty ==
-                                                          true
-                                                      ? 18
-                                                      : 0,
-                                                )
-                                              : EdgeInsets.zero,
-                                          child: (widget.message.isDeleted &&
-                                                  !isFailedState)
-                                              ? Container(
-                                                  // ignore: lines_longer_than_80_chars
-                                                  margin: EdgeInsets.symmetric(
-                                                    horizontal:
-                                                        // ignore: lines_longer_than_80_chars
-                                                        widget.showUserAvatar ==
-                                                                // ignore: lines_longer_than_80_chars
-                                                                DisplayWidget
-                                                                    .gone
-                                                            ? 0
-                                                            : 4.0,
-                                                  ),
-                                                  child: DeletedMessage(
-                                                    borderRadiusGeometry: widget
-                                                        .borderRadiusGeometry,
-                                                    borderSide:
-                                                        widget.borderSide,
-                                                    shape: widget.shape,
-                                                    messageTheme:
-                                                        widget.messageTheme,
-                                                  ),
-                                                )
-                                              : Card(
-                                                  clipBehavior: Clip.hardEdge,
-                                                  elevation: 0,
-                                                  margin: EdgeInsets.symmetric(
-                                                    horizontal: (isFailedState
-                                                            ? 15.0
-                                                            : 0.0) +
-                                                        // ignore: lines_longer_than_80_chars
-                                                        (widget.showUserAvatar ==
-                                                                DisplayWidget
-                                                                    .gone
-                                                            ? 0
-                                                            : 4.0),
-                                                  ),
-                                                  shape: widget.shape ??
-                                                      RoundedRectangleBorder(
-                                                        side: widget
-                                                                .borderSide ??
-                                                            BorderSide(
-                                                              color: widget
-                                                                      // ignore: lines_longer_than_80_chars
-                                                                      .messageTheme
-                                                                      // ignore: lines_longer_than_80_chars
-                                                                      .messageBorderColor ??
-                                                                  Colors.grey,
-                                                            ),
-                                                        borderRadius: widget
-                                                                // ignore: lines_longer_than_80_chars
-                                                                .borderRadiusGeometry ??
-                                                            BorderRadius.zero,
-                                                      ),
-                                                  color: _getBackgroundColor(),
-                                                  child: Column(
-                                                    crossAxisAlignment:
-                                                        CrossAxisAlignment.end,
-                                                    mainAxisSize:
-                                                        MainAxisSize.min,
-                                                    children: <Widget>[
-                                                      if (hasQuotedMessage)
-                                                        _buildQuotedMessage(),
-                                                      if (hasNonUrlAttachments)
-                                                        _parseAttachments(),
-                                                      if (!isGiphy)
-                                                        _buildTextBubble(),
-                                                    ],
-                                                  ),
+      child: InkWell(
+        onTap: () {
+          widget.onMessageTap!(widget.message);
+        },
+        onLongPress: widget.message.isDeleted && !isFailedState
+            ? null
+            : () => onLongPress(context),
+        child: Padding(
+          padding: widget.padding ?? const EdgeInsets.all(8),
+          child: FractionallySizedBox(
+            alignment:
+                widget.reverse ? Alignment.centerRight : Alignment.centerLeft,
+            widthFactor: 0.78,
+            child: Column(
+              crossAxisAlignment: widget.reverse
+                  ? CrossAxisAlignment.end
+                  : CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Stack(
+                  clipBehavior: Clip.none,
+                  alignment: widget.reverse
+                      ? AlignmentDirectional.bottomEnd
+                      : AlignmentDirectional.bottomStart,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(
+                        bottom: isPinned && widget.showPinHighlight ? 8.0 : 0.0,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: widget.reverse
+                            ? CrossAxisAlignment.end
+                            : CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (widget.message.pinned &&
+                              widget.message.pinnedBy != null &&
+                              widget.showPinHighlight)
+                            _buildPinnedMessage(widget.message),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              if (!widget.reverse &&
+                                  widget.showUserAvatar == DisplayWidget.show &&
+                                  widget.message.user != null) ...[
+                                _buildUserAvatar(),
+                                const SizedBox(width: 4),
+                              ],
+                              if (widget.showUserAvatar == DisplayWidget.hide)
+                                SizedBox(width: avatarWidth + 4),
+                              Flexible(
+                                child: PortalEntry(
+                                  visible: showReactions,
+                                  portal: showReactions
+                                      ? Container(
+                                          transform: Matrix4.translationValues(
+                                            widget.reverse ? 12 : -12,
+                                            0,
+                                            0,
+                                          ),
+                                          constraints: const BoxConstraints(
+                                            maxWidth: 22 * 6.0,
+                                          ),
+                                          child: _buildReactionIndicator(
+                                            context,
+                                          ),
+                                        )
+                                      : null,
+                                  portalAnchor:
+                                      Alignment(widget.reverse ? 1 : -1, -1),
+                                  childAnchor:
+                                      Alignment(widget.reverse ? -1 : 1, -1),
+                                  child: Stack(
+                                    clipBehavior: Clip.none,
+                                    children: [
+                                      Padding(
+                                        padding: widget.showReactions
+                                            ? EdgeInsets.only(
+                                                top: widget
+                                                            .message
+                                                            .reactionCounts
+                                                            ?.isNotEmpty ==
+                                                        true
+                                                    ? 18
+                                                    : 0,
+                                              )
+                                            : EdgeInsets.zero,
+                                        child: (widget.message.isDeleted &&
+                                                !isFailedState)
+                                            ? Container(
+                                                // ignore: lines_longer_than_80_chars
+                                                margin: EdgeInsets.symmetric(
+                                                  horizontal:
+                                                      // ignore: lines_longer_than_80_chars
+                                                      widget.showUserAvatar ==
+                                                              // ignore: lines_longer_than_80_chars
+                                                              DisplayWidget.gone
+                                                          ? 0
+                                                          : 4.0,
                                                 ),
-                                        ),
-                                        if (widget.showReactionPickerIndicator)
-                                          Positioned(
-                                            right: widget.reverse ? null : 4,
-                                            left: widget.reverse ? 4 : null,
-                                            top: -8,
-                                            child: CustomPaint(
-                                              painter: ReactionBubblePainter(
-                                                _streamChatTheme
-                                                    .colorTheme.barsBg,
-                                                Colors.transparent,
-                                                Colors.transparent,
-                                                tailCirclesSpace: 1,
+                                                child: DeletedMessage(
+                                                  borderRadiusGeometry: widget
+                                                      .borderRadiusGeometry,
+                                                  borderSide: widget.borderSide,
+                                                  shape: widget.shape,
+                                                  messageTheme:
+                                                      widget.messageTheme,
+                                                ),
+                                              )
+                                            : Card(
+                                                clipBehavior: Clip.hardEdge,
+                                                elevation: 0,
+                                                margin: EdgeInsets.symmetric(
+                                                  horizontal: (isFailedState
+                                                          ? 15.0
+                                                          : 0.0) +
+                                                      // ignore: lines_longer_than_80_chars
+                                                      (widget.showUserAvatar ==
+                                                              DisplayWidget.gone
+                                                          ? 0
+                                                          : 4.0),
+                                                ),
+                                                shape: widget.shape ??
+                                                    RoundedRectangleBorder(
+                                                      side: widget.borderSide ??
+                                                          BorderSide(
+                                                            color: widget
+                                                                    // ignore: lines_longer_than_80_chars
+                                                                    .messageTheme
+                                                                    // ignore: lines_longer_than_80_chars
+                                                                    .messageBorderColor ??
+                                                                Colors.grey,
+                                                          ),
+                                                      borderRadius: widget
+                                                              // ignore: lines_longer_than_80_chars
+                                                              .borderRadiusGeometry ??
+                                                          BorderRadius.zero,
+                                                    ),
+                                                color: _getBackgroundColor(),
+                                                child: Column(
+                                                  crossAxisAlignment:
+                                                      CrossAxisAlignment.end,
+                                                  mainAxisSize:
+                                                      MainAxisSize.min,
+                                                  children: <Widget>[
+                                                    if (hasQuotedMessage)
+                                                      _buildQuotedMessage(),
+                                                    if (hasNonUrlAttachments)
+                                                      _parseAttachments(),
+                                                    if (!isGiphy)
+                                                      _buildTextBubble(),
+                                                  ],
+                                                ),
                                               ),
+                                      ),
+                                      if (widget.showReactionPickerIndicator)
+                                        Positioned(
+                                          right: widget.reverse ? null : 4,
+                                          left: widget.reverse ? 4 : null,
+                                          top: -8,
+                                          child: CustomPaint(
+                                            painter: ReactionBubblePainter(
+                                              _streamChatTheme
+                                                  .colorTheme.barsBg,
+                                              Colors.transparent,
+                                              Colors.transparent,
+                                              tailCirclesSpace: 1,
                                             ),
                                           ),
-                                      ],
-                                    ),
+                                        ),
+                                    ],
                                   ),
                                 ),
-                                if (widget.reverse &&
-                                    widget.showUserAvatar ==
-                                        DisplayWidget.show &&
-                                    widget.message.user != null) ...[
-                                  _buildUserAvatar(),
-                                  const SizedBox(width: 4),
-                                ],
+                              ),
+                              if (widget.reverse &&
+                                  widget.showUserAvatar == DisplayWidget.show &&
+                                  widget.message.user != null) ...[
+                                _buildUserAvatar(),
+                                const SizedBox(width: 4),
                               ],
-                            ),
-                            if (showBottomRow)
-                              SizedBox(height: context.textScaleFactor * 18.0),
-                          ],
-                        ),
-                      ),
-                      if (showBottomRow)
-                        Padding(
-                          padding: EdgeInsets.only(
-                            left: !widget.reverse ? bottomRowPadding : 0,
-                            right: widget.reverse ? bottomRowPadding : 0,
-                            bottom:
-                                isPinned && widget.showPinHighlight ? 6.0 : 0.0,
+                            ],
                           ),
-                          child: widget.bottomRowBuilder?.call(
-                                context,
-                                widget.message,
-                              ) ??
-                              _bottomRow,
+                          if (showBottomRow)
+                            SizedBox(height: context.textScaleFactor * 18.0),
+                        ],
+                      ),
+                    ),
+                    if (showBottomRow)
+                      Padding(
+                        padding: EdgeInsets.only(
+                          left: !widget.reverse ? bottomRowPadding : 0,
+                          right: widget.reverse ? bottomRowPadding : 0,
+                          bottom:
+                              isPinned && widget.showPinHighlight ? 6.0 : 0.0,
                         ),
-                      if (isFailedState)
-                        Positioned(
-                          right: widget.reverse ? 0 : null,
-                          left: widget.reverse ? null : 0,
-                          bottom: showBottomRow ? 18 : -2,
-                          child: StreamSvgIcon.error(size: 20),
-                        ),
-                    ],
-                  ),
-                ],
-              ),
+                        child: widget.bottomRowBuilder?.call(
+                              context,
+                              widget.message,
+                            ) ??
+                            _bottomRow,
+                      ),
+                    if (isFailedState)
+                      Positioned(
+                        right: widget.reverse ? 0 : null,
+                        left: widget.reverse ? null : 0,
+                        bottom: showBottomRow ? 18 : -2,
+                        child: StreamSvgIcon.error(size: 20),
+                      ),
+                  ],
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
Instead of creating a portal for each message widget, create a portal for each message list. It cannot be moved higher in the widget tree, otherwise it will result in the reactions overlaying other components (for example, the AppBarr)