### PR TITLE
feat(localization): Changing new messages separator text - ISSUE-1435

### DIFF
--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -81,7 +81,10 @@ abstract class Translations {
 
   /// The text for showing the unread messages count
   /// in the [StreamMessageListView]
-  String unreadMessagesSeparatorText();
+  String unreadMessagesSeparatorText(
+    @Deprecated('unreadCount is not used anymore and will be removed ')
+        int unreadCount,
+  );
 
   /// The label for "connected" in [StreamConnectionStatusBuilder]
   String get connectedLabel;
@@ -797,7 +800,7 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
   String get linkDisabledError => 'Links are disabled';
 
   @override
-  String unreadMessagesSeparatorText() => 'New messages';
+  String unreadMessagesSeparatorText(int unreadCount) => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Please enable access to files'

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -81,7 +81,7 @@ abstract class Translations {
 
   /// The text for showing the unread messages count
   /// in the [StreamMessageListView]
-  String unreadMessagesSeparatorText(int unreadCount);
+  String unreadMessagesSeparatorText();
 
   /// The label for "connected" in [StreamConnectionStatusBuilder]
   String get connectedLabel;
@@ -797,12 +797,7 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
   String get linkDisabledError => 'Links are disabled';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 unread message';
-    }
-    return '$unreadCount unread messages';
-  }
+  String unreadMessagesSeparatorText() => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Please enable access to files'

--- a/packages/stream_chat_flutter/lib/src/message_list_view/unread_messages_separator.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/unread_messages_separator.dart
@@ -24,7 +24,7 @@ class UnreadMessagesSeparator extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(8),
           child: Text(
-            context.translations.unreadMessagesSeparatorText(),
+            context.translations.unreadMessagesSeparatorText(unreadCount),
             textAlign: TextAlign.center,
             style: StreamChannelHeaderTheme.of(context).subtitleStyle,
           ),

--- a/packages/stream_chat_flutter/lib/src/message_list_view/unread_messages_separator.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/unread_messages_separator.dart
@@ -24,9 +24,7 @@ class UnreadMessagesSeparator extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(8),
           child: Text(
-            context.translations.unreadMessagesSeparatorText(
-              unreadCount,
-            ),
+            context.translations.unreadMessagesSeparatorText(),
             textAlign: TextAlign.center,
             style: StreamChannelHeaderTheme.of(context).subtitleStyle,
           ),

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for [Catalan](https://github.com/GetStream/stream-chat-flutter/blob/master/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart) locale.
 * Added translations for new `noPhotoOrVideoLabel` label.
+* Changed text in New messages separator. Now is doesn't count the new messages and only shows "New messages". All the translations were updated.
 
 🔄 Changed
 

--- a/packages/stream_chat_localizations/example/lib/add_new_lang.dart
+++ b/packages/stream_chat_localizations/example/lib/add_new_lang.dart
@@ -459,7 +459,7 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'View library';
 
   @override
-  String unreadMessagesSeparatorText() => 'New messages';
+  String unreadMessagesSeparatorText(int unreadCount) => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Enable file access to continue';

--- a/packages/stream_chat_localizations/example/lib/add_new_lang.dart
+++ b/packages/stream_chat_localizations/example/lib/add_new_lang.dart
@@ -459,12 +459,7 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'View library';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 unread message';
-    }
-    return '$unreadCount unread messages';
-  }
+  String unreadMessagesSeparatorText() => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Enable file access to continue';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
@@ -438,7 +438,7 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'Els enllaços estan deshabilitats';
 
   @override
-  String unreadMessagesSeparatorText() => 'Missatges nous';
+  String unreadMessagesSeparatorText(int unreadCount) => 'Missatges nous';
 
   @override
   String get enableFileAccessMessage => "Habilita l'accés als fitxers"

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
@@ -438,12 +438,7 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'Els enllaços estan deshabilitats';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 missatge no llegit';
-    }
-    return '$unreadCount missatges no llegits';
-  }
+  String unreadMessagesSeparatorText() => 'Missatges nous';
 
   @override
   String get enableFileAccessMessage => "Habilita l'accés als fitxers"

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -431,7 +431,7 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'Bibliothek öffnen';
 
   @override
-  String unreadMessagesSeparatorText() => 'Neue Nachrichten';
+  String unreadMessagesSeparatorText(int unreadCount) => 'Neue Nachrichten';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -15,7 +15,7 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get noUsersLabel => 'Derzeit gibt es keine User';
 
   @override
-  String get noPhotoOrVideoLabel => 'Es gibt keine Foto oder Video';
+  String get noPhotoOrVideoLabel => 'Es gibt kein Foto oder Video';
 
   @override
   String get retryLabel => 'Erneut versuchen';
