### PR TITLE
fix(core): Enable compatibility with Flutter 3.22 - Dependency override

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
 
 🔄 Changed
+
 - Forced dependency override of `audio_video_progress_bar` to version `^2.0.2` [to enable compatibility with flutter 3.22](https://github.com/GetStream/stream-chat-flutter/issues/1920).
 
 ## 7.2.1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
 
+🔄 Changed
+- Forced dependency override of `audio_video_progress_bar` to version `^2.0.2` [to enable compatibility with flutter 3.22](https://github.com/GetStream/stream-chat-flutter/issues/1920).
+
 ## 7.2.1
 
 ✅ Added

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,9 +8,6 @@
 - `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
-
-🔄 Changed
-
 - Forced dependency override of `audio_video_progress_bar` to version `^2.0.2` [to enable compatibility with flutter 3.22](https://github.com/GetStream/stream-chat-flutter/issues/1920).
 
 ## 7.2.1

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -47,6 +47,10 @@ dependencies:
   video_player: ^2.7.0
   video_thumbnail: ^0.5.3
 
+dependency_overrides:
+  # Compatibility with flutter 3.22: https://github.com/GetStream/stream-chat-flutter/issues/1920
+  audio_video_progress_bar: ^2.0.2
+
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Override the dependency of `audio_video_progress_bar` used by `dart_vlc` to solve #1920 and enable compatibility with flutter version 3.22