### PR TITLE
feat(ui): Add ability to specify onLinkTap for url attachments

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Mentions overlay now doesn't overflow when not enough height available
 
+
+✅ Added
+
+- `onLinkTap` for `MessageWidget` can now be passed down to `UrlAttachment`.
+
+
 ## 3.5.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
@@ -14,6 +14,7 @@ class UrlAttachment extends StatelessWidget {
       horizontal: 16,
       vertical: 8,
     ),
+    this.onLinkTap,
   }) : super(key: key);
 
   /// Attachment to be displayed
@@ -28,13 +29,20 @@ class UrlAttachment extends StatelessWidget {
   /// [MessageThemeData] for showing image title
   final MessageThemeData messageTheme;
 
+  /// The function called when tapping on a link
+  final void Function(String)? onLinkTap;
+
   @override
   Widget build(BuildContext context) {
     final chatThemeData = StreamChatTheme.of(context);
     return GestureDetector(
       onTap: () {
         final titleLink = urlAttachment.titleLink;
-        if (titleLink != null) launchURL(context, titleLink);
+        if (titleLink != null) {
+          onLinkTap != null
+              ? onLinkTap!(titleLink)
+              : launchURL(context, titleLink);
+        }
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/stream_chat_flutter/lib/src/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget.dart
@@ -1013,6 +1013,7 @@ class _MessageWidgetState extends State<MessageWidget>
       hostDisplayName: hostDisplayName,
       textPadding: widget.textPadding,
       messageTheme: widget.messageTheme,
+      onLinkTap: widget.onLinkTap,
     );
   }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Closes #1003 

If the user specifies onLinkTap for MessageWidget, it now gets passed down to the UrlAttachment widget.

