### PR TITLE
fix(ui): fix clipboardData requires non-nullable string as text.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -15,7 +15,7 @@
   applied correctly.
 - [[#1525]](https://github.com/GetStream/stream-chat-flutter/issues/1525) Fixed `StreamQuotedMessageWidget` message for
   deleted messages not being shown correctly.
-- [[#1529]](https://github.com/GetStream/stream-chat-flutter/issues/1529) Fixed fix `ClipboardData` requires non-nullable string as text on Flutter 2.10. 
+- [[#1529]](https://github.com/GetStream/stream-chat-flutter/issues/1529) Fixed fix `ClipboardData` requires non-nullable string as text on Flutter 3.10. 
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -15,6 +15,7 @@
   applied correctly.
 - [[#1525]](https://github.com/GetStream/stream-chat-flutter/issues/1525) Fixed `StreamQuotedMessageWidget` message for
   deleted messages not being shown correctly.
+- [[#1529]](https://github.com/GetStream/stream-chat-flutter/issues/1529) Fixed fix `ClipboardData` requires non-nullable string as text on Flutter 2.10. 
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1170,7 +1170,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                     : DisplayWidget.show,
           ),
           onCopyTap: (message) {
-             final text = message.text;
+            final text = message.text;
             if (text != null) Clipboard.setData(ClipboardData(text: text));
           },
           messageTheme: widget.messageTheme,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1009,7 +1009,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           title: Text(context.translations.copyMessageLabel),
           onClick: () {
             Navigator.of(context, rootNavigator: true).pop();
-            Clipboard.setData(ClipboardData(text: widget.message.text));
+            Clipboard.setData(ClipboardData(text: widget.message.text ?? ''));
           },
         ),
       if (shouldShowEditAction) ...[
@@ -1169,7 +1169,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                     : DisplayWidget.show,
           ),
           onCopyTap: (message) =>
-              Clipboard.setData(ClipboardData(text: message.text)),
+              Clipboard.setData(ClipboardData(text: message.text ?? '')),
           messageTheme: widget.messageTheme,
           reverse: widget.reverse,
           showDeleteMessage: shouldShowDeleteAction,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1009,7 +1009,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           title: Text(context.translations.copyMessageLabel),
           onClick: () {
             Navigator.of(context, rootNavigator: true).pop();
-            final text = message.text;
+            final text = widget.message.text;
             if (text != null) Clipboard.setData(ClipboardData(text: text));
           },
         ),

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1169,8 +1169,10 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                     ? DisplayWidget.gone
                     : DisplayWidget.show,
           ),
-          onCopyTap: (message) =>
-              Clipboard.setData(ClipboardData(text: message.text ?? '')),
+          onCopyTap: (message) {
+             final text = message.text;
+            if (text != null) Clipboard.setData(ClipboardData(text: text));
+          },
           messageTheme: widget.messageTheme,
           reverse: widget.reverse,
           showDeleteMessage: shouldShowDeleteAction,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1009,7 +1009,8 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           title: Text(context.translations.copyMessageLabel),
           onClick: () {
             Navigator.of(context, rootNavigator: true).pop();
-            Clipboard.setData(ClipboardData(text: widget.message.text ?? ''));
+            final text = message.text;
+            if (text != null) Clipboard.setData(ClipboardData(text: text));
           },
         ),
       if (shouldShowEditAction) ...[


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
Fixes #1529: ClipboardDate text param requires non nullable string. 