### PR TITLE
chore(ui): update photo_manager dependency

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+🔄 Changed
+
+- Updated `photo_manager` dependency to `^2.5.2`
+
 🐞 Fixed
 - [[#1424]](https://github.com/GetStream/stream-chat-flutter/issues/1424) Fixed a render issue when showing messages starting with 4 whitespaces.
 - Fixed a bug where the `AttachmentPickerBottomSheet` was not able to identify the mobile browser.

--- a/packages/stream_chat_flutter/README.md
+++ b/packages/stream_chat_flutter/README.md
@@ -48,6 +48,7 @@ You should then run `flutter packages get`
 
 The package uses [photo_manager](https://pub.dev/packages/photo_manager) to access the device's photo library.
 Follow [this wiki](https://pub.dev/packages/photo_manager#android-10-q-29) to fulfil the Android requirements.
+You need to take additional steps if you are targeting Android 13. Read [this section](https://pub.dev/packages/photo_manager#android-13-api-33-extra-configs) for more information.
 
 ### iOS
 

--- a/packages/stream_chat_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/stream_chat_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <application
         android:name=".Application"
         android:icon="@mipmap/ic_launcher"

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   lottie: ^2.0.0
   meta: ^1.3.0
   path_provider: ^2.0.9
-  photo_manager: ^2.0.1
+  photo_manager: ^2.5.2
   photo_view: ^0.14.0
   rxdart: ^0.27.0
   share_plus: ^4.5.0


### PR DESCRIPTION
#1431 

Updated `photo_manager` dependency in order to support Android 13.