### PR TITLE
Stream Chat Overrides (WIP)

### DIFF
--- a/packages/stream_chat_flutter/test/src/attachment_actions_modal_test.dart
+++ b/packages/stream_chat_flutter/test/src/attachment_actions_modal_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 import 'mocks.dart';
+import 'stream_chat_overrides.dart';
 
 class MockAttachmentDownloader extends Mock {
   ProgressCallback? progressCallback;
@@ -33,44 +34,41 @@ void main() {
   testWidgets(
     'it should show all the actions',
     (WidgetTester tester) async {
-      final client = MockClient();
-      final clientState = MockClientState();
 
-      when(() => client.state).thenReturn(clientState);
-      when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
-
-      final themeData = ThemeData();
-      final streamTheme = StreamChatThemeData.fromTheme(themeData);
-      final attachment = Attachment(
-        type: 'image',
-        title: 'text.jpg',
-      );
-      final message = Message(
-        text: 'test',
-        user: User(
-          id: 'user-id',
-        ),
-        attachments: [
-          attachment,
-        ],
-      );
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: themeData,
-          home: StreamChat(
-            streamChatThemeData: streamTheme,
-            client: client,
-            child: AttachmentActionsModal(
-              message: message,
-              attachment: attachment,
+      await StreamChatOverrides.runZoned(() async {
+        final themeData = ThemeData();
+        final streamTheme = StreamChatThemeData.fromTheme(themeData);
+        final attachment = Attachment(
+          type: 'image',
+          title: 'text.jpg',
+        );
+        final message = Message(
+          text: 'test',
+          user: User(
+            id: 'user-id',
+          ),
+          attachments: [
+            attachment,
+          ],
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: themeData,
+            home: StreamChat(
+              streamChatThemeData: streamTheme,
+              client: StreamChatOverrides.current!.client,
+              child: AttachmentActionsModal(
+                message: message,
+                attachment: attachment,
+              ),
             ),
           ),
-        ),
-      );
-      expect(find.text('Reply'), findsOneWidget);
-      expect(find.text('Show in Chat'), findsOneWidget);
-      expect(find.text('Save Image'), findsOneWidget);
-      expect(find.text('Delete'), findsOneWidget);
+        );
+        expect(find.text('Reply'), findsOneWidget);
+        expect(find.text('Show in Chat'), findsOneWidget);
+        expect(find.text('Save Image'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      });
     },
   );
 

--- a/packages/stream_chat_flutter/test/src/stream_chat_overrides.dart
+++ b/packages/stream_chat_flutter/test/src/stream_chat_overrides.dart
@@ -56,21 +56,3 @@ abstract class StreamChatOverrides {
     return _asyncRunZoned(body, zoneValues: {_token: overrides});
   }
 }
-
-// void main() {
-//   testWidgets('test name', (tester) async {
-//     StreamChatOverrides.runZoned(() async {
-//       // final themeData = ThemeData();
-//       // final streamTheme = StreamChatThemeData.fromTheme(themeData);
-//       await tester.pumpWidget(MaterialApp(
-//           home: StreamChat(
-//         client: StreamChatOverrides.current!.client,
-//         child: null,
-//       )));
-
-//       // final client = StreamChat(client: ,)
-//       // when(() => StreamChatOverrides.current!.clientState.currentUser)
-//       //     .thenReturn(OwnUser(id: 'user-id'));
-//     });
-//   });
-// }

--- a/packages/stream_chat_flutter/test/src/stream_chat_overrides.dart
+++ b/packages/stream_chat_flutter/test/src/stream_chat_overrides.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import 'mocks.dart';
+
+const _asyncRunZoned = runZoned;
+
+class _StreamChatOverridesScopes extends StreamChatOverrides {
+  _StreamChatOverridesScopes({
+    ClientState? clientState,
+    StreamChatClient? client,
+    Channel? channel,
+  })  : _clientState = clientState ?? MockClientState(),
+        _channel = channel ?? MockChannel(),
+        _client = client ?? MockClient();
+  final ClientState _clientState;
+  final StreamChatClient _client;
+  final Channel _channel;
+
+  @override
+  ClientState get clientState => _clientState;
+
+  @override
+  StreamChatClient get client => _client;
+
+  @override
+  Channel get channel => _channel;
+}
+
+abstract class StreamChatOverrides {
+  static final _token = Object();
+  static StreamChatOverrides? get current {
+    return Zone.current[_token] as StreamChatOverrides?;
+  }
+
+  ClientState get clientState;
+  StreamChatClient get client;
+
+  Channel get channel;
+  static R runZoned<R>(
+    R Function() body, {
+    ClientState Function()? clientState,
+    StreamChatClient Function()? client,
+    Channel Function()? channel,
+  }) {
+    final overrides = _StreamChatOverridesScopes(
+        clientState: clientState?.call(),
+        client: client?.call(),
+        channel: channel?.call());
+    when(() => overrides.client.state).thenReturn(overrides.clientState);
+    when(() => overrides.clientState.currentUser)
+        .thenReturn(OwnUser(id: 'user-id'));
+
+    return _asyncRunZoned(body, zoneValues: {_token: overrides});
+  }
+}
+
+// void main() {
+//   testWidgets('test name', (tester) async {
+//     StreamChatOverrides.runZoned(() async {
+//       // final themeData = ThemeData();
+//       // final streamTheme = StreamChatThemeData.fromTheme(themeData);
+//       await tester.pumpWidget(MaterialApp(
+//           home: StreamChat(
+//         client: StreamChatOverrides.current!.client,
+//         child: null,
+//       )));
+
+//       // final client = StreamChat(client: ,)
+//       // when(() => StreamChatOverrides.current!.clientState.currentUser)
+//       //     .thenReturn(OwnUser(id: 'user-id'));
+//     });
+//   });
+// }


### PR DESCRIPTION
Utility class for mocking Widgets that depend on StreamChatClient, Channel, or ClientState. Useful for cleaning up tests but also for the WidgetBook effort.

It comes with built-in mocked methods like `currentUser` and since it runs in a zone, those built-in mocked methods can also be overridden