### PR TITLE
fix(ui): render overflow in message search title

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcomming
+
+🐞 Fixed
+- Fix render overflow issue with `MessageSearchListTileTitle`. It now uses `Text.rich` instead of `Row`. Better default behaviour and allows `TextOverflow`.
 ## 5.1.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_tile.dart
@@ -122,7 +122,8 @@ class StreamMessageSearchListTile extends StatelessWidget {
     final title = this.title ??
         MessageSearchListTileTitle(
           messageResponse: messageResponse,
-          textStyle: channelPreviewTheme.titleStyle,
+          textStyle: channelPreviewTheme.titleStyle
+              ?.copyWith(overflow: TextOverflow.ellipsis),
         );
 
     final subtitle = this.subtitle ??
@@ -177,27 +178,28 @@ class MessageSearchListTileTitle extends StatelessWidget {
     final channel = messageResponse.channel;
     final channelName = channel?.extraData['name'];
 
-    return Row(
-      children: [
-        Text(
-          user.id == StreamChat.of(context).currentUser?.id
-              ? context.translations.youText
-              : user.name,
-          style: textStyle,
-        ),
-        if (channelName != null) ...[
-          Text(
-            ' ${context.translations.inText} ',
-            style: textStyle?.copyWith(
-              fontWeight: FontWeight.normal,
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: user.id == StreamChat.of(context).currentUser?.id
+                ? context.translations.youText
+                : user.name,
+          ),
+          if (channelName != null) ...[
+            TextSpan(
+              text: ' ${context.translations.inText} ',
+              style: textStyle?.copyWith(
+                fontWeight: FontWeight.normal,
+              ),
             ),
-          ),
-          Text(
-            channelName as String,
-            style: textStyle,
-          ),
+            TextSpan(
+              text: channelName as String,
+            ),
+          ],
         ],
-      ],
+      ),
+      style: textStyle,
     );
   }
 }


### PR DESCRIPTION
This PR fixes:
![Screenshot 2022-11-17 at 16 39 25](https://user-images.githubusercontent.com/13705472/202499673-6c54c96f-06aa-4afa-9eeb-3fab070579fc.png)
And allows the TextStyle to also have a text overflow.

Before merging, we need to choose a default behavior. 

Plain:
![Screenshot 2022-11-17 at 16 40 25](https://user-images.githubusercontent.com/13705472/202499768-022bfffe-5308-4498-9326-d9b9c3945c34.png)

TextOverlow:
![Screenshot 2022-11-17 at 16 41 16](https://user-images.githubusercontent.com/13705472/202499780-0ea14987-d99e-446d-b18e-b518f76872b9.png)
