### PR TITLE
chore: Upgrade `photo_manager` dependency

### DIFF
--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   cached_network_image: ^3.2.3
@@ -33,7 +33,7 @@ dependencies:
   lottie: ^2.6.0
   meta: ^1.9.1
   path_provider: ^2.1.0
-  photo_manager: ^2.7.1
+  photo_manager: ^2.8.1
   photo_view: ^0.14.0
   rxdart: ^0.27.7
   share_plus: ^7.1.0


### PR DESCRIPTION
Previous version was blocking the use on flutter 3.16.0 release

# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
The previous version of photo_manager is blocking app build on the new flutter release