### PR TITLE
fix(ui): type `ImageDecoderCallback` not found on pre-Flutter 3.10.0 versions.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#1600]](https://github.com/GetStream/stream-chat-flutter/issues/1600) Fixed type `ImageDecoderCallback` not found
+  error on pre-Flutter 3.10.0 versions.
+
 ## 6.3.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
@@ -202,9 +202,13 @@ class MediaThumbnailProvider extends ImageProvider<MediaThumbnailProvider> {
   }
 
   @override
-  ImageStreamCompleter loadImage(
+  @Deprecated(
+    'Implement loadImage for image loading. '
+    'This feature was deprecated after v6.4.0.',
+  )
+  ImageStreamCompleter loadBuffer(
     MediaThumbnailProvider key,
-    ImageDecoderCallback decode,
+    DecoderBufferCallback decode,
   ) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key, decode),
@@ -219,9 +223,13 @@ class MediaThumbnailProvider extends ImageProvider<MediaThumbnailProvider> {
     );
   }
 
+  @Deprecated(
+    'Implement loadImage for image loading. '
+    'This feature was deprecated after v6.4.0.',
+  )
   Future<ui.Codec> _loadAsync(
     MediaThumbnailProvider key,
-    ImageDecoderCallback decode,
+    DecoderBufferCallback decode,
   ) async {
     assert(key == this, '$key is not $this');
     final bytes = await media.thumbnailDataWithSize(

--- a/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
@@ -202,10 +202,7 @@ class MediaThumbnailProvider extends ImageProvider<MediaThumbnailProvider> {
   }
 
   @override
-  @Deprecated(
-    'Implement loadImage for image loading. '
-    'This feature was deprecated after v6.4.0.',
-  )
+  @Deprecated('Will get replaced by loadImage in the next major version.')
   ImageStreamCompleter loadBuffer(
     MediaThumbnailProvider key,
     DecoderBufferCallback decode,
@@ -223,10 +220,7 @@ class MediaThumbnailProvider extends ImageProvider<MediaThumbnailProvider> {
     );
   }
 
-  @Deprecated(
-    'Implement loadImage for image loading. '
-    'This feature was deprecated after v6.4.0.',
-  )
+  @Deprecated('Will get replaced by loadImage in the next major version.')
   Future<ui.Codec> _loadAsync(
     MediaThumbnailProvider key,
     DecoderBufferCallback decode,


### PR DESCRIPTION
Fixes: #1600 