### PR TITLE
feat(llc): add support for AttachmentFileUploaderProvider.

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Fix WebSocket contemporary connection calls while disconnecting
 
+✅ Added
+
+- Export `StreamAttachmentFileUploader`.
+
+🔄 Changed
+
+- Deprecated `StreamChatClient.attachmentFileUploader`,
+  Use `StreamChatClient.attachmentFileUploaderProvider` instead.
+
 ## 4.3.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:collection/collection.dart'
     show IterableExtension, ListEquality;
-import 'package:dio/dio.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/client/retry_queue.dart';
 import 'package:stream_chat/src/core/util/utils.dart';

--- a/packages/stream_chat/lib/src/core/api/attachment_file_uploader.dart
+++ b/packages/stream_chat/lib/src/core/api/attachment_file_uploader.dart
@@ -3,6 +3,11 @@ import 'package:stream_chat/src/core/api/responses.dart';
 import 'package:stream_chat/src/core/http/stream_http_client.dart';
 import 'package:stream_chat/src/core/models/attachment_file.dart';
 
+/// Signature for a function which provides instance of [AttachmentFileUploader]
+typedef AttachmentFileUploaderProvider = AttachmentFileUploader Function(
+  StreamHttpClient httpClient,
+);
+
 /// Class responsible for uploading images and files to a given channel
 abstract class AttachmentFileUploader {
   /// Uploads a [image] to the given channel.

--- a/packages/stream_chat/lib/src/core/api/stream_chat_api.dart
+++ b/packages/stream_chat/lib/src/core/api/stream_chat_api.dart
@@ -22,9 +22,10 @@ class StreamChatApi {
     StreamHttpClientOptions? options,
     TokenManager? tokenManager,
     ConnectionIdManager? connectionIdManager,
-    AttachmentFileUploader? attachmentFileUploader,
+    AttachmentFileUploaderProvider? attachmentFileUploaderProvider,
     Logger? logger,
-  })  : _fileUploader = attachmentFileUploader,
+  })  : _fileUploaderProvider =
+            attachmentFileUploaderProvider ?? StreamAttachmentFileUploader.new,
         _client = client ??
             StreamHttpClient(
               apiKey,
@@ -35,6 +36,7 @@ class StreamChatApi {
             );
 
   final StreamHttpClient _client;
+  final AttachmentFileUploaderProvider _fileUploaderProvider;
 
   UserApi? _user;
 
@@ -75,5 +77,5 @@ class StreamChatApi {
 
   /// Class responsible for uploading images and files to a given channel
   AttachmentFileUploader get fileUploader =>
-      _fileUploader ??= StreamAttachmentFileUploader(_client);
+      _fileUploader ??= _fileUploaderProvider.call(_client);
 }

--- a/packages/stream_chat/lib/stream_chat.dart
+++ b/packages/stream_chat/lib/stream_chat.dart
@@ -1,6 +1,7 @@
 library stream_chat;
 
 export 'package:async/async.dart';
+export 'package:dio/src/cancel_token.dart';
 export 'package:dio/src/dio_error.dart';
 export 'package:dio/src/multipart_file.dart';
 export 'package:dio/src/options.dart';
@@ -9,8 +10,7 @@ export 'package:logging/logging.dart' show Logger, Level, LogRecord;
 export 'package:rate_limiter/rate_limiter.dart';
 export 'package:uuid/uuid.dart';
 
-export './src/core/api/attachment_file_uploader.dart'
-    show AttachmentFileUploader;
+export './src/core/api/attachment_file_uploader.dart';
 export './src/core/api/requests.dart';
 export './src/core/api/requests.dart';
 export './src/core/api/responses.dart';
@@ -44,7 +44,7 @@ export 'src/core/api/attachment_file_uploader.dart' show AttachmentFileUploader;
 export 'src/core/api/requests.dart';
 export 'src/core/api/requests.dart';
 export 'src/core/api/responses.dart';
-export 'src/core/api/stream_chat_api.dart' show PushProvider;
+export 'src/core/api/stream_chat_api.dart';
 export 'src/core/error/error.dart';
 export 'src/core/models/action.dart';
 export 'src/core/models/attachment.dart';

--- a/packages/stream_chat/test/src/fakes.dart
+++ b/packages/stream_chat/test/src/fakes.dart
@@ -8,7 +8,6 @@ import 'package:stream_chat/src/core/api/general_api.dart';
 import 'package:stream_chat/src/core/api/guest_api.dart';
 import 'package:stream_chat/src/core/api/message_api.dart';
 import 'package:stream_chat/src/core/api/moderation_api.dart';
-import 'package:stream_chat/src/core/api/stream_chat_api.dart';
 import 'package:stream_chat/src/core/api/user_api.dart';
 import 'package:stream_chat/src/core/http/token.dart';
 import 'package:stream_chat/src/core/http/token_manager.dart';


### PR DESCRIPTION
This PR was created to handle these kinds of use-cases.
https://github.com/GetStream/stream-chat-flutter/pull/1225

Solution
```dart
class MyCustomUploader extends StreamAttachmentFileUploader {
  const MyCustomUploader(super.client);

  @override
  Future<SendImageResponse> sendImage(
    AttachmentFile file,
    String channelId,
    String channelType, {
    ProgressCallback? onSendProgress,
    CancelToken? cancelToken,
    Map<String, Object?>? extraData,
  }) async {
    // ImageCompressor could be any library which supports image compression.
    final compressedImage = await ImageCompressor.compress(file);
    return super.sendImage(
      compressedImage,
      channelId,
      channelType,
      onSendProgress: onSendProgress,
      cancelToken: cancelToken,
      extraData: extraData,
    );
  }
}
```

```dart
/// Create a new instance of [StreamChatClient] passing the apikey obtained
/// from your project dashboard.
final client = StreamChatClient(
  apiKey,
  logLevel: Level.INFO,

  // Pass the instance of your newly created uploader.
  attachmentFileUploaderProvider: (httpClient){
    return MyCustomUploader(httpClient);
  },
);
```