### PR TITLE
doc(repo): Fixed code in the overlapping chat with transparency docs

### DIFF
--- a/docusaurus/docs/Flutter/guides/adding_chat_to_video_livestreams.mdx
+++ b/docusaurus/docs/Flutter/guides/adding_chat_to_video_livestreams.mdx
@@ -61,75 +61,37 @@ The second type looks like this:
 
 ![](../assets/live_stream_2.jpg)
 
-We can use a `Stack` for achieving this, here's a complete working implementation:
+We can use a `Stack` for achieving this:
 
 ```dart
-class MyApp extends StatelessWidget {
-  const MyApp({
-    Key? key,
-    required this.client,
-    required this.channel,
-  }) : super(key: key);
-
-  final StreamChatClient client;
-
-  final Channel channel;
-
-  @override
-  Widget build(BuildContext context) => MaterialApp(
-        theme: ThemeData.light(),
-        darkTheme: ThemeData.dark(),
-        builder: (context, widget) => StreamChat(
-          client: client,
-          child: widget,
-          streamChatThemeData: StreamChatThemeData().copyWith(
-            messageListViewTheme: const MessageListViewThemeData(
-              backgroundColor: Colors.transparent,
+Stack(
+  children: <Widget>[
+    // Add your video implementation here
+    ShaderMask(
+      shaderCallback: (rect) {
+        return const LinearGradient(
+            begin: Alignment.bottomCenter,
+            end: Alignment.topCenter,
+            colors: [Colors.black, Colors.transparent],
+            stops: [0.4, 0.8]).createShader(
+          Rect.fromLTRB(0, 0, rect.width, rect.height),
+        );
+      },
+      blendMode: BlendMode.dstIn,
+      child: Column(
+        children: const [
+          Expanded(
+            child: MessageListViewTheme(
+              data: MessageListViewThemeData(
+                backgroundColor: Colors.transparent,
+              ),
+              child: MessageListView(),
             ),
           ),
-        ),
-        home: StreamChannel(
-          channel: channel,
-          child: const ChannelPage(),
-        ),
-      );
-}
-
-class ChannelPage extends StatelessWidget {
-  const ChannelPage({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: Stack(
-        children: <Widget>[
-          // Add your video implementation here
-          ShaderMask(
-            shaderCallback: (rect) {
-              return const LinearGradient(
-                  begin: Alignment.bottomCenter,
-                  end: Alignment.topCenter,
-                  colors: [Colors.black, Colors.transparent],
-                  stops: [0.4, 0.8]).createShader(
-                Rect.fromLTRB(0, 0, rect.width, rect.height),
-              );
-            },
-            blendMode: BlendMode.dstIn,
-            child: Column(
-              children: const [
-                Expanded(
-                  child: MessageListView(),
-                ),
-                MessageInput(),
-              ],
-            ),
-          ),
+          MessageInput(),
         ],
       ),
-    );
-  }
-}
+    ),
+  ],
+),
 ```

--- a/docusaurus/docs/Flutter/guides/adding_chat_to_video_livestreams.mdx
+++ b/docusaurus/docs/Flutter/guides/adding_chat_to_video_livestreams.mdx
@@ -61,33 +61,75 @@ The second type looks like this:
 
 ![](../assets/live_stream_2.jpg)
 
-We can use a `Stack` for achieving this:
+We can use a `Stack` for achieving this, here's a complete working implementation:
 
 ```dart
-Scaffold(
-  body: Stack(
-    children: <Widget>[
-      // Add your video implementation here
-      ShaderMask(
-        shaderCallback: (rect) {
-          return LinearGradient(
-            begin: Alignment.bottomCenter,
-            end: Alignment.topCenter,
-           colors: [Colors.black, Colors.transparent],
-           stops: [0.4, 0.65]
-          ).createShader(Rect.fromLTRB(0, 0, rect.width, rect.height));
-        },
-       blendMode: BlendMode.dstIn,
-         child: Column(
-           children: [
-             Expanded(
-               child: MessageListView(),
-             ),
-             MessageInput(),
-           ],
-         ),
-       ),
-     ],
-   ),
- )
+class MyApp extends StatelessWidget {
+  const MyApp({
+    Key? key,
+    required this.client,
+    required this.channel,
+  }) : super(key: key);
+
+  final StreamChatClient client;
+
+  final Channel channel;
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        builder: (context, widget) => StreamChat(
+          client: client,
+          child: widget,
+          streamChatThemeData: StreamChatThemeData().copyWith(
+            messageListViewTheme: const MessageListViewThemeData(
+              backgroundColor: Colors.transparent,
+            ),
+          ),
+        ),
+        home: StreamChannel(
+          channel: channel,
+          child: const ChannelPage(),
+        ),
+      );
+}
+
+class ChannelPage extends StatelessWidget {
+  const ChannelPage({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Stack(
+        children: <Widget>[
+          // Add your video implementation here
+          ShaderMask(
+            shaderCallback: (rect) {
+              return const LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [Colors.black, Colors.transparent],
+                  stops: [0.4, 0.8]).createShader(
+                Rect.fromLTRB(0, 0, rect.width, rect.height),
+              );
+            },
+            blendMode: BlendMode.dstIn,
+            child: Column(
+              children: const [
+                Expanded(
+                  child: MessageListView(),
+                ),
+                MessageInput(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 ```


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The docs for overlapping chat on a transparency background were broken because since the docs were published the MessageListViewTheme was introduced, in which the developers could set the background colour. Thew docs now account for the same.