### PR TITLE
fix(llc): initializing last synced data

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcomming
+
+🐞 Fixed
+- Fixed initializing last synced date.
+
 ## 5.1.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -453,6 +453,15 @@ class StreamChatClient {
         if (persistenceEnabled) {
           await sync(cids: cids, lastSyncAt: _lastSyncedAt);
         }
+      } else {
+        // channels are empty, assuming it's a fresh start
+        // and making sure `lastSyncAt` is initialized
+        if (persistenceEnabled) {
+          final lastSyncAt = await _chatPersistenceClient?.getLastSyncAt();
+          if (lastSyncAt == null) {
+            await _chatPersistenceClient?.updateLastSyncAt(DateTime.now());
+          }
+        }
       }
       handleEvent(Event(
         type: EventType.connectionRecovered,

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -535,7 +535,8 @@ void main() {
       test(
         '''should update persistence connectionInfo and lastSync when sync succeeds''',
         () async {
-          // persistence.updateLastSyncAt might be called when connecting the user.
+          // persistence.updateLastSyncAt might be called
+          // when connecting the user.
           // Resetting the logs so we start counting invocations correctly.
           reset(persistence);
           const cids = ['test-cid-1', 'test-cid-2', 'test-cid-3'];
@@ -572,7 +573,8 @@ void main() {
       test(
         'should work fine if persistence contains sync params',
         () async {
-          // persistence.updateLastSyncAt might be called when connecting the user.
+          // persistence.updateLastSyncAt might be called
+          // when connecting the user.
           // Resetting the logs so we start counting invocations correctly.
           reset(persistence);
           const cids = ['test-cid-1', 'test-cid-2', 'test-cid-3'];

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -516,6 +516,9 @@ void main() {
     });
 
     setUp(() async {
+      when(() => persistence.updateLastSyncAt(any()))
+          .thenAnswer((_) => Future.value());
+      when(persistence.getLastSyncAt).thenAnswer((_) async => null);
       client = StreamChatClient(apiKey, chatApi: api, ws: ws)
         ..chatPersistenceClient = persistence;
       await client.connectUser(user, token);
@@ -532,9 +535,11 @@ void main() {
       test(
         '''should update persistence connectionInfo and lastSync when sync succeeds''',
         () async {
+          // persistence.updateLastSyncAt might be called when connecting the user.
+          // Resetting the logs so we start counting invocations correctly.
+          reset(persistence);
           const cids = ['test-cid-1', 'test-cid-2', 'test-cid-3'];
           final lastSyncAt = DateTime.now();
-
           when(() => api.general.sync(cids, lastSyncAt))
               .thenAnswer((_) async => SyncResponse()
                 ..events = [
@@ -567,6 +572,9 @@ void main() {
       test(
         'should work fine if persistence contains sync params',
         () async {
+          // persistence.updateLastSyncAt might be called when connecting the user.
+          // Resetting the logs so we start counting invocations correctly.
+          reset(persistence);
           const cids = ['test-cid-1', 'test-cid-2', 'test-cid-3'];
           final lastSyncAt = DateTime.now();
 


### PR DESCRIPTION
## Description of the pull request
Fixed initializing `lastSyncedDate`. It fixes the problem with missing messages inside the thread when bringing app to the foreground.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/17440581/208107800-3ee74502-f332-41e0-8ad7-55cfa8eda09a.mp4
" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/17440581/208107788-887a5a27-41c6-4028-9626-3475bd170414.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

