### PR TITLE
feat(ui): sendingIndicatorBuilder

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UPCOMING
+
+✅ Added
+
+- Added `sendingIndicatorBuilder` to customize sending indicator in `StreamMessageWidget`.
+
 ## 5.0.1
 
 🔄 Changed

--- a/packages/stream_chat_flutter/lib/src/message_widget/bottom_row.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/bottom_row.dart
@@ -29,6 +29,7 @@ class BottomRow extends StatelessWidget {
     required this.streamChatTheme,
     required this.hasNonUrlAttachments,
     required this.streamChat,
+    this.sendingIndicatorBuilder,
     this.deletedBottomRowBuilder,
     this.onThreadTap,
     this.usernameBuilder,
@@ -39,6 +40,9 @@ class BottomRow extends StatelessWidget {
 
   /// {@macro deletedBottomRowBuilder}
   final Widget Function(BuildContext, Message)? deletedBottomRowBuilder;
+
+  /// {@macro sendingIndicatorBuilder}
+  final Widget Function(BuildContext, Message)? sendingIndicatorBuilder;
 
   /// {@macro message}
   final Message message;
@@ -147,13 +151,14 @@ class BottomRow extends StatelessWidget {
         ),
       if (showSendingIndicator)
         WidgetSpan(
-          child: SendingIndicatorWrapper(
-            messageTheme: messageTheme,
-            message: message,
-            hasNonUrlAttachments: hasNonUrlAttachments,
-            streamChat: streamChat,
-            streamChatTheme: streamChatTheme,
-          ),
+          child: sendingIndicatorBuilder?.call(context, message) ??
+              SendingIndicatorWrapper(
+                messageTheme: messageTheme,
+                message: message,
+                hasNonUrlAttachments: hasNonUrlAttachments,
+                streamChat: streamChat,
+                streamChatTheme: streamChatTheme,
+              ),
         ),
     ]);
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -92,6 +92,7 @@ class StreamMessageWidget extends StatefulWidget {
     this.customActions = const [],
     this.onAttachmentTap,
     this.usernameBuilder,
+    this.sendingIndicatorBuilder,
     this.imageAttachmentThumbnailSize = const Size(400, 400),
     this.imageAttachmentThumbnailResizeType = 'clip',
     this.imageAttachmentThumbnailCropType = 'center',
@@ -296,6 +297,11 @@ class StreamMessageWidget extends StatefulWidget {
   /// Widget builder for building username
   /// {@endtemplate}
   final Widget Function(BuildContext, Message)? usernameBuilder;
+
+  /// {@template sendingIndicatorBuilder}
+  /// Widget builder for building sending indicator
+  /// {@endtemplate}
+  final Widget Function(BuildContext, Message)? sendingIndicatorBuilder;
 
   /// {@template onMessageActions}
   /// Function called on long press
@@ -532,6 +538,7 @@ class StreamMessageWidget extends StatefulWidget {
     Widget Function(BuildContext, Message)? editMessageInputBuilder,
     Widget Function(BuildContext, Message)? textBuilder,
     Widget Function(BuildContext, Message)? usernameBuilder,
+    Widget Function(BuildContext, Message)? sendingIndicatorBuilder,
     Widget Function(BuildContext, Message)? bottomRowBuilder,
     Widget Function(BuildContext, Message)? deletedBottomRowBuilder,
     void Function(BuildContext, Message)? onMessageActions,
@@ -589,6 +596,8 @@ class StreamMessageWidget extends StatefulWidget {
           editMessageInputBuilder ?? this.editMessageInputBuilder,
       textBuilder: textBuilder ?? this.textBuilder,
       usernameBuilder: usernameBuilder ?? this.usernameBuilder,
+      sendingIndicatorBuilder:
+          sendingIndicatorBuilder ?? this.sendingIndicatorBuilder,
       bottomRowBuilder: bottomRowBuilder ?? this.bottomRowBuilder,
       deletedBottomRowBuilder:
           deletedBottomRowBuilder ?? this.deletedBottomRowBuilder,
@@ -875,6 +884,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                     onUserAvatarTap: widget.onUserAvatarTap,
                     userAvatarBuilder: widget.userAvatarBuilder,
                     usernameBuilder: widget.usernameBuilder,
+                    sendingIndicatorBuilder: widget.sendingIndicatorBuilder,
                   ),
                 ),
               ),

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
@@ -56,6 +56,7 @@ class MessageWidgetContent extends StatelessWidget {
     this.deletedBottomRowBuilder,
     this.userAvatarBuilder,
     this.usernameBuilder,
+    this.sendingIndicatorBuilder,
   });
 
   /// {@macro reverse}
@@ -154,6 +155,9 @@ class MessageWidgetContent extends StatelessWidget {
   /// {@macro bottomRowBuilder}
   final Widget Function(BuildContext, Message)? bottomRowBuilder;
 
+  /// {@macro sendingIndicatorBuilder}
+  final Widget Function(BuildContext, Message)? sendingIndicatorBuilder;
+
   /// {@macro showInChannelIndicator}
   final bool showInChannel;
 
@@ -230,6 +234,7 @@ class MessageWidgetContent extends StatelessWidget {
                       streamChat: streamChat,
                       hasNonUrlAttachments: hasNonUrlAttachments,
                       usernameBuilder: usernameBuilder,
+                      sendingIndicatorBuilder: sendingIndicatorBuilder,
                     ),
               ),
             Padding(


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Similar to `usernameBuilder` and others it allows customizing sending indicator in `BottomRow` without touching the whole `BottomRow` of the message