@@ -431,12 +431,7 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'Bibliothek öffnen';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 ungelesene Nachricht';
-    }
-    return '$unreadCount ungelesene Nachrichten';
-  }
+  String unreadMessagesSeparatorText() => 'Neue Nachrichten';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -435,12 +435,7 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'View library';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 unread message';
-    }
-    return '$unreadCount unread messages';
-  }
+  String unreadMessagesSeparatorText() => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Please enable access to files'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -435,7 +435,7 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'View library';
 
   @override
-  String unreadMessagesSeparatorText() => 'New messages';
+  String unreadMessagesSeparatorText(int unreadCount) => 'New messages';
 
   @override
   String get enableFileAccessMessage => 'Please enable access to files'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
@@ -440,12 +440,7 @@ No es posible añadir más de $limit archivos adjuntos
   String get linkDisabledError => 'Los enlaces están deshabilitados';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 mensaje no leído';
-    }
-    return '$unreadCount mensajes no leídos';
-  }
+  String unreadMessagesSeparatorText() => 'Nuevos mensajes';
 
   @override
   String get enableFileAccessMessage => 'Habilite el acceso a los archivos'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
@@ -440,7 +440,7 @@ No es posible añadir más de $limit archivos adjuntos
   String get linkDisabledError => 'Los enlaces están deshabilitados';
 
   @override
-  String unreadMessagesSeparatorText() => 'Nuevos mensajes';
+  String unreadMessagesSeparatorText(int unreadCount) => 'Nuevos mensajes';
 
   @override
   String get enableFileAccessMessage => 'Habilite el acceso a los archivos'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -439,12 +439,7 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
   String get linkDisabledError => 'Les liens sont désactivés';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 message non lu';
-    }
-    return '$unreadCount messages non lus';
-  }
+  String unreadMessagesSeparatorText() => "Nouveaux messages";
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -439,7 +439,7 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
   String get linkDisabledError => 'Les liens sont désactivés';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) => "Nouveaux messages";
+  String unreadMessagesSeparatorText(int unreadCount) => 'Nouveaux messages';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -439,7 +439,7 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
   String get linkDisabledError => 'Les liens sont désactivés';
 
   @override
-  String unreadMessagesSeparatorText() => "Nouveaux messages";
+  String unreadMessagesSeparatorText(int unreadCount) => "Nouveaux messages";
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -433,7 +433,7 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'लिंक भेजना प्रतिबंधित';
 
   @override
-  String unreadMessagesSeparatorText() => 'नए संदेश।';
+  String unreadMessagesSeparatorText(int unreadCount) => 'नए संदेश।';
 
   @override
   String get enableFileAccessMessage => 'कृपया फ़ाइलों तक पहुंच सक्षम करें ताकि'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -433,12 +433,7 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'लिंक भेजना प्रतिबंधित';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 अपठित संदेश';
-    }
-    return '$unreadCount अपठित संदेश';
-  }
+  String unreadMessagesSeparatorText() => 'नए संदेश।';
 
   @override
   String get enableFileAccessMessage => 'कृपया फ़ाइलों तक पहुंच सक्षम करें ताकि'

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -442,12 +442,7 @@ Attenzione: il limite massimo di $limit file è stato superato.
   String get linkDisabledError => 'I links sono disattivati';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 messaggio non letto';
-    }
-    return '$unreadCount messaggi non letti';
-  }
+  String unreadMessagesSeparatorText() => "Nouveaux messages";
 
   @override
   String get enableFileAccessMessage => "Per favore attiva l'accesso ai file"

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -442,7 +442,7 @@ Attenzione: il limite massimo di $limit file è stato superato.
   String get linkDisabledError => 'I links sono disattivati';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) => "Nouveaux messages";
+  String unreadMessagesSeparatorText(int unreadCount) => 'Nouveaux messages';
 
   @override
   String get enableFileAccessMessage => "Per favore attiva l'accesso ai file"

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -442,7 +442,7 @@ Attenzione: il limite massimo di $limit file è stato superato.
   String get linkDisabledError => 'I links sono disattivati';
 
   @override
-  String unreadMessagesSeparatorText() => "Nouveaux messages";
+  String unreadMessagesSeparatorText(int unreadCount) => "Nouveaux messages";
 
   @override
   String get enableFileAccessMessage => "Per favore attiva l'accesso ai file"

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
@@ -418,7 +418,7 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'リンクが無効になっています';
 
   @override
-  String unreadMessagesSeparatorText() => '新しいメッセージ。';
+  String unreadMessagesSeparatorText(int unreadCount) => '新しいメッセージ。';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
@@ -418,12 +418,7 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get linkDisabledError => 'リンクが無効になっています';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '未読メッセージ1通';
-    }
-    return '$unreadCountつの未読メッセージ';
-  }
+  String unreadMessagesSeparatorText() => '新しいメッセージ。';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
@@ -419,7 +419,7 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
   String get linkDisabledError => '링크가 비활성화되었습니다.';
 
   @override
-  String unreadMessagesSeparatorText() => '새 메시지.';
+  String unreadMessagesSeparatorText(int unreadCount) => '새 메시지.';
 
   @override
   String get enableFileAccessMessage => '친구와 공유할 수 있도록 파일에 대한 액세스를 허용하세요.';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
@@ -419,12 +419,7 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
   String get linkDisabledError => '링크가 비활성화되었습니다.';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '읽지 않은 메시지 1개';
-    }
-    return '읽지 않은 메시지 $unreadCount개';
-  }
+  String unreadMessagesSeparatorText() => '새 메시지.';
 
   @override
   String get enableFileAccessMessage => '친구와 공유할 수 있도록 파일에 대한 액세스를 허용하세요.';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
@@ -383,12 +383,7 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'Se bibliotek';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 ulest melding';
-    }
-    return '$unreadCount uleste meldinger';
-  }
+  String unreadMessagesSeparatorText() => 'Nye meldinger.';
 
   @override
   String get couldNotReadBytesFromFileError =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
@@ -383,7 +383,7 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
   String get viewLibrary => 'Se bibliotek';
 
   @override
-  String unreadMessagesSeparatorText() => 'Nye meldinger.';
+  String unreadMessagesSeparatorText(int unreadCount) => 'Nye meldinger.';
 
   @override
   String get couldNotReadBytesFromFileError =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -438,7 +438,7 @@ Não é possível adicionar mais de $limit arquivos de uma vez
   String get viewLibrary => 'Ver biblioteca';
 
   @override
-  String unreadMessagesSeparatorText() => "Novas mensagens";
+  String unreadMessagesSeparatorText(int unreadCount) => "Novas mensagens";
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -438,7 +438,7 @@ Não é possível adicionar mais de $limit arquivos de uma vez
   String get viewLibrary => 'Ver biblioteca';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) => "Novas mensagens";
+  String unreadMessagesSeparatorText(int unreadCount) => 'Novas mensagens';
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -438,12 +438,7 @@ Não é possível adicionar mais de $limit arquivos de uma vez
   String get viewLibrary => 'Ver biblioteca';
 
   @override
-  String unreadMessagesSeparatorText(int unreadCount) {
-    if (unreadCount == 1) {
-      return '1 mensagem não lida';
-    }
-    return '$unreadCount mensagens não lidas';
-  }
+  String unreadMessagesSeparatorText() => "Novas mensagens";
 
   @override
   String get enableFileAccessMessage =>

--- a/packages/stream_chat_localizations/test/translations_test.dart
+++ b/packages/stream_chat_localizations/test/translations_test.dart
@@ -195,7 +195,7 @@ void main() {
           localizations.toggleMuteUnmuteUserQuestion(isMuted: true), isNotNull);
       expect(localizations.toggleMuteUnmuteUserText(isMuted: true), isNotNull);
       expect(localizations.viewLibrary, isNotNull);
-      expect(localizations.unreadMessagesSeparatorText(2), isNotNull);
+      expect(localizations.unreadMessagesSeparatorText(), isNotNull);
       expect(localizations.enableFileAccessMessage, isNotNull);
       expect(localizations.allowFileAccessMessage, isNotNull);
     });

--- a/packages/stream_chat_localizations/test/translations_test.dart
+++ b/packages/stream_chat_localizations/test/translations_test.dart
@@ -195,7 +195,7 @@ void main() {
           localizations.toggleMuteUnmuteUserQuestion(isMuted: true), isNotNull);
       expect(localizations.toggleMuteUnmuteUserText(isMuted: true), isNotNull);
       expect(localizations.viewLibrary, isNotNull);
-      expect(localizations.unreadMessagesSeparatorText(), isNotNull);
+      expect(localizations.unreadMessagesSeparatorText(2), isNotNull);
       expect(localizations.enableFileAccessMessage, isNotNull);
       expect(localizations.allowFileAccessMessage, isNotNull);
     });


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Changes the separator of the messages. Now it doesn't count new messages anymore. 

It is not necessary to count the new messages as this information is already available in a better place, which is the scroll button that appears when the user scrolls up. The divisor can be misleading because new messages may arrive, it should be just a marker showing when the new conversation started when the user entered a channel. 

Updating the counting inside the divisor could create performance problems because we would need to search for the divisor on every new message that arrives. 
