### PR TITLE
fix(ui): temp file path on Windows

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 🐞 Fixed
 - [[#1424]](https://github.com/GetStream/stream-chat-flutter/issues/1424) Fixed a render issue when showing messages starting with 4 whitespaces.
 - Fixed a bug where the `AttachmentPickerBottomSheet` was not able to identify the mobile browser.
+- Fixed uploading files on Windows - fixed temp file path.
 
 ## 5.2.0
 

--- a/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler_io.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler_io.dart
@@ -123,10 +123,9 @@ class StreamAttachmentHandler extends StreamAttachmentHandlerBase {
 
     final tempDir = await getTemporaryDirectory();
     final tempPath = Uri.file(tempDir.path, windows: CurrentPlatform.isWindows);
-    var tempFilePath = tempPath.resolve(fileName!).path;
-    if (CurrentPlatform.isWindows && tempFilePath.startsWith('/')) {
-      tempFilePath = tempFilePath.substring(1);
-    }
+    final tempFilePath = tempPath
+        .resolve(fileName!)
+        .toFilePath(windows: CurrentPlatform.isWindows);
     print(tempFilePath);
 
     final attachmentFileBytes = attachmentFile.bytes;

--- a/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler_io.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler_io.dart
@@ -123,7 +123,10 @@ class StreamAttachmentHandler extends StreamAttachmentHandlerBase {
 
     final tempDir = await getTemporaryDirectory();
     final tempPath = Uri.file(tempDir.path, windows: CurrentPlatform.isWindows);
-    final tempFilePath = tempPath.resolve(fileName!).path;
+    var tempFilePath = tempPath.resolve(fileName!).path;
+    if (CurrentPlatform.isWindows && tempFilePath.startsWith('/')) {
+      tempFilePath = tempFilePath.substring(1);
+    }
     print(tempFilePath);
 
     final attachmentFileBytes = attachmentFile.bytes;


### PR DESCRIPTION
Fixed temp file path on Windows. For some reason, the `tempFilePath ` contains an extra `/` at the start. Make sure it gets removed before the file is created.