### PR TITLE
fix(ui): added calculation for reaction picker tail

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ✅ Added
 
-- Copying a message now replaces the User IDs with user names.
-- Exported thumbnail widgets from the package.
 - Added `customAttachmentBuilders` parameter for `StreamAttachmentWidgetBuilder.defaultBuilders`.
 - `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
+
+🐞 Fixed
+
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
 - Fixed error when channel image is not set.
+- Fixes reaction picker tail showing up unexpectedly.
+- Copying a message now replaces the User IDs with user names.
+- Exported thumbnail widgets from the package.
 
 ## 7.2.1
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `attachmentBuilders` parameter for `StreamMessageWidget` now only expects custom builders.
 - Added `StreamMediaAttachmentBuilder` widget to show media attachments in a message.
 - Added export for `message_widget_content_components.dart` to allow for easier customization of message content components.
+- Fixed error when channel image is not set.
 
 ## 7.2.1
 

--- a/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
@@ -106,6 +106,16 @@ class StreamChannelAvatar extends StatelessWidget {
     final colorTheme = chatThemeData.colorTheme;
     final previewTheme = chatThemeData.channelPreviewTheme.avatarTheme;
 
+    final fallbackWidget = Center(
+      child: Text(
+        channel.name?[0] ?? '',
+        style: TextStyle(
+          color: colorTheme.barsBg,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+
     return BetterStreamBuilder<String>(
       stream: channel.imageStream,
       initialData: channel.image,
@@ -118,19 +128,13 @@ class StreamChannelAvatar extends StatelessWidget {
             decoration: BoxDecoration(color: colorTheme.accentPrimary),
             child: InkWell(
               onTap: onTap,
-              child: CachedNetworkImage(
-                imageUrl: channelImage,
-                errorWidget: (_, __, ___) => Center(
-                  child: Text(
-                    channel.name?[0] ?? '',
-                    style: TextStyle(
-                      color: colorTheme.barsBg,
-                      fontWeight: FontWeight.bold,
+              child: channelImage.isEmpty
+                  ? fallbackWidget
+                  : CachedNetworkImage(
+                      imageUrl: channelImage,
+                      errorWidget: (_, __, ___) => fallbackWidget,
+                      fit: BoxFit.cover,
                     ),
-                  ),
-                ),
-                fit: BoxFit.cover,
-              ),
             ),
           ),
         );

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -8,6 +8,7 @@ import 'package:stream_chat_flutter/src/context_menu_items/context_menu_reaction
 import 'package:stream_chat_flutter/src/context_menu_items/stream_chat_context_menu_item.dart';
 import 'package:stream_chat_flutter/src/dialogs/dialogs.dart';
 import 'package:stream_chat_flutter/src/message_actions_modal/message_actions_modal.dart';
+import 'package:stream_chat_flutter/src/message_list_view/message_list_view.dart';
 import 'package:stream_chat_flutter/src/message_widget/message_widget_content.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -1100,7 +1101,10 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
 /// Enum for declaring the location of the message for which the reaction picker
 /// is to be enabled.
 enum ReactionTailType {
+  /// Message is in the [StreamMessageListView]
   list,
+  /// Message is in the [MessageActionsModal]
   messageActions,
+  /// Message is in the message reactions modal
   reactions,
 }

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1097,6 +1097,8 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
   }
 }
 
+/// Enum for declaring the location of the message for which the reaction picker
+/// is to be enabled.
 enum ReactionTailType {
   list,
   messageActions,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -8,7 +8,6 @@ import 'package:stream_chat_flutter/src/context_menu_items/context_menu_reaction
 import 'package:stream_chat_flutter/src/context_menu_items/stream_chat_context_menu_item.dart';
 import 'package:stream_chat_flutter/src/dialogs/dialogs.dart';
 import 'package:stream_chat_flutter/src/message_actions_modal/message_actions_modal.dart';
-import 'package:stream_chat_flutter/src/message_list_view/message_list_view.dart';
 import 'package:stream_chat_flutter/src/message_widget/message_widget_content.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -723,8 +722,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                       messageWidget: widget,
                       showBottomRow: showBottomRow,
                       showPinHighlight: widget.showPinHighlight,
-                      showReactionPickerTail:
-                          calculateReactionTailEnabled(
+                      showReactionPickerTail: calculateReactionTailEnabled(
                         ReactionTailType.list,
                       ),
                       showReactions: showReactions,
@@ -1103,8 +1101,10 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
 enum ReactionTailType {
   /// Message is in the [StreamMessageListView]
   list,
+
   /// Message is in the [MessageActionsModal]
   messageActions,
+
   /// Message is in the message reactions modal
   reactions,
 }

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -53,6 +53,7 @@ class StreamMessageWidget extends StatefulWidget {
     this.onReactionsTap,
     this.onReactionsHover,
     this.showReactionPicker = true,
+    this.showReactionTail,
     this.showUserAvatar = DisplayWidget.show,
     this.showSendingIndicator = true,
     this.showThreadReplyIndicator = false,
@@ -246,6 +247,12 @@ class StreamMessageWidget extends StatefulWidget {
   /// {@endtemplate}
   final bool showReactionPicker;
 
+  /// {@template showReactionPickerTail}
+  /// Whether or not to show the reaction picker tail.
+  /// This is calculated internally in most cases and does not need to be set.
+  /// {@endtemplate}
+  final bool? showReactionTail;
+
   /// {@template onShowMessage}
   /// Callback when show message is tapped
   /// {@endtemplate}
@@ -403,6 +410,7 @@ class StreamMessageWidget extends StatefulWidget {
     void Function(String)? onLinkTap,
     bool? showReactionBrowser,
     bool? showReactionPicker,
+    bool? showReactionTail,
     List<Read>? readList,
     ShowMessageCallback? onShowMessage,
     bool? showUsername,
@@ -465,6 +473,7 @@ class StreamMessageWidget extends StatefulWidget {
       onUserAvatarTap: onUserAvatarTap ?? this.onUserAvatarTap,
       onLinkTap: onLinkTap ?? this.onLinkTap,
       showReactionPicker: showReactionPicker ?? this.showReactionPicker,
+      showReactionTail: showReactionTail ?? this.showReactionTail,
       onShowMessage: onShowMessage ?? this.onShowMessage,
       showUsername: showUsername ?? this.showUsername,
       showTimestamp: showTimestamp ?? this.showTimestamp,
@@ -713,7 +722,10 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                       messageWidget: widget,
                       showBottomRow: showBottomRow,
                       showPinHighlight: widget.showPinHighlight,
-                      showReactionPickerTail: widget.showReactionPicker,
+                      showReactionPickerTail:
+                          calculateReactionTailEnabled(
+                        ReactionTailType.list,
+                      ),
                       showReactions: showReactions,
                       onReactionsTap: () {
                         widget.onReactionsTap != null
@@ -958,6 +970,9 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                   : widget.message.text,
             ),
             showReactions: false,
+            showReactionTail: calculateReactionTailEnabled(
+              ReactionTailType.reactions,
+            ),
             showUsername: false,
             showTimestamp: false,
             translateUserAvatar: false,
@@ -1011,6 +1026,9 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                     : widget.message.text,
               ),
               showReactions: false,
+              showReactionTail: calculateReactionTailEnabled(
+                ReactionTailType.messageActions,
+              ),
               showUsername: false,
               showTimestamp: false,
               translateUserAvatar: false,
@@ -1063,4 +1081,24 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
       },
     );
   }
+
+  /// Calculates if the reaction picker tail should be enabled.
+  bool calculateReactionTailEnabled(ReactionTailType type) {
+    if (widget.showReactionTail != null) return widget.showReactionTail!;
+
+    switch (type) {
+      case ReactionTailType.list:
+        return false;
+      case ReactionTailType.messageActions:
+        return widget.showReactionPicker;
+      case ReactionTailType.reactions:
+        return widget.showReactionPicker;
+    }
+  }
+}
+
+enum ReactionTailType {
+  list,
+  messageActions,
+  reactions,
 }


### PR DESCRIPTION
Fixes #1879 

Reaction picker tails are currently visible in the list view and also show when reaction picker is disabled. This PR exposes a new property for enabling and disabling the tail as well as a default calculation for when the tail should be enabled.