### PR TITLE
fix(ui): The URL enrichment logic does not allow path or query params in URL

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix commands resetting the `StreamMessageInputController.value`.
 - [[#996]](https://github.com/GetStream/stream-chat-flutter/issues/996) Videos break bottom photo
   carousal.
+- Fix: URLs with path and/or query params are not enriched.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/v4/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/v4/message_input/stream_message_input.dart
@@ -998,7 +998,10 @@ class StreamMessageInputState extends State<StreamMessageInput>
     _lastSearchedContainsUrlText = value;
 
     final matchedUrls = _urlRegex.allMatches(value).toList()
-      ..removeWhere((it) => it.group(0)?.split('.').last.isValidTLD() == false);
+      ..removeWhere((it) {
+        final _parsedMatch = Uri.tryParse(it.group(0) ?? '')?.withScheme;
+        return _parsedMatch?.host.split('.').last.isValidTLD() == false;
+      });
 
     // Reset the og attachment if the text doesn't contain any url
     if (matchedUrls.isEmpty ||


### PR DESCRIPTION
## Description of the pull request

The logic of finding URL matches and getting the URL to enrich the message and prepare an attachment did not allow the URLs that either had a path, eg. 'mywebsite.com/page' or query params 'google.com/search?term=flutter'.

Fixed that logic.