### PR TITLE
fix: Trim whitespaces of a message before rendering it

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+🐞 Fixed
+- [[#1424]](https://github.com/GetStream/stream-chat-flutter/issues/1424) Fixed a render issue when showing messages starting with 4 whitespaces.
+
 ## 5.2.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_text.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_text.dart
@@ -40,7 +40,8 @@ class StreamMessageText extends StatelessWidget {
             .translate(language)
             .replaceMentions()
             .text
-            ?.replaceAll('\n', '\n\n');
+            ?.replaceAll('\n', '\n\n')
+            .trim();
         final themeData = Theme.of(context);
         return MarkdownBody(
           data: messageText ?? '',


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

By some reason the `MarkdownBody` widget is rendering "4+ whitespace" at the beginning of the message as a "code block" style. To fix it we are trimming the message before rendering it.

| Before | After |
| --- | --- |
| ![Screenshot from 2023-01-04 09-27-27](https://user-images.githubusercontent.com/4047514/210513971-70ec2b20-3021-430f-bcf4-da0b58d1b1e6.png)  | ![Screenshot from 2023-01-04 09-27-05](https://user-images.githubusercontent.com/4047514/210514029-b43a959c-6ffe-4d05-a996-2b53aed33d56.png) |

Fix #1424 