### PR TITLE
Release: v6.8.0

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Upcoming
+## 6.7.0
 
 ✅ Added
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Upcoming
+
+✅ Added
+
+- Added support for setting `Message.type`. [#1682](https://github.com/GetStream/stream-chat-flutter/issues/1682)
+  ```
+  It is now possible to send system messages. System messages differ from normal messages in the way they are
+  presented to the user. Like the name says, system messages are normally send from the system itself, but a user is
+  able to send it as well by specifying type: 'system' with the message. The user who sends a system message client-side
+  should have the Create System Message permission. Server-side system messages don't need that permission.
+  ```
+
 ## 6.6.0
 
 🔄 Changed

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -168,7 +168,6 @@ class Message extends Equatable {
   late final MessageState state;
 
   /// The message type.
-  @JsonKey(includeToJson: false)
   final String type;
 
   /// The list of attachments, either provided by the user or generated from a

--- a/packages/stream_chat/lib/src/core/models/message.g.dart
+++ b/packages/stream_chat/lib/src/core/models/message.g.dart
@@ -74,6 +74,7 @@ Message _$MessageFromJson(Map<String, dynamic> json) => Message(
 Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'id': instance.id,
       'text': instance.text,
+      'type': instance.type,
       'attachments': instance.attachments.map((e) => e.toJson()).toList(),
       'mentioned_users': User.toIds(instance.mentionedUsers),
       'parent_id': instance.parentId,

--- a/packages/stream_chat/lib/version.dart
+++ b/packages/stream_chat/lib/version.dart
@@ -3,4 +3,4 @@ import 'package:stream_chat/src/client/client.dart';
 /// Current package version
 /// Used in [StreamChatClient] to build the `x-stream-client` header
 // ignore: constant_identifier_names
-const PACKAGE_VERSION = '6.6.0';
+const PACKAGE_VERSION = '6.7.0';

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat
 homepage: https://getstream.io/
 description: The official Dart client for Stream Chat, a service for building chat applications.
-version: 6.6.0
+version: 6.7.0
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 

--- a/packages/stream_chat/test/fixtures/channel_state_to_json.json
+++ b/packages/stream_chat/test/fixtures/channel_state_to_json.json
@@ -14,6 +14,7 @@
   "messages": [
     {
       "id": "dry-meadow-0-2b73cc8b-cd86-4a01-8d40-bd82ad07a030",
+      "type": "regular",
       "text": "fasdfa",
       "attachments": [],
       "parent_id": null,
@@ -27,6 +28,7 @@
     },
     {
       "id": "dry-meadow-0-e8e74482-b4cd-48db-9d1e-30e6c191786f",
+      "type": "regular",
       "text": "test message",
       "attachments": [],
       "parent_id": null,
@@ -40,6 +42,7 @@
     },
     {
       "id": "dry-meadow-0-53e6299f-9b97-4a9c-a27e-7e2dde49b7e0",
+      "type": "regular",
       "text": "test message",
       "attachments": [],
       "parent_id": null,
@@ -53,6 +56,7 @@
     },
     {
       "id": "dry-meadow-0-80925be0-786e-40a5-b225-486518dafd35",
+      "type": "regular",
       "text": "asdfadf",
       "attachments": [],
       "parent_id": null,
@@ -66,6 +70,7 @@
     },
     {
       "id": "dry-meadow-0-64d7970f-ede8-4b31-9738-1bc1756d2bfe",
+      "type": "regular",
       "text": "test",
       "attachments": [],
       "parent_id": null,
@@ -79,6 +84,7 @@
     },
     {
       "id": "withered-cell-0-84cbd760-cf55-4f7e-9207-c5f66cccc6dc",
+      "type": "regular",
       "text": "hi",
       "attachments": [],
       "parent_id": null,
@@ -92,6 +98,7 @@
     },
     {
       "id": "dry-meadow-0-e9203588-43c3-40b1-91f7-f217fc42aa53",
+      "type": "regular",
       "text": "fantastic",
       "attachments": [],
       "parent_id": null,
@@ -105,6 +112,7 @@
     },
     {
       "id": "withered-cell-0-7e3552d7-7a0d-45f2-a856-e91b23a7e240",
+      "type": "regular",
       "text": "nice to meet you",
       "attachments": [],
       "parent_id": null,
@@ -118,6 +126,7 @@
     },
     {
       "id": "dry-meadow-0-1ffeafd4-e4fc-4c84-9394-9d7cb10fff42",
+      "type": "regular",
       "text": "hey",
       "attachments": [],
       "parent_id": null,
@@ -131,6 +140,7 @@
     },
     {
       "id": "dry-meadow-0-3f147324-12c8-4b41-9fb5-2db88d065efa",
+      "type": "regular",
       "text": "hello, everyone",
       "attachments": [],
       "parent_id": null,
@@ -144,6 +154,7 @@
     },
     {
       "id": "dry-meadow-0-51a348ae-0c0a-44de-a556-eac7891c0cf0",
+      "type": "regular",
       "text": "who is there?",
       "attachments": [],
       "parent_id": null,
@@ -157,6 +168,7 @@
     },
     {
       "id": "icy-recipe-7-a29e237b-8d81-4a97-9bc8-d42bca3f1356",
+      "type": "regular",
       "text": "하이",
       "attachments": [],
       "parent_id": null,
@@ -170,6 +182,7 @@
     },
     {
       "id": "icy-recipe-7-935c396e-ddf8-4a9a-951c-0a12fa5bf055",
+      "type": "regular",
       "text": "what are you doing?",
       "attachments": [],
       "parent_id": null,
@@ -183,6 +196,7 @@
     },
     {
       "id": "throbbing-boat-5-1e4d5730-5ff0-4d25-9948-9f34ffda43e4",
+      "type": "regular",
       "text": "👍",
       "attachments": [],
       "parent_id": null,
@@ -196,6 +210,7 @@
     },
     {
       "id": "snowy-credit-3-3e0c1a0d-d22f-42ee-b2a1-f9f49477bf21",
+      "type": "regular",
       "text": "sdasas",
       "attachments": [],
       "parent_id": null,
@@ -209,6 +224,7 @@
     },
     {
       "id": "snowy-credit-3-3319537e-2d0e-4876-8170-a54f046e4b7d",
+      "type": "regular",
       "text": "cjshsa",
       "attachments": [],
       "parent_id": null,
@@ -222,6 +238,7 @@
     },
     {
       "id": "snowy-credit-3-cfaf0b46-1daa-49c5-947c-b16d6697487d",
+      "type": "regular",
       "text": "nhisagdhsadz",
       "attachments": [],
       "parent_id": null,
@@ -235,6 +252,7 @@
     },
     {
       "id": "snowy-credit-3-cebe25a7-a3a3-49fc-9919-91c6725e81f3",
+      "type": "regular",
       "text": "hvadhsahzd",
       "attachments": [],
       "parent_id": null,
@@ -248,6 +266,7 @@
     },
     {
       "id": "divine-glade-9-0cea9262-5766-48e9-8b22-311870aed3bf",
+      "type": "regular",
       "text": "hello",
       "attachments": [],
       "parent_id": null,
@@ -261,6 +280,7 @@
     },
     {
       "id": "red-firefly-9-c4e9007b-bb7d-4238-ae08-5f8e3cd03d73",
+      "type": "regular",
       "text": "hello",
       "attachments": [],
       "parent_id": null,
@@ -274,6 +294,7 @@
     },
     {
       "id": "bitter-glade-2-02aee4eb-4093-4736-808b-2de75820e854",
+      "type": "regular",
       "text": "hello",
       "attachments": [],
       "parent_id": null,
@@ -287,6 +308,7 @@
     },
     {
       "id": "morning-sea-1-0c700bcb-46dd-4224-b590-e77bdbccc480",
+      "type": "regular",
       "text": "http://jaeger.ui.gtstrm.com/",
       "attachments": [],
       "parent_id": null,
@@ -300,6 +322,7 @@
     },
     {
       "id": "ancient-salad-0-53e8b4e6-5b7b-43ad-aeee-8bfb6a9ed0be",
+      "type": "regular",
       "text": "hi",
       "attachments": [],
       "parent_id": null,
@@ -313,6 +336,7 @@
     },
     {
       "id": "ancient-salad-0-8c225075-bd4c-42e2-8024-530aae13cd40",
+      "type": "regular",
       "text": "hi",
       "attachments": [],
       "parent_id": null,
@@ -326,6 +350,7 @@
     },
     {
       "id": "proud-sea-7-17802096-cbf8-4e3c-addd-4ee31f4c8b5c",
+      "type": "regular",
       "text": "😃",
       "attachments": [],
       "parent_id": null,

--- a/packages/stream_chat/test/fixtures/message_to_json.json
+++ b/packages/stream_chat/test/fixtures/message_to_json.json
@@ -1,5 +1,6 @@
 {
   "id": "4637f7e4-a06b-42db-ba5a-8d8270dd926f",
+  "type": "regular",
   "text": "https://giphy.com/gifs/the-lion-king-live-action-5zvN79uTGfLMOVfQaA",
   "silent": false,
   "attachments": [

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.8.0
+
+🔄 Changed
+
+- Updated `stream_chat_flutter_core` dependency
+  to [`6.7.0`](https://pub.dev/packages/stream_chat_flutter_core/changelog).
+
 ## 6.7.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
@@ -220,6 +220,7 @@ class _MessageCardState extends State<MessageCard> {
 
     return StreamUrlAttachment(
       key: linksKey,
+      onLinkTap: widget.onLinkTap,
       urlAttachment: urlAttachment,
       hostDisplayName: hostDisplayName,
       textPadding: widget.textPadding,

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 6.7.0
+version: 6.8.0
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -38,7 +38,7 @@ dependencies:
   rxdart: ^0.27.7
   share_plus: ^7.0.2
   shimmer: ^3.0.0
-  stream_chat_flutter_core: ^6.6.0
+  stream_chat_flutter_core: ^6.7.0
   synchronized: ^3.1.0
   thumblr: ^0.0.4
   url_launcher: ^6.1.11

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.0
+
+- Updated `stream_chat` dependency to [`6.7.0`](https://pub.dev/packages/stream_chat/changelog).
+
 ## 6.6.0
 
 - Updated `stream_chat` dependency to [`6.6.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter_core
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK Core. Build your own chat experience using Dart and Flutter.
-version: 6.6.0
+version: 6.7.0
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -17,7 +17,7 @@ dependencies:
   freezed_annotation: ^2.2.0
   meta: ^1.8.0
   rxdart: ^0.27.7
-  stream_chat: ^6.6.0
+  stream_chat: ^6.7.0
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.0
+
+* Updated `stream_chat_flutter` dependency to [`6.8.0`](https://pub.dev/packages/stream_chat_flutter/changelog).
+
 ## 5.7.0
 
 * Updated `stream_chat_flutter` dependency to [`6.7.0`](https://pub.dev/packages/stream_chat_flutter/changelog).

--- a/packages/stream_chat_localizations/pubspec.yaml
+++ b/packages/stream_chat_localizations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_chat_localizations
 description: The Official localizations for Stream Chat Flutter, a service for building chat applications
-version: 5.7.0
+version: 5.8.0
 homepage: https://github.com/GetStream/stream-chat-flutter
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  stream_chat_flutter: ^6.7.0
+  stream_chat_flutter: ^6.8.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+- [[#1683]](https://github.com/GetStream/stream-chat-flutter/issues/1683) Fixed SqliteException no such
+  column `messages.state`.
+
 ## 6.6.0
 
 - Updated `stream_chat` dependency to [`6.6.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Upcoming
+## 6.7.0
 
 - [[#1683]](https://github.com/GetStream/stream-chat-flutter/issues/1683) Fixed SqliteException no such
   column `messages.state`.

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -48,7 +48,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/packages/stream_chat_persistence/pubspec.yaml
+++ b/packages/stream_chat_persistence/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_persistence
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Official Stream Chat Persistence library. Build your own chat experience using Dart and Flutter.
-version: 6.6.0
+version: 6.7.0
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -18,7 +18,7 @@ dependencies:
   path: ^1.8.2
   path_provider: ^2.0.15
   sqlite3_flutter_libs: ^0.5.15
-  stream_chat: ^6.6.0
+  stream_chat: ^6.7.0
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
## What's Changed
* chore(ui): Send `onLinkTap` on url attachement by @MateusHBR in https://github.com/GetStream/stream-chat-flutter/pull/1679
* fix(persistence): fix column `message.state` not found. by @xsahil03x in https://github.com/GetStream/stream-chat-flutter/pull/1684
* feat(llc): add support for setting `message.type`. by @xsahil03x in https://github.com/GetStream/stream-chat-flutter/pull/1685


**Full Changelog**: https://github.com/GetStream/stream-chat-flutter/compare/6.7.0...6.8.0