### PR TITLE
fix(ui): custom attachment builders

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ✅ Added
 
+- Added `customAttachmentBuilders` parameter for `StreamAttachmentWidgetBuilder.defaultBuilders`.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 
 ## 7.2.1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 ✅ Added
 
 - Added `customAttachmentBuilders` parameter for `StreamAttachmentWidgetBuilder.defaultBuilders`.
+- `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 
 ## 7.2.1

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
@@ -51,12 +51,12 @@ abstract class StreamAttachmentWidgetBuilder {
   /// Example:
   ///
   /// ```dart
-  /// final myBuilders = [
-  ///  ...StreamAttachmentWidgetBuilder.defaultBuilders,
-  ///  MyCustomAttachmentBuilder(),
-  ///  MyOtherCustomAttachmentBuilder(),
-  ///  ...
-  /// ];
+  ///   final myBuilders = StreamAttachmentWidgetBuilder.defaultBuilders(
+  ///     customAttachmentBuilders: [
+  ///       MyCustomAttachmentBuilder(),
+  ///       MyOtherCustomAttachmentBuilder(),
+  ///     ]
+  ///   );
   /// ```
   ///
   /// **Note**: The order of the builders in the list is important. The first

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
@@ -67,8 +67,11 @@ abstract class StreamAttachmentWidgetBuilder {
     ShapeBorder? shape,
     EdgeInsetsGeometry padding = const EdgeInsets.all(4),
     StreamAttachmentWidgetTapCallback? onAttachmentTap,
+    List<StreamAttachmentWidgetBuilder>? customAttachmentBuilders,
   }) {
     return [
+      ...?customAttachmentBuilders,
+
       // Handles a mix of image, gif, video, url and file attachments.
       MixedAttachmentBuilder(
         padding: padding,

--- a/packages/stream_chat_flutter/lib/src/message_widget/parse_attachments.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/parse_attachments.dart
@@ -104,12 +104,12 @@ class ParseAttachments extends StatelessWidget {
     };
 
     // Create a default attachmentBuilders list if not provided.
-    var builders = attachmentBuilders;
-    builders ??= StreamAttachmentWidgetBuilder.defaultBuilders(
+    final builders = StreamAttachmentWidgetBuilder.defaultBuilders(
       message: message,
       shape: attachmentShape,
       padding: attachmentPadding,
       onAttachmentTap: onAttachmentTap,
+      customAttachmentBuilders: attachmentBuilders,
     );
 
     final catalog = AttachmentWidgetCatalog(builders: builders);


### PR DESCRIPTION
PR based on #1826 

The attachment builder now expects custom attachments only and adds the attachment builders for the normal attachment types by default.

Old:

```dart
messageWidget.copyWith(
  // ....
  attachmentBuilders: [
    CustomBuilder()
    ...StreamAttachmentWidgetBuilder.defaultBuilders(message: messageDetails.message),
  ],
);
```

New:

```dart
messageWidget.copyWith(
  // ....
  attachmentBuilders: [
    CustomBuilder()
  ],
);
```

OR 

```dart
messageWidget.copyWith(
  // ....
  attachmentBuilders: [
    ...StreamAttachmentWidgetBuilder.defaultBuilders(
      message: messageDetails.message,
        customAttachmentBuilders: [
           CustomBuilder(),
        ],
     ),
  ],
);
```