### PR TITLE
fix(ui): Remove the user is a member check for unreadIndicator.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -14,6 +14,8 @@
   used in `MessageActionsModal.editMessage` option.
 - [[#1544]](https://github.com/GetStream/stream-chat-flutter/issues/1544) Fixed error thrown when unable to fetch
   image/data in Message link preview.
+- [[#1482]](https://github.com/GetStream/stream-chat-flutter/issues/1482) Fixed `StreaChannelListTile` not showing
+  unread indicator when `currentUser` is not present in the initial member list.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -196,8 +196,7 @@ class StreamChannelListTile extends StatelessWidget {
                 initialData: channelState.members,
                 comparator: const ListEquality().equals,
                 builder: (context, members) {
-                  if (members.isEmpty ||
-                      !members.any((it) => it.user!.id == currentUser.id)) {
+                  if (members.isEmpty) {
                     return const Offstage();
                   }
                   return unreadIndicatorBuilder?.call(context) ??


### PR DESCRIPTION
Fixes: #1482 