### PR TITLE
fix(repo): switch to media_kit

### DIFF
--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1714,8 +1714,6 @@ class ClientState {
   /// The current user as a stream
   Stream<OwnUser?> get currentUserStream => _currentUserController.stream;
 
-  // coverage:ignore-end
-
   /// The current user
   Map<String, User> get users => _usersController.value;
 

--- a/packages/stream_chat_flutter/lib/src/video/vlc/vlc_manager_desktop.dart
+++ b/packages/stream_chat_flutter/lib/src/video/vlc/vlc_manager_desktop.dart
@@ -1,11 +1,11 @@
-import 'package:dart_vlc/dart_vlc.dart';
+import 'package:media_kit/media_kit.dart';
 import 'package:stream_chat_flutter/src/video/vlc/vlc_manager.dart';
 
 /// The desktop implementation of [VlcManager]. It simply initializes VLC.
 class VlcManagerDesktop extends VlcManager {
   @override
   void initialize() {
-    DartVLC.initialize();
+    MediaKit.ensureInitialized();
   }
 }
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   chewie: ^1.8.1
   collection: ^1.17.2
   contextmenu: ^3.0.0
-  dart_vlc: ^0.4.0
+  # dart_vlc: ^0.4.0
+  media_kit: ^1.1.10+1
   desktop_drop: ^0.4.4
   diacritic: ^0.1.5
   dio: ^5.4.3+1
@@ -46,6 +47,7 @@ dependencies:
   url_launcher: ^6.3.0
   video_player: ^2.8.7
   video_thumbnail: ^0.5.3
+  media_kit_video: ^1.2.4
 
 flutter:
   plugin:


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Switched to `media_kit` because `dart_vlc` is deprecated.
