### PR TITLE
fix(llc): reply being considered deleted if a new message was typed inside its thread

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+🐞 Fixed
+- Fixes a thread message causing reply messages on the main thread to be considered deleted
+
 ## 7.0.2
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2101,7 +2101,7 @@ class ChannelClientState {
     }));
   }
 
-  /// Updates the message in the state if it exists. Adds it otherwise.
+  /// Updates the [message] in the state if it exists. Adds it otherwise.
   void updateMessage(Message message) {
     // Determine if the message should be displayed in the channel view.
     if (message.parentId == null || message.showInChannel == true) {
@@ -2172,7 +2172,7 @@ class ChannelClientState {
   /// Updates the list of pinned messages based on the current message's
   /// pinned status.
   List<Message> _updatePinnedMessages(Message message) {
-    var newPinnedMessages = [...pinnedMessages];
+    final newPinnedMessages = [...pinnedMessages];
     final oldPinnedIndex =
         newPinnedMessages.indexWhere((m) => m.id == message.id);
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request

### Problem Description
We encountered a bug in our messaging feature where quoted messages were inadvertently marked as deleted when replying within a thread. This behavior was linked to the `updateMessage` method's logic, which inaccurately managed the state of quoted messages during updates, particularly in thread reply scenarios.

### Root Cause Analysis
The core of the issue was found in the original implementation of the `updateMessage` method within the `Channel` class. The method indiscriminately updated quoted messages whenever an updating message's ID matched that of a quoted message, leading to quoted messages being marked as deleted by mistake, simply due to their reference in updates or replies.

### Solution Implemented
The fix involved a strategic refactor of the `updateMessage` method to ensure updates to messages, especially regarding quoted messages, are handled with precision, maintaining the integrity of quoted messages unless explicitly deleted. The following key improvements were made:

1. **Preserving Quoted Messages**: Enhanced the method to verify if an updating message references a quoted message without intent to delete, preserving the quoted message's original state in such instances.

2. **Refined Deletion Logic**: Refined the approach to marking a quoted message as deleted, ensuring this only occurs with clear indications of the quoted message's deletion (e.g., when the message's type is 'deleted').

3. **Code Readability and Maintainability**: Restructured the method for improved readability, segregating concerns clearly and documenting with comments.

4. **Separate Handling for Pinned Messages**: Segregated the pinned messages handling logic into its own method, simplifying the `updateMessage` method.

### How it was 

https://github.com/GetStream/stream-chat-flutter/assets/13854934/03feb6c1-2535-46d9-b686-ebd33a898138

### How it is now

https://github.com/GetStream/stream-chat-flutter/assets/13854934/b0f4f5e2-d1b0-464b-80fd-97d2e360a0aa


