### PR TITLE
fix(ui): handle `StreamMessageInput` enrichUrl exceptions.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [[#1548]](https://github.com/GetStream/stream-chat-flutter/issues/1548) Fixed `StreamMessageInput` urlRegex only
   matching the
   lowercase `http(s)|ftp`.
+- [[#1542]](https://github.com/GetStream/stream-chat-flutter/issues/1542) Handle error thrown in `StreamMessageInput`
+  when unable to fetch a
+  link preview.
 
 ## 6.1.0
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -1104,8 +1104,12 @@ class StreamMessageInputState extends State<StreamMessageInput>
     var response = _ogAttachmentCache[url];
     if (response == null) {
       final client = StreamChat.of(context).client;
-      response = await client.enrichUrl(url);
-      _ogAttachmentCache[url] = response;
+      try {
+        response = await client.enrichUrl(url);
+        _ogAttachmentCache[url] = response;
+      } catch (e, stk) {
+        return Future.error(e, stk);
+      }
     }
     return response;
   }


### PR DESCRIPTION
Fixes: #1542 