### PR TITLE
feat(ui): add showFailedIndicator parameter into StreamMessageWidget

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -146,6 +146,10 @@
 
 ## 8.0.0
 
+✅ Added
+
+- Added `showFailedIndicator` parameter for `StreamMessageWidget` to toggle displaying the failed message icon.
+
 🐞 Fixed
 
 - Fixed null errors in web from markdown.

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
@@ -29,6 +29,7 @@ class MessageCard extends StatefulWidget {
     required this.attachmentActionsModalBuilder,
     required this.textPadding,
     required this.reverse,
+    required this.showFailedIndicator,
     this.shape,
     this.borderSide,
     this.borderRadiusGeometry,
@@ -120,6 +121,9 @@ class MessageCard extends StatefulWidget {
   /// {@macro reverse}
   final bool reverse;
 
+  /// {@macro showFailedIndicator}
+  final bool showFailedIndicator;
+
   @override
   State<MessageCard> createState() => _MessageCardState();
 }
@@ -165,8 +169,9 @@ class _MessageCardState extends State<MessageCard> {
     return Container(
       constraints: const BoxConstraints().copyWith(maxWidth: widthLimit),
       margin: EdgeInsets.symmetric(
-        horizontal: (widget.isFailedState ? 15.0 : 0.0) +
-            (widget.showUserAvatar == DisplayWidget.gone ? 0 : 4.0),
+        horizontal:
+            (widget.isFailedState && widget.showFailedIndicator ? 15.0 : 0.0) +
+                (widget.showUserAvatar == DisplayWidget.gone ? 0 : 4.0),
       ),
       clipBehavior: Clip.hardEdge,
       decoration: ShapeDecoration(

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -451,6 +451,7 @@ class StreamMessageWidget extends StatefulWidget {
     String? imageAttachmentThumbnailResizeType,
     String? imageAttachmentThumbnailCropType,
     AttachmentActionsBuilder? attachmentActionsModalBuilder,
+    bool? showFailedIndicator
   }) {
     return StreamMessageWidget(
       key: key ?? this.key,
@@ -520,6 +521,7 @@ class StreamMessageWidget extends StatefulWidget {
           this.imageAttachmentThumbnailCropType,
       attachmentActionsModalBuilder:
           attachmentActionsModalBuilder ?? this.attachmentActionsModalBuilder,
+      showFailedIndicator: showFailedIndicator ?? this.showFailedIndicator,
     );
   }
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -99,6 +99,7 @@ class StreamMessageWidget extends StatefulWidget {
     this.imageAttachmentThumbnailResizeType = 'clip',
     this.imageAttachmentThumbnailCropType = 'center',
     this.attachmentActionsModalBuilder,
+    this.showFailedIndicator = true,
   });
 
   /// {@template onMentionTap}
@@ -380,6 +381,11 @@ class StreamMessageWidget extends StatefulWidget {
   final String /*center|top|bottom|left|right*/
       imageAttachmentThumbnailCropType;
 
+  /// {@template showFailedIndicator}
+  /// Show the failed message indicator
+  /// {@endtemplate}
+  final bool showFailedIndicator;
+
   /// {@template copyWith}
   /// Creates a copy of [StreamMessageWidget] with specified attributes
   /// overridden.
@@ -641,6 +647,8 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
 
   bool get shouldShowDeleteAction => widget.showDeleteMessage || isDeleteFailed;
 
+  bool get showFailedIndicator => widget.showFailedIndicator;
+
   @override
   bool get wantKeepAlive => widget.message.attachments.isNotEmpty;
 
@@ -764,6 +772,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
                           widget.bottomRowBuilderWithDefaultWidget,
                       onUserAvatarTap: widget.onUserAvatarTap,
                       userAvatarBuilder: widget.userAvatarBuilder,
+                      showFailedIndicator: showFailedIndicator,
                     );
                   }),
                 ),

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
@@ -334,6 +334,8 @@ class MessageWidgetContent extends StatelessWidget {
                                     : MessageCard(
                                         message: message,
                                         isFailedState: isFailedState,
+                                        showFailedIndicator:
+                                            showFailedIndicator,
                                         showUserAvatar: showUserAvatar,
                                         messageTheme: messageTheme,
                                         hasQuotedMessage: hasQuotedMessage,

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
@@ -65,6 +65,7 @@ class MessageWidgetContent extends StatelessWidget {
     required this.showEditedLabel,
     required this.messageWidget,
     required this.onThreadTap,
+    required this.showFailedIndicator,
     this.onUserAvatarTap,
     this.borderRadiusGeometry,
     this.borderSide,
@@ -227,6 +228,9 @@ class MessageWidgetContent extends StatelessWidget {
 
   /// {@macro userAvatarBuilder}
   final Widget Function(BuildContext, User)? userAvatarBuilder;
+
+  /// {@macro showFailedIndicator}
+  final bool showFailedIndicator;
 
   @override
   Widget build(BuildContext context) {
@@ -421,7 +425,7 @@ class MessageWidgetContent extends StatelessWidget {
                 ],
               ),
             ),
-            if (isFailedState)
+            if (isFailedState && showFailedIndicator)
               Positioned(
                 right: reverse ? 0 : null,
                 left: reverse ? null : 0,


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR added `showFailedIndicator` parameter into StreamMessageWidget to toggle displaying the failed message icon.