### PR TITLE
fix(ui): cached attachment image not showing on web

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcomming
+
+🐞 Fixed
+- [[#1379]](https://github.com/GetStream/stream-chat-flutter/issues/1379) Fixed "Issues with photo attachments on web", where the cached image attachment would not render while uploading.
+
 ## 5.1.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
@@ -56,22 +56,33 @@ class StreamImageAttachment extends StreamAttachmentWidget {
   Widget build(BuildContext context) {
     return source.when(
       local: () {
-        if (attachment.localUri == null || attachment.file?.bytes == null) {
-          return AttachmentError(constraints: constraints);
-        }
-        return _buildImageAttachment(
-          context,
-          Image.memory(
-            attachment.file!.bytes!,
-            height: constraints?.maxHeight,
-            width: constraints?.maxWidth,
-            fit: BoxFit.cover,
-            errorBuilder: (context, _, __) => Image.asset(
-              'images/placeholder.png',
-              package: 'stream_chat_flutter',
+        if (attachment.file?.bytes != null) {
+          return _buildImageAttachment(
+            context,
+            Image.memory(
+              attachment.file!.bytes!,
+              height: constraints?.maxHeight,
+              width: constraints?.maxWidth,
+              fit: BoxFit.cover,
+              errorBuilder: _imageErrorBuilder,
             ),
-          ),
-        );
+          );
+        } else if (attachment.localUri != null) {
+          return _buildImageAttachment(
+            context,
+            Image.asset(
+              attachment.localUri!.path,
+              height: constraints?.maxHeight,
+              width: constraints?.maxWidth,
+              fit: BoxFit.cover,
+              errorBuilder: _imageErrorBuilder,
+            ),
+          );
+        } else {
+          return AttachmentError(
+            constraints: constraints,
+          );
+        }
       },
       network: () {
         var imageUrl =
@@ -115,6 +126,12 @@ class StreamImageAttachment extends StreamAttachmentWidget {
       },
     );
   }
+
+  Widget _imageErrorBuilder(BuildContext _, Object __, StackTrace? ___) =>
+      Image.asset(
+        'images/placeholder.png',
+        package: 'stream_chat_flutter',
+      );
 
   Widget _buildImageAttachment(BuildContext context, Widget imageWidget) {
     return Container(

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,8 +1,3 @@
-## Upcomming
-
-🐞 Fixed
-- [[#1379]](https://github.com/GetStream/stream-chat-flutter/issues/1379) Fixed "Issues with photo attachments on web", where the cached image attachment would not render while uploading.
-- 
 ## 5.1.0
 
 - Deprecated the `sort` parameter in the `StreamChannelListController` in favor of `channelStateSort`.

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcomming
+
+🐞 Fixed
+- [[#1379]](https://github.com/GetStream/stream-chat-flutter/issues/1379) Fixed "Issues with photo attachments on web", where the cached image attachment would not render while uploading.
+- 
 ## 5.1.0
 
 - Deprecated the `sort` parameter in the `StreamChannelListController` in favor of `channelStateSort`.


### PR DESCRIPTION
Fixes https://github.com/GetStream/stream-chat-flutter/issues/1379