### PR TITLE
chore(localization): improve german translations

### DIFF
--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -163,7 +163,7 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get allowGalleryAccessMessage => 'Zugang zu Ihrer Galerie gewähren';
 
   @override
-  String get flagMessageLabel => 'Markierte Nachricht';
+  String get flagMessageLabel => 'Nachricht melden';
 
   @override
   String get flagMessageQuestion =>
@@ -171,13 +171,13 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
       '\nModerator für weitere Untersuchungen senden?';
 
   @override
-  String get flagLabel => 'MARKIEREN';
+  String get flagLabel => 'MELDEN';
 
   @override
   String get cancelLabel => 'ABBRECHEN';
 
   @override
-  String get flagMessageSuccessfulLabel => 'Nachricht markiert';
+  String get flagMessageSuccessfulLabel => 'Nachricht gemeldet';
 
   @override
   String get flagMessageSuccessfulText =>
@@ -283,7 +283,7 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get streamChatLabel => 'Stream Chat';
 
   @override
-  String get searchingForNetworkText => 'Searching for Network';
+  String get searchingForNetworkText => 'Netzwerk wird gesucht';
 
   @override
   String get offlineLabel => 'Offline...';
@@ -380,5 +380,5 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
       'Sie sind nicht berechtigt Nachrichten zu senden';
 
   @override
-  String get viewLibrary => 'Bibliothek ansehen';
+  String get viewLibrary => 'Bibliothek öffnen';
 }


### PR DESCRIPTION

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
-  --> Not tested, as only minor translation changes

## Description of the pull request
For flagged messages the german word "markieren" only means "marked", while "melden" means "report", which is more suitable in this context.

For viewLibrary, it is better to say "öffnen" which means "open" -> as this is what happens when the user clicks this button in the app.