### PR TITLE
chore(repo): Proposal: Don't run actions on draft PR's

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   analyze:
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: "Git Checkout"
@@ -45,6 +46,7 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     timeout-minutes: 15
     steps:
       - name: "Git Checkout"
@@ -73,6 +75,7 @@ jobs:
 
   test:
     runs-on: macos-latest
+    if: github.event.pull_request.draft == false
     timeout-minutes: 20
     steps:
       - name: "Git Checkout"
@@ -123,3 +126,12 @@ jobs:
         with:
           path: packages/stream_chat_flutter/coverage/lcov.info
           min_coverage: 67
+
+  draft-build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == true
+    timeout-minutes: 1
+
+    steps:
+      - name: Run a one-line script
+        run: echo Draft PR, you are good.


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
It can be immensely aggravating to get constant emails of actions failing when adding commits to draft pull requests - #913 is a perfect example of this. I get bombarded with failure emails every time I push commits, and it's quite irritating. 

Per a GitHub Community post that I found, I have set the actions to only run on regular PR's, and a one-line action to run on drafts that just prints a message (I think this is needed for the sake of being thorough?).
