### PR TITLE
chore(ui): StreamUserListTile to receive `tileColor` properly

### DIFF
--- a/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_tile.dart
@@ -157,6 +157,7 @@ class StreamUserListTile extends StatelessWidget {
       trailing: selected ? selectedWidget : null,
       title: title,
       subtitle: subtitle,
+      tileColor: tileColor,
     );
   }
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

fix StreamUserListTile to receive tileColor properly

the tileColor was not repassed to ListTile