### PR TITLE
fix(ui): fix `MessageInputTheme.linkHighlightColor` returning null for default theme.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#1546]](https://github.com/GetStream/stream-chat-flutter/issues/1546)
+  Fixed `StreamMessageInputTheme.linkHighlightColor` returning null for default theme.
+
 ## 6.1.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
@@ -153,6 +153,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       sendButtonColor: sendButtonColor ?? this.sendButtonColor,
       actionButtonIdleColor:
           actionButtonIdleColor ?? this.actionButtonIdleColor,
+      linkHighlightColor: linkHighlightColor ?? this.linkHighlightColor,
       expandButtonColor: expandButtonColor ?? this.expandButtonColor,
       inputTextStyle: inputTextStyle ?? this.inputTextStyle,
       sendButtonIdleColor: sendButtonIdleColor ?? this.sendButtonIdleColor,


### PR DESCRIPTION
Fixes: #1546 