### PR TITLE
fix(core): video attachment upload

### DIFF
--- a/packages/stream_chat/lib/src/core/http/stream_http_client_options.dart
+++ b/packages/stream_chat/lib/src/core/http/stream_http_client_options.dart
@@ -7,8 +7,8 @@ class StreamHttpClientOptions {
   /// Instantiates a new [StreamHttpClientOptions]
   const StreamHttpClientOptions({
     String? baseUrl,
-    this.connectTimeout = const Duration(seconds: 6),
-    this.receiveTimeout = const Duration(seconds: 6),
+    this.connectTimeout = const Duration(seconds: 30),
+    this.receiveTimeout = const Duration(seconds: 30),
     this.queryParameters = const {},
     this.headers = const {},
   }) : baseUrl = baseUrl ?? _defaultBaseURL;
@@ -16,10 +16,10 @@ class StreamHttpClientOptions {
   /// base url to use with client.
   final String baseUrl;
 
-  /// connect timeout, default to 6s
+  /// connect timeout, default to 30s
   final Duration connectTimeout;
 
-  /// received timeout, default to 6s
+  /// received timeout, default to 30s
   final Duration receiveTimeout;
 
   /// Common query parameters.

--- a/packages/stream_chat/test/src/core/http/stream_http_client_options_test.dart
+++ b/packages/stream_chat/test/src/core/http/stream_http_client_options_test.dart
@@ -5,8 +5,8 @@ void main() {
   test('should return the all default set params', () {
     const options = StreamHttpClientOptions();
     expect(options.baseUrl, 'https://chat.stream-io-api.com');
-    expect(options.connectTimeout, const Duration(seconds: 6));
-    expect(options.receiveTimeout, const Duration(seconds: 6));
+    expect(options.connectTimeout, const Duration(seconds: 30));
+    expect(options.receiveTimeout, const Duration(seconds: 30));
     expect(options.queryParameters, const {});
     expect(options.headers, const {});
   });

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+🐞 Fixed
+
+- Fixed video attachment uploading. [#1754](https://github.com/GetStream/stream-chat-flutter/pull/1754)
+
 ## 6.10.0
 
 - Added mixin support to `StreamChannelListEventHandler`.


### PR DESCRIPTION
# Submit a pull request

The default `connectTimeout` and `receiveTimeout` were too small for Video uploads.
Now we use default values similar to Android SDK.

Resolves: [zendesk-42260](https://getstream.zendesk.com/agent/tickets/42260)
Related thread is [here](https://getstream.slack.com/archives/C0601841J84/p1697034507204559).

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
