### PR TITLE
fix(ui): fix `video_player:macos` multiple possible implementations.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 6.10.0
+# Upcoming
+
+🐞 Fixed
+
+- [[#1740]](https://github.com/GetStream/stream-chat-flutter/issues/1740) Fixed
+  Plugin `video_player:macos` has multiple possible implementations.
+
+# 6.10.0
 
 🐞 Fixed
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   thumblr: ^0.0.4
   url_launcher: ^6.1.12
   video_player: ^2.7.0
-  video_player_macos: ^2.0.1
   video_thumbnail: ^0.5.3
 
 flutter:


### PR DESCRIPTION
Fixes: #1740 