### PR TITLE
Changed permission request api in attachment picker(v4)

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_input/stream_attachment_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_attachment_picker.dart
@@ -426,12 +426,12 @@ class _PickerWidget extends StatefulWidget {
 }
 
 class _PickerWidgetState extends State<_PickerWidget> {
-  Future<bool>? requestPermission;
+  Future<PermissionState>? requestPermission;
 
   @override
   void initState() {
     super.initState();
-    requestPermission = PhotoManager.requestPermission();
+    requestPermission = PhotoManager.requestPermissionExtend();
   }
 
   @override
@@ -440,14 +440,15 @@ class _PickerWidgetState extends State<_PickerWidget> {
       return widget.customAttachmentTypes[widget.filePickerIndex - 1]
           .pickerBuilder(context);
     }
-    return FutureBuilder<bool>(
+    return FutureBuilder<PermissionState>(
       future: requestPermission,
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Offstage();
         }
 
-        if (snapshot.data!) {
+        if ([PermissionState.authorized, PermissionState.limited]
+            .contains(snapshot.data)) {
           if (widget.containsFile ||
               !widget.allowedAttachmentTypes
                   .contains(DefaultAttachmentTypes.image)) {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The Photo Manager plugin has now removed the `requestPermission` API that had previously been deprecated. This migrates the same code in StreamAttachmentPicker to the new API