### PR TITLE
fix(ui): fix `StreamMessageWidget` actions dialog backdrop filter is cut off by safe area.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -19,6 +19,8 @@
   string as text on Flutter 3.10.
 - [[#1533]](https://github.com/GetStream/stream-chat-flutter/issues/1533) Fixed `StreamMessageListView` messages grouped
   incorrectly w.r.t. timestamp.
+- [[#1532]](https://github.com/GetStream/stream-chat-flutter/issues/1532) Fixed `StreamMessageWidget` actions dialog
+  backdrop filter is cut off by safe area.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1144,6 +1144,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
     showDialog(
       useRootNavigator: false,
       context: context,
+      useSafeArea: false,
       barrierColor: _streamChatTheme.colorTheme.overlay,
       builder: (context) => StreamChannel(
         channel: channel,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
@@ -433,6 +433,7 @@ class MessageWidgetContent extends StatelessWidget {
     showDialog(
       useRootNavigator: false,
       context: context,
+      useSafeArea: false,
       barrierColor: streamChatTheme.colorTheme.overlay,
       builder: (context) => StreamChannel(
         channel: channel,


### PR DESCRIPTION
Fixes: #1532 