### PR TITLE
fix(ui): fixes copying a message with mentions

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ✅ Added
 
+- Copying a message now replaces the User IDs with user names.
 - Exported thumbnail widgets from the package.
 - Added `customAttachmentBuilders` parameter for `StreamAttachmentWidgetBuilder.defaultBuilders`.
 - `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -808,7 +808,22 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           onClick: () {
             Navigator.of(context, rootNavigator: true).pop();
             final text = widget.message.text;
-            if (text != null) Clipboard.setData(ClipboardData(text: text));
+            String? messageToCopy;
+            for (final user in widget.message.mentionedUsers.toSet()) {
+              final userId = user.id;
+              final userName = user.name;
+              messageToCopy = text?.replaceAll(
+                    RegExp('@($userId|$userName)'),
+                    '@$userName',
+                  ) ??
+                  '';
+            }
+
+            if (messageToCopy != null) {
+              Clipboard.setData(
+                ClipboardData(text: messageToCopy),
+              );
+            }
           },
         ),
       if (shouldShowEditAction) ...[
@@ -1011,7 +1026,21 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
             ),
             onCopyTap: (message) {
               final text = message.text;
-              if (text != null) Clipboard.setData(ClipboardData(text: text));
+              String? messageToCopy;
+              for (final user in widget.message.mentionedUsers.toSet()) {
+                final userId = user.id;
+                final userName = user.name;
+                messageToCopy = text?.replaceAll(
+                      RegExp('@($userId|$userName)'),
+                      '@$userName',
+                    ) ??
+                    '';
+              }
+              if (messageToCopy != null) {
+                Clipboard.setData(
+                  ClipboardData(text: messageToCopy),
+                );
+              }
             },
             messageTheme: widget.messageTheme,
             reverse: widget.reverse,


### PR DESCRIPTION
Fixes #1929 

Currently copying a message does not replace the mentioned IDs with user names. This PR uses the same logic from the package that fixes this in the message text to fix it.