### PR TITLE
feat(ui): expose attachment actions modal builder

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 ✅ Added
 
 - Now it is possible to customize the max lines of the title of a url attachment. Before it was always 1 line.
+- Added `attachmentActionsModalBuilder` parameter to `StreamMessageWidget` that allows to customize `AttachmentActionsModal`.
 
 🔄 Changed
 

--- a/packages/stream_chat_flutter/lib/src/attachment/giphy_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/giphy_attachment.dart
@@ -17,6 +17,7 @@ class StreamGiphyAttachment extends StreamAttachmentWidget {
     this.onShowMessage,
     this.onReplyMessage,
     this.onAttachmentTap,
+    this.attachmentActionsModalBuilder,
   });
 
   /// {@macro showMessageCallback}
@@ -27,6 +28,9 @@ class StreamGiphyAttachment extends StreamAttachmentWidget {
 
   /// {@macro onAttachmentTap}
   final OnAttachmentTap? onAttachmentTap;
+
+  /// {@macro attachmentActionsBuilder}
+  final AttachmentActionsBuilder? attachmentActionsModalBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -260,6 +264,7 @@ class StreamGiphyAttachment extends StreamAttachmentWidget {
               userName: message.user!.name,
               onShowMessage: onShowMessage,
               onReplyMessage: onReplyMessage,
+              attachmentActionsModalBuilder: attachmentActionsModalBuilder,
             ),
           );
         },

--- a/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
@@ -22,6 +22,7 @@ class StreamImageAttachment extends StreamAttachmentWidget {
     this.imageThumbnailSize = const Size(400, 400),
     this.imageThumbnailResizeType = 'clip',
     this.imageThumbnailCropType = 'center',
+    this.attachmentActionsModalBuilder,
   });
 
   /// The [StreamMessageThemeData] to use for the image title
@@ -51,6 +52,9 @@ class StreamImageAttachment extends StreamAttachmentWidget {
   ///
   /// Defaults to [center]
   final String /*center|top|bottom|left|right*/ imageThumbnailCropType;
+
+  /// {@macro attachmentActionsBuilder}
+  final AttachmentActionsBuilder? attachmentActionsModalBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -161,6 +165,8 @@ class StreamImageAttachment extends StreamAttachmentWidget {
                                     userName: message.user!.name,
                                     onShowMessage: onShowMessage,
                                     onReplyMessage: onReplyMessage,
+                                    attachmentActionsModalBuilder:
+                                        attachmentActionsModalBuilder,
                                   ),
                                 );
                               },

--- a/packages/stream_chat_flutter/lib/src/attachment/image_group.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/image_group.dart
@@ -18,6 +18,7 @@ class StreamImageGroup extends StatelessWidget {
     this.imageThumbnailSize = const Size(400, 400),
     this.imageThumbnailResizeType = 'clip',
     this.imageThumbnailCropType = 'center',
+    this.attachmentActionsModalBuilder,
   });
 
   /// List of attachments to show
@@ -53,6 +54,9 @@ class StreamImageGroup extends StatelessWidget {
   ///
   /// Defaults to [center]
   final String /*center|top|bottom|left|right*/ imageThumbnailCropType;
+
+  /// {@macro attachmentActionsBuilder}
+  final AttachmentActionsBuilder? attachmentActionsModalBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -154,6 +158,7 @@ class StreamImageGroup extends StatelessWidget {
             userName: message.user!.name,
             onShowMessage: onShowMessage,
             onReplyMessage: onReplyMessage,
+            attachmentActionsModalBuilder: attachmentActionsModalBuilder,
           ),
         ),
       ),
@@ -170,6 +175,7 @@ class StreamImageGroup extends StatelessWidget {
       imageThumbnailSize: imageThumbnailSize,
       imageThumbnailResizeType: imageThumbnailResizeType,
       imageThumbnailCropType: imageThumbnailCropType,
+      attachmentActionsModalBuilder: attachmentActionsModalBuilder,
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/attachment/video_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/video_attachment.dart
@@ -17,6 +17,7 @@ class StreamVideoAttachment extends StreamAttachmentWidget {
     this.onShowMessage,
     this.onReplyMessage,
     this.onAttachmentTap,
+    this.attachmentActionsModalBuilder,
   });
 
   /// The [StreamMessageThemeData] to use for the title
