### PR TITLE
feat(ui): Adding custom line for url attachment

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.4.0
+
+✅ Added 
+- Now it is possible to customize the max lines of the title of a url attachment. Before it was always 1 line.
+
 ## 5.3.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
@@ -74,6 +74,9 @@ class MyApp extends StatelessWidget {
           fit: BoxFit.cover,
         ),
       ),
+      ownMessageTheme: const StreamMessageThemeData(
+        urlLinkTitleMaxLine: 1,
+      ),
       otherMessageTheme: StreamMessageThemeData(
         messageBackgroundColor: colorTheme.textHighEmphasis,
         messageTextStyle: TextStyle(
@@ -82,6 +85,7 @@ class MyApp extends StatelessWidget {
         avatarTheme: StreamAvatarThemeData(
           borderRadius: BorderRadius.circular(8),
         ),
+        urlLinkTitleMaxLine: 1,
       ),
     ).merge(defaultTheme);
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
@@ -75,7 +75,7 @@ class MyApp extends StatelessWidget {
         ),
       ),
       ownMessageTheme: const StreamMessageThemeData(
-        urlLinkTitleMaxLine: 1,
+        urlAttachmentTitleMaxLine: 1,
       ),
       otherMessageTheme: StreamMessageThemeData(
         messageBackgroundColor: colorTheme.textHighEmphasis,
@@ -85,7 +85,7 @@ class MyApp extends StatelessWidget {
         avatarTheme: StreamAvatarThemeData(
           borderRadius: BorderRadius.circular(8),
         ),
-        urlLinkTitleMaxLine: 1,
+        urlAttachmentTitleMaxLine: 1,
       ),
     ).merge(defaultTheme);
 

--- a/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
@@ -107,7 +107,7 @@ class StreamUrlAttachment extends StatelessWidget {
                     if (urlAttachment.title != null)
                       Text(
                         urlAttachment.title!.trim(),
-                        maxLines: messageTheme.urlLinkTitleMaxLine ?? 1,
+                        maxLines: messageTheme.urlAttachmentTitleMaxLine ?? 1,
                         overflow: TextOverflow.ellipsis,
                         style: chatThemeData.textTheme.body
                             .copyWith(fontWeight: FontWeight.w700),

--- a/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/url_attachment.dart
@@ -107,7 +107,7 @@ class StreamUrlAttachment extends StatelessWidget {
                     if (urlAttachment.title != null)
                       Text(
                         urlAttachment.title!.trim(),
-                        maxLines: 1,
+                        maxLines: messageTheme.urlLinkTitleMaxLine ?? 1,
                         overflow: TextOverflow.ellipsis,
                         style: chatThemeData.textTheme.body
                             .copyWith(fontWeight: FontWeight.w700),

--- a/packages/stream_chat_flutter/lib/src/theme/message_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/message_theme.dart
@@ -21,7 +21,7 @@ class StreamMessageThemeData with Diagnosticable {
     this.avatarTheme,
     this.createdAtStyle,
     this.linkBackgroundColor,
-    this.urlLinkTitleMaxLine,
+    this.urlAttachmentTitleMaxLine,
   });
 
   /// Text style for message text
@@ -61,7 +61,7 @@ class StreamMessageThemeData with Diagnosticable {
   final Color? linkBackgroundColor;
 
   /// Max number of lines in Url link title
-  final int? urlLinkTitleMaxLine;
+  final int? urlAttachmentTitleMaxLine;
 
   /// Copy with a theme
   StreamMessageThemeData copyWith({
@@ -94,7 +94,8 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsBorderColor: reactionsBorderColor ?? this.reactionsBorderColor,
       reactionsMaskColor: reactionsMaskColor ?? this.reactionsMaskColor,
       linkBackgroundColor: linkBackgroundColor ?? this.linkBackgroundColor,
-      urlLinkTitleMaxLine: urlLinkTitleMaxLine ?? this.urlLinkTitleMaxLine,
+      urlAttachmentTitleMaxLine:
+          urlLinkTitleMaxLine ?? this.urlAttachmentTitleMaxLine,
     );
   }
 
@@ -154,7 +155,7 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsBorderColor: other.reactionsBorderColor,
       reactionsMaskColor: other.reactionsMaskColor,
       linkBackgroundColor: other.linkBackgroundColor,
-      urlLinkTitleMaxLine: other.urlLinkTitleMaxLine,
+      urlLinkTitleMaxLine: other.urlAttachmentTitleMaxLine,
     );
   }
 
@@ -175,7 +176,7 @@ class StreamMessageThemeData with Diagnosticable {
           reactionsMaskColor == other.reactionsMaskColor &&
           avatarTheme == other.avatarTheme &&
           linkBackgroundColor == other.linkBackgroundColor &&
-          urlLinkTitleMaxLine == other.urlLinkTitleMaxLine;
+          urlAttachmentTitleMaxLine == other.urlAttachmentTitleMaxLine;
 
   @override
   int get hashCode =>
@@ -191,7 +192,7 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsMaskColor.hashCode ^
       avatarTheme.hashCode ^
       linkBackgroundColor.hashCode ^
-      urlLinkTitleMaxLine.hashCode;
+      urlAttachmentTitleMaxLine.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -209,6 +210,9 @@ class StreamMessageThemeData with Diagnosticable {
       ..add(ColorProperty('reactionsBorderColor', reactionsBorderColor))
       ..add(ColorProperty('reactionsMaskColor', reactionsMaskColor))
       ..add(ColorProperty('linkBackgroundColor', linkBackgroundColor))
-      ..add(DiagnosticsProperty('urlLinkTitleMaxLine', urlLinkTitleMaxLine));
+      ..add(DiagnosticsProperty(
+        'urlAttachmentTitleMaxLine',
+        urlAttachmentTitleMaxLine,
+      ));
   }
 }

--- a/packages/stream_chat_flutter/lib/src/theme/message_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/message_theme.dart
@@ -21,6 +21,7 @@ class StreamMessageThemeData with Diagnosticable {
     this.avatarTheme,
     this.createdAtStyle,
     this.linkBackgroundColor,
+    this.urlLinkTitleMaxLine,
   });
 
   /// Text style for message text
@@ -59,6 +60,9 @@ class StreamMessageThemeData with Diagnosticable {
   /// Background color for messages with url attachments.
   final Color? linkBackgroundColor;
 
+  /// Max number of lines in Url link title
+  final int? urlLinkTitleMaxLine;
+
   /// Copy with a theme
   StreamMessageThemeData copyWith({
     TextStyle? messageTextStyle,
@@ -73,6 +77,7 @@ class StreamMessageThemeData with Diagnosticable {
     Color? reactionsBorderColor,
     Color? reactionsMaskColor,
     Color? linkBackgroundColor,
+    int? urlLinkTitleMaxLine,
   }) {
     return StreamMessageThemeData(
       messageTextStyle: messageTextStyle ?? this.messageTextStyle,
@@ -89,6 +94,7 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsBorderColor: reactionsBorderColor ?? this.reactionsBorderColor,
       reactionsMaskColor: reactionsMaskColor ?? this.reactionsMaskColor,
       linkBackgroundColor: linkBackgroundColor ?? this.linkBackgroundColor,
+      urlLinkTitleMaxLine: urlLinkTitleMaxLine ?? this.urlLinkTitleMaxLine,
     );
   }
 
@@ -148,6 +154,7 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsBorderColor: other.reactionsBorderColor,
       reactionsMaskColor: other.reactionsMaskColor,
       linkBackgroundColor: other.linkBackgroundColor,
+      urlLinkTitleMaxLine: other.urlLinkTitleMaxLine,
     );
   }
 
@@ -167,7 +174,8 @@ class StreamMessageThemeData with Diagnosticable {
           reactionsBorderColor == other.reactionsBorderColor &&
           reactionsMaskColor == other.reactionsMaskColor &&
           avatarTheme == other.avatarTheme &&
-          linkBackgroundColor == other.linkBackgroundColor;
+          linkBackgroundColor == other.linkBackgroundColor &&
+          urlLinkTitleMaxLine == other.urlLinkTitleMaxLine;
 
   @override
   int get hashCode =>
@@ -182,7 +190,8 @@ class StreamMessageThemeData with Diagnosticable {
       reactionsBorderColor.hashCode ^
       reactionsMaskColor.hashCode ^
       avatarTheme.hashCode ^
-      linkBackgroundColor.hashCode;
+      linkBackgroundColor.hashCode ^
+      urlLinkTitleMaxLine.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -199,6 +208,7 @@ class StreamMessageThemeData with Diagnosticable {
       ..add(ColorProperty('reactionsBackgroundColor', reactionsBackgroundColor))
       ..add(ColorProperty('reactionsBorderColor', reactionsBorderColor))
       ..add(ColorProperty('reactionsMaskColor', reactionsMaskColor))
-      ..add(ColorProperty('linkBackgroundColor', linkBackgroundColor));
+      ..add(ColorProperty('linkBackgroundColor', linkBackgroundColor))
+      ..add(DiagnosticsProperty('urlLinkTitleMaxLine', urlLinkTitleMaxLine));
   }
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- ~[ ] Code changes are tested (add some information if not applicable)~ -> This is just a small customization. 

## Description of the pull request
Adding the possibility to customize the number of lines in the urkl attachments.
