### PR TITLE
fix(ui): pass onConfirmDeleteTap to MessageActionsModal.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#1620]](https://github.com/GetStream/stream-chat-flutter/issues/1620) Fixed messages Are Not Hard Deleting even
+  after overriding the `onConfirmDeleteTap` callback.
+
 ## 6.4.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1202,6 +1202,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           messageTheme: widget.messageTheme,
           reverse: widget.reverse,
           showDeleteMessage: shouldShowDeleteAction,
+          onConfirmDeleteTap: widget.onConfirmDeleteTap,
           message: widget.message,
           editMessageInputBuilder: widget.editMessageInputBuilder,
           onReplyTap: widget.onReplyTap,


### PR DESCRIPTION
Fixes: #1620 