### PR TITLE
fix(ui): stops cached image from being used when channel image is not set

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
+- Fixed error when channel image is not set.
 
 ## 7.2.1
 

--- a/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
@@ -106,6 +106,16 @@ class StreamChannelAvatar extends StatelessWidget {
     final colorTheme = chatThemeData.colorTheme;
     final previewTheme = chatThemeData.channelPreviewTheme.avatarTheme;
 
+    final fallbackWidget = Center(
+      child: Text(
+        channel.name?[0] ?? '',
+        style: TextStyle(
+          color: colorTheme.barsBg,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+
     return BetterStreamBuilder<String>(
       stream: channel.imageStream,
       initialData: channel.image,
@@ -118,19 +128,13 @@ class StreamChannelAvatar extends StatelessWidget {
             decoration: BoxDecoration(color: colorTheme.accentPrimary),
             child: InkWell(
               onTap: onTap,
-              child: CachedNetworkImage(
-                imageUrl: channelImage,
-                errorWidget: (_, __, ___) => Center(
-                  child: Text(
-                    channel.name?[0] ?? '',
-                    style: TextStyle(
-                      color: colorTheme.barsBg,
-                      fontWeight: FontWeight.bold,
+              child: channelImage.isEmpty
+                  ? fallbackWidget
+                  : CachedNetworkImage(
+                      imageUrl: channelImage,
+                      errorWidget: (_, __, ___) => fallbackWidget,
+                      fit: BoxFit.cover,
                     ),
-                  ),
-                ),
-                fit: BoxFit.cover,
-              ),
             ),
           ),
         );


### PR DESCRIPTION
Fixes #1931

`ChannelHeader` no longer uses `CachedNetworkImage` if channel image is not set.