@@ -30,6 +31,9 @@ class StreamVideoAttachment extends StreamAttachmentWidget {
 
   /// {@macro onAttachmentTap}
   final OnAttachmentTap? onAttachmentTap;
+
+  /// {@macro attachmentActionsBuilder}
+  final AttachmentActionsBuilder? attachmentActionsModalBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -86,6 +90,8 @@ class StreamVideoAttachment extends StreamAttachmentWidget {
                               userName: message.user!.name,
                               onShowMessage: onShowMessage,
                               onReplyMessage: onReplyMessage,
+                              attachmentActionsModalBuilder:
+                                  attachmentActionsModalBuilder,
                             ),
                           ),
                         ),

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -107,6 +107,7 @@ class StreamMessageWidget extends StatefulWidget {
     this.imageAttachmentThumbnailSize = const Size(400, 400),
     this.imageAttachmentThumbnailResizeType = 'clip',
     this.imageAttachmentThumbnailCropType = 'center',
+    this.attachmentActionsModalBuilder,
   })  : assert(
           bottomRowBuilder == null || bottomRowBuilderWithDefaultWidget == null,
           'You can only use one of the two bottom row builders',
@@ -144,6 +145,8 @@ class StreamMessageWidget extends StatefulWidget {
                       imageThumbnailResizeType:
                           imageAttachmentThumbnailResizeType,
                       imageThumbnailCropType: imageAttachmentThumbnailCropType,
+                      attachmentActionsModalBuilder:
+                          attachmentActionsModalBuilder,
                     ),
                   ),
                   attachmentShape: border,
@@ -171,6 +174,7 @@ class StreamMessageWidget extends StatefulWidget {
                 imageThumbnailSize: imageAttachmentThumbnailSize,
                 imageThumbnailResizeType: imageAttachmentThumbnailResizeType,
                 imageThumbnailCropType: imageAttachmentThumbnailCropType,
+                attachmentActionsModalBuilder: attachmentActionsModalBuilder,
               ),
               attachmentShape: border,
             );
@@ -204,6 +208,8 @@ class StreamMessageWidget extends StatefulWidget {
                             onAttachmentTap(message, attachment);
                           }
                         : null,
+                    attachmentActionsModalBuilder:
+                        attachmentActionsModalBuilder,
                   );
                 }).toList(),
               ),
@@ -533,6 +539,9 @@ class StreamMessageWidget extends StatefulWidget {
   /// {@macro onMessageWidgetAttachmentTap}
   final OnMessageWidgetAttachmentTap? onAttachmentTap;
 
+  /// {@macro attachmentActionsBuilder}
+  final AttachmentActionsBuilder? attachmentActionsModalBuilder;
+
   /// Size of the image attachment thumbnail.
   final Size imageAttachmentThumbnailSize;
 
@@ -617,6 +626,7 @@ class StreamMessageWidget extends StatefulWidget {
     Size? imageAttachmentThumbnailSize,
     String? imageAttachmentThumbnailResizeType,
     String? imageAttachmentThumbnailCropType,
+    AttachmentActionsBuilder? attachmentActionsModalBuilder,
   }) {
     assert(
       bottomRowBuilder == null || bottomRowBuilderWithDefaultWidget == null,
@@ -703,6 +713,8 @@ class StreamMessageWidget extends StatefulWidget {
           this.imageAttachmentThumbnailResizeType,
       imageAttachmentThumbnailCropType: imageAttachmentThumbnailCropType ??
           this.imageAttachmentThumbnailCropType,
+      attachmentActionsModalBuilder:
+          attachmentActionsModalBuilder ?? this.attachmentActionsModalBuilder,
     );
   }
 


### PR DESCRIPTION
Exposed `attachmentActionsModalBuilder` in `StreamMessageWidget` so it's possible to customize `ActionsModal`.
For example - you can hide `saveImage` option by using below snippet:
```
StreamMessageListView(
                    messageBuilder:
                        (context, details, messages, defaultWidget) {
                      return defaultWidget.copyWith(
                        onReplyTap: reply,
                        attachmentActionsModalBuilder: (_, __, defaultWidget) {
                          return defaultWidget.copyWith(
                            showSave: true,
                          );
                        }
                      );
                    },
                  ),
                  ```