### PR TITLE
chore(ui): Send onLinkTap on url attachement

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
@@ -220,6 +220,7 @@ class _MessageCardState extends State<MessageCard> {
 
     return StreamUrlAttachment(
       key: linksKey,
+      onLinkTap: widget.onLinkTap,
       urlAttachment: urlAttachment,
       hostDisplayName: hostDisplayName,
       textPadding: widget.textPadding,


### PR DESCRIPTION
# Submit a pull request
Fixes the issue: https://github.com/GetStream/stream-chat-flutter/issues/1680
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR sends the OnLinkTap to URL attachement. This is needed to customize the onLinkTap function, otherwise they does not work
