### PR TITLE
fix(llc): fix connecting while connecting and disconneting

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fix WebSocket contemporary connection calls while disconnecting
+
 ## 4.3.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -436,6 +436,11 @@ class WebSocket with TimerHelper {
   /// Disconnects the WS and releases eventual resources
   void disconnect() {
     if (connectionStatus == ConnectionStatus.disconnected) return;
+
+    if (connectionStatus == ConnectionStatus.connecting) {
+      _resetRequestFlags(resetAttempts: true);
+    }
+
     _connectionStatus = ConnectionStatus.disconnected;
 
     _logger?.info('Disconnecting web-socket connection');
@@ -447,6 +452,7 @@ class WebSocket with TimerHelper {
     _stopMonitoringEvents();
 
     _manuallyClosed = true;
+
     _closeWebSocketChannel();
   }
 }

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -437,9 +437,7 @@ class WebSocket with TimerHelper {
   void disconnect() {
     if (connectionStatus == ConnectionStatus.disconnected) return;
 
-    if (connectionStatus == ConnectionStatus.connecting) {
-      _resetRequestFlags(resetAttempts: true);
-    }
+    _resetRequestFlags(resetAttempts: true);
 
     _connectionStatus = ConnectionStatus.disconnected;
 

--- a/packages/stream_chat/test/src/ws/websocket_test.dart
+++ b/packages/stream_chat/test/src/ws/websocket_test.dart
@@ -138,7 +138,7 @@ void main() {
     );
     const connectionId = 'test-connection-id';
     // Sends connect event to web-socket stream
-    final timer = Timer(const Duration(milliseconds: 300), () {
+    final timer = Timer.periodic(const Duration(milliseconds: 300), (_) {
       final event = Event(
         type: EventType.healthCheck,
         connectionId: connectionId,
@@ -147,15 +147,15 @@ void main() {
       webSocketSink.add(json.encode(event));
     });
 
-    final event = await webSocket.connect(
+    await webSocket.connect(
       user,
     );
 
     webSocket
       ..disconnect()
       ..connect(user)
-      ..disconnect()
-      ..connect(user);
+      ..disconnect();
+    final event = await webSocket.connect(user);
 
     expect(event.type, EventType.healthCheck);
     expect(event.connectionId, connectionId);

--- a/packages/stream_chat/test/src/ws/websocket_test.dart
+++ b/packages/stream_chat/test/src/ws/websocket_test.dart
@@ -131,6 +131,40 @@ void main() {
     addTearDown(timer.cancel);
   });
 
+  test('`connect`, `disconnect` and `connect` again without waiting', () async {
+    final user = OwnUser(
+      id: 'test-user',
+      name: 'test',
+    );
+    const connectionId = 'test-connection-id';
+    // Sends connect event to web-socket stream
+    final timer = Timer(const Duration(milliseconds: 300), () {
+      final event = Event(
+        type: EventType.healthCheck,
+        connectionId: connectionId,
+        me: user,
+      );
+      webSocketSink.add(json.encode(event));
+    });
+
+    final event = await webSocket.connect(
+      user,
+    );
+
+    webSocket
+      ..disconnect()
+      ..connect(user)
+      ..disconnect()
+      ..connect(user);
+
+    expect(event.type, EventType.healthCheck);
+    expect(event.connectionId, connectionId);
+    expect(event.me, isNotNull);
+    expect(event.me!.id, user.id);
+
+    addTearDown(timer.cancel);
+  });
+
   test('`connect` should throw if already in connection attempt', () async {
     final user = OwnUser(id: 'test-user');
     webSocket.connect(user);


### PR DESCRIPTION
1. Send a connectUser request.
2. During the request disconnect the user and send a connectUser.

This fails currently and the websocket completely stops working 
It might fix #1086 