### PR TITLE
fix(ui): be lenient when calling nullable onThreadTap method

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 🐞 Fixed
 - Removed double focus on `StreamMessageInput` when `focusNode` is provided for web and desktop.
+- Optionally call `onThreadTap` in `BottomRow` to avoid `Null check operator used on a null value`
+
 
 ## 7.0.1
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/bottom_row.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/bottom_row.dart
@@ -169,7 +169,7 @@ class BottomRow extends StatelessWidget {
           final channel = StreamChannel.of(context);
           message = await channel.getMessage(message.parentId!);
         }
-        return onThreadTap!(message);
+        return onThreadTap?.call(message);
       } catch (e, stk) {
         debugPrint('Error while fetching message: $e, $stk');
       }

--- a/packages/stream_chat_flutter/test/src/message_list_view/bottom_row_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/bottom_row_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/src/message_widget/bottom_row.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late Channel channel;
+  late ChannelClientState channelClientState;
+
+  setUp(() {
+    channel = MockChannel();
+    when(() => channel.on(any(), any(), any(), any()))
+        .thenAnswer((_) => const Stream.empty());
+    channelClientState = MockChannelState();
+    when(() => channel.state).thenReturn(channelClientState);
+    when(() => channelClientState.messages).thenReturn([
+      Message(
+        id: 'parentId',
+      )
+    ]);
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Message());
+  });
+
+  testWidgets('BottomRow', (tester) async {
+    final theme = StreamChatThemeData.light();
+    final onThreadTap = MockVoidSingleParamCallback<Message>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: StreamChannel(
+              channel: channel,
+              child: BottomRow(
+                message: Message(
+                  parentId: 'parentId',
+                ),
+                isDeleted: false,
+                showThreadReplyIndicator: false,
+                showUsername: false,
+                showInChannel: true,
+                showTimeStamp: false,
+                reverse: false,
+                showSendingIndicator: false,
+                hasUrlAttachments: false,
+                isGiphy: false,
+                isOnlyEmoji: false,
+                messageTheme: theme.otherMessageTheme,
+                streamChatTheme: theme,
+                hasNonUrlAttachments: false,
+                streamChat: StreamChatState(),
+                onThreadTap: onThreadTap,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pumpAndSettle();
+
+    verify(() => onThreadTap.call(any()));
+  });
+}

--- a/packages/stream_chat_flutter/test/src/mocks.dart
+++ b/packages/stream_chat_flutter/test/src/mocks.dart
@@ -46,6 +46,10 @@ class MockVoidCallback extends Mock {
   void call();
 }
 
+class MockVoidSingleParamCallback<T> extends Mock {
+  void call(T param);
+}
+
 class MockAttachmentHandler extends Mock implements StreamAttachmentHandler {}
 
 class MockMember extends Mock implements Member {}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
Be lenient on the presence of `onThreadTap` paramenter in `BottomRow` component.

Error:
```
I/flutter (30434): Error while fetching message: Null check operator used on a null value, #0      BottomRow.build._onThreadTap (package:stream_chat_flutter/src/message_widget/bottom_row.dart:172:27)
```