### PR TITLE
check whether persistent client is connected

### DIFF
--- a/packages/stream_chat/lib/src/db/chat_persistence_client.dart
+++ b/packages/stream_chat/lib/src/db/chat_persistence_client.dart
@@ -14,6 +14,9 @@ import 'package:stream_chat/src/core/util/extension.dart';
 
 /// A simple client used for persisting chat data locally.
 abstract class ChatPersistenceClient {
+  /// Whether the connection is established.
+  bool get isConnected;
+
   /// Creates a new connection to the client
   Future<void> connect(String userId);
 

--- a/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
+++ b/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
@@ -80,6 +80,9 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
       );
 
   @override
+  bool get isConnected => db != null;
+
+  @override
   Future<void> connect(
     String userId, {
     DatabaseProvider? databaseProvider, // Used only for testing


### PR DESCRIPTION
Adds `StreamChatPersistenceClient.isConnected` flag to check whether or not `StreamChatPersistenceClient` is connected.

It's used in the sample app's PR: https://github.com/GetStream/flutter-samples/pull/96

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
