### PR TITLE
fix(ui): fix `editMessageInputBuilder` property not used in `MessageActionsModal.editMessage` option.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -10,6 +10,8 @@
   when unable to fetch a link preview.
 - [[#1540]](https://github.com/GetStream/stream-chat-flutter/issues/1540) Use `CircularProgressIndicator.adaptive`
   instead of material indicator.
+- [[#1490]](https://github.com/GetStream/stream-chat-flutter/issues/1490) Fixed `editMessageInputBuilder` property not
+  used in `MessageActionsModal.editMessage` option.
 
 ## 6.1.0
 

--- a/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
+++ b/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
@@ -400,8 +400,9 @@ class _MessageActionsModalState extends State<MessageActionsModal> {
         ),
       ),
       builder: (context) => EditMessageSheet(
-        message: widget.message,
         channel: channel,
+        message: widget.message,
+        editMessageInputBuilder: widget.editMessageInputBuilder,
       ),
     );
   }


### PR DESCRIPTION
Completely fixes: #1490 