### PR TITLE
chore(repo): lock the flutter version of pipelines

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -3,6 +3,7 @@ name: stream_flutter_workflow
 env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
   flutter_channel: "stable"
+  flutter_version: "3.10.6"
 
 on:
   pull_request:
@@ -36,6 +37,7 @@ jobs:
       - name: "Install Flutter"
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.flutter_version }}
           cache: true
           channel: ${{ env.flutter_channel }}
       - name: "Install Tools"
@@ -63,6 +65,7 @@ jobs:
       - name: "Install Flutter"
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.flutter_version }}
           cache: true
           channel: ${{ env.flutter_channel }}
       - name: "Install Tools"
@@ -88,6 +91,7 @@ jobs:
       - name: "Install Flutter"
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.flutter_version }}
           cache: true
           channel: ${{ env.flutter_channel }}
       - name: "Install Tools"

--- a/packages/stream_chat/test/src/core/http/stream_http_client_test.dart
+++ b/packages/stream_chat/test/src/core/http/stream_http_client_test.dart
@@ -164,7 +164,8 @@ void main() {
       expect(
         e.message,
         "The connection errored: Dio can't establish a new connection"
-        ' after it was closed.',
+        ' after it was closed. This indicates an error which most likely'
+        ' cannot be solved by the library.',
       );
     }
   });


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request

Locks the flutter version in the GH actions