### PR TITLE
feat(llc): Added a new field called push provider name in addDevice api call

### DIFF
--- a/docusaurus/docs/Flutter/guides/adding_push_notifications_v2.mdx
+++ b/docusaurus/docs/Flutter/guides/adding_push_notifications_v2.mdx
@@ -86,6 +86,14 @@ firebaseMessaging.onTokenRefresh.listen((token) {
 }); 
 ```
 
+Push Notifications v2 also supports specifying a name to the push tokens you register. By setting the optional `pushProviderName` param in the `addDevice` call you can support different configurations between and the device and the `PushProvider`.
+
+```dart
+firebaseMessaging.onTokenRefresh.listen((token) { 
+      client.addDevice(token, PushProvider.firebase, pushProviderName: 'my-custom-config'); 
+}); 
+```
+
 ### Receiving Notifications
 
 Push notifications behave a bit differently depending on whether you are using iOS or Android.

--- a/docusaurus/docs/Flutter/guides/adding_push_notifications_v2.mdx
+++ b/docusaurus/docs/Flutter/guides/adding_push_notifications_v2.mdx
@@ -86,7 +86,7 @@ firebaseMessaging.onTokenRefresh.listen((token) {
 }); 
 ```
 
-Push Notifications v2 also supports specifying a name to the push tokens you register. By setting the optional `pushProviderName` param in the `addDevice` call you can support different configurations between and the device and the `PushProvider`.
+Push Notifications v2 also supports specifying a name to the push device tokens you register. By setting the optional `pushProviderName` param in the `addDevice` call you can support different configurations between the device and the `PushProvider`.
 
 ```dart
 firebaseMessaging.onTokenRefresh.listen((token) { 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- Added `push_provider_name` to `addDevice` API call
+
 ## 3.6.1
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -818,8 +818,16 @@ class StreamChatClient {
       );
 
   /// Add a device for Push Notifications.
-  Future<EmptyResponse> addDevice(String id, PushProvider pushProvider) =>
-      _chatApi.device.addDevice(id, pushProvider);
+  Future<EmptyResponse> addDevice(
+    String id,
+    PushProvider pushProvider, {
+    String? pushProviderName,
+  }) =>
+      _chatApi.device.addDevice(
+        id,
+        pushProvider,
+        pushProviderName: pushProviderName,
+      );
 
   /// Gets a list of user devices.
   Future<ListDevicesResponse> getDevices() => _chatApi.device.getDevices();

--- a/packages/stream_chat/lib/src/core/api/device_api.dart
+++ b/packages/stream_chat/lib/src/core/api/device_api.dart
@@ -29,13 +29,16 @@ class DeviceApi {
   /// Add a device for Push Notifications.
   Future<EmptyResponse> addDevice(
     String deviceId,
-    PushProvider pushProvider,
-  ) async {
+    PushProvider pushProvider, {
+    String? pushProviderName,
+  }) async {
     final response = await _client.post(
       '/devices',
       data: {
         'id': deviceId,
         'push_provider': pushProvider.name,
+        if (pushProviderName != null && pushProviderName.isNotEmpty)
+          'push_provider_name': pushProviderName,
       },
     );
     return EmptyResponse.fromJson(response.data);

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1171,7 +1171,7 @@ void main() {
       verifyNoMoreInteractions(api.channel);
     });
 
-    test('`.addDevice`', () async {
+    test('`.addDevice should work`', () async {
       const id = 'test-device-id';
       const provider = PushProvider.firebase;
 
@@ -1182,6 +1182,34 @@ void main() {
       expect(res, isNotNull);
 
       verify(() => api.device.addDevice(id, provider)).called(1);
+      verifyNoMoreInteractions(api.device);
+    });
+
+    test('`.addDevice should work with pushProviderName`', () async {
+      const id = 'test-device-id';
+      const provider = PushProvider.firebase;
+      const pushProviderName = 'my-custom-config';
+
+      when(
+        () => api.device.addDevice(
+          id,
+          provider,
+          pushProviderName: pushProviderName,
+        ),
+      ).thenAnswer((_) async => EmptyResponse());
+
+      final res = await client.addDevice(
+        id,
+        provider,
+        pushProviderName: pushProviderName,
+      );
+      expect(res, isNotNull);
+
+      verify(() => api.device.addDevice(
+            id,
+            provider,
+            pushProviderName: pushProviderName,
+          )).called(1);
       verifyNoMoreInteractions(api.device);
     });
 

--- a/packages/stream_chat/test/src/core/api/device_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/device_api_test.dart
@@ -20,7 +20,7 @@ void main() {
     deviceApi = DeviceApi(client);
   });
 
-  test('addDevice', () async {
+  test('addDevice should work', () async {
     const deviceId = 'test-device-id';
     const pushProvider = PushProvider.firebase;
 
@@ -37,6 +37,36 @@ void main() {
             (_) async => successResponse(path, data: <String, dynamic>{}));
 
     final res = await deviceApi.addDevice(deviceId, pushProvider);
+
+    expect(res, isNotNull);
+
+    verify(() => client.post(path, data: any(named: 'data'))).called(1);
+    verifyNoMoreInteractions(client);
+  });
+
+  test('addDevice should work with pushProviderName', () async {
+    const deviceId = 'test-device-id';
+    const pushProvider = PushProvider.firebase;
+    const pushProviderName = 'my-custom-config';
+
+    const path = '/devices';
+
+    when(() => client.post(
+              path,
+              data: {
+                'id': deviceId,
+                'push_provider': pushProvider.name,
+                'push_provider_name': pushProviderName,
+              },
+            ))
+        .thenAnswer(
+            (_) async => successResponse(path, data: <String, dynamic>{}));
+
+    final res = await deviceApi.addDevice(
+      deviceId,
+      pushProvider,
+      pushProviderName: pushProviderName,
+    );
 
     expect(res, isNotNull);
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Push v2 supports adding a `push_provider_name` field to support creating different configurations for device and push provider.