### PR TITLE
fix(ui): fix WebOrDesktopAttachmentPickerOption not using localized title.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -16,6 +16,8 @@
   image/data in Message link preview.
 - [[#1482]](https://github.com/GetStream/stream-chat-flutter/issues/1482) Fixed `StreaChannelListTile` not showing
   unread indicator when `currentUser` is not present in the initial member list.
+- [[#1487]](https://github.com/GetStream/stream-chat-flutter/issues/1487) Use localized title
+  for `WebOrDesktopAttachmentPickerOption` in `StreamMessageInput`.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
@@ -792,19 +792,19 @@ Widget webOrDesktopAttachmentPickerBuilder({
         key: 'image-picker',
         type: AttachmentPickerType.images,
         icon: StreamSvgIcon.pictures(size: 36).toIconThemeSvgIcon(),
-        title: 'Upload a photo',
+        title: context.translations.uploadAPhotoLabel,
       ),
       WebOrDesktopAttachmentPickerOption(
         key: 'video-picker',
         type: AttachmentPickerType.videos,
         icon: StreamSvgIcon.record(size: 36).toIconThemeSvgIcon(),
-        title: 'Upload a video',
+        title: context.translations.uploadAVideoLabel,
       ),
       WebOrDesktopAttachmentPickerOption(
         key: 'file-picker',
         type: AttachmentPickerType.files,
         icon: StreamSvgIcon.files(size: 36).toIconThemeSvgIcon(),
-        title: 'Upload a file',
+        title: context.translations.uploadAFileLabel,
       ),
     },
     onOptionTap: (context, controller, option) async {


### PR DESCRIPTION
fixes: #1487 