### PR TITLE
fix(ui): fix `createdAtStyle` null check error in `SendingIndicatorBuilder`

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [[#1620]](https://github.com/GetStream/stream-chat-flutter/issues/1620) Fixed messages Are Not Hard Deleting even
   after overriding the `onConfirmDeleteTap` callback.
+- [[#1621]](https://github.com/GetStream/stream-chat-flutter/issues/1621) Fixed `createdAtStyle` null check error
+  in `SendingIndicatorBuilder`.
 
 ## 6.4.0
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/sending_indicator_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/sending_indicator_builder.dart
@@ -76,7 +76,7 @@ class SendingIndicatorBuilder extends StatelessWidget {
         Widget child = StreamSendingIndicator(
           message: message,
           isMessageRead: isMessageRead,
-          size: style!.fontSize,
+          size: style?.fontSize,
         );
 
         if (isMessageRead) {
@@ -86,7 +86,7 @@ class SendingIndicatorBuilder extends StatelessWidget {
               if (memberCount > 2)
                 Text(
                   readList.length.toString(),
-                  style: style.copyWith(
+                  style: style?.copyWith(
                     color: streamChatTheme.colorTheme.accentPrimary,
                   ),
                 ),


### PR DESCRIPTION
Partially Fixes: #1621