### PR TITLE
fix(ui): added option to use native picker for mobile

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Added option to use the native attachment picker on mobile
+
 ## 8.0.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
@@ -78,6 +78,7 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
+  bool useNativeAttachmentPickerOnMobile = false,
   RouteSettings? routeSettings,
   AnimationController? transitionAnimationController,
   Clip? clipBehavior = Clip.hardEdge,
@@ -115,7 +116,7 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
               currentPlatform == TargetPlatform.linux ||
               currentPlatform == TargetPlatform.windows;
 
-          if (isWebOrDesktop) {
+          if (isWebOrDesktop || useNativeAttachmentPickerOnMobile) {
             return webOrDesktopAttachmentPickerBuilder.call(
               context: context,
               onError: onError,

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -151,6 +151,7 @@ class StreamMessageInput extends StatefulWidget {
     this.ogPreviewFilter = _defaultOgPreviewFilter,
     this.hintGetter = _defaultHintGetter,
     this.contentInsertionConfiguration,
+    this.useNativeAttachmentPickerOnMobile = false,
   });
 
   /// The predicate used to send a message on desktop/web
@@ -345,6 +346,9 @@ class StreamMessageInput extends StatefulWidget {
 
   /// {@macro flutter.widgets.editableText.contentInsertionConfiguration}
   final ContentInsertionConfiguration? contentInsertionConfiguration;
+
+  /// Use native attachment picker on mobile instead of the inbuilt attachment picker
+  final bool useNativeAttachmentPickerOnMobile;
 
   static String? _defaultHintGetter(
     BuildContext context,
@@ -851,6 +855,8 @@ class StreamMessageInputState extends State<StreamMessageInput>
       onError: widget.onError,
       allowedTypes: widget.allowedAttachmentPickerTypes,
       initialAttachments: _effectiveController.attachments,
+      useNativeAttachmentPickerOnMobile:
+          widget.useNativeAttachmentPickerOnMobile,
     );
 
     if (attachments != null) {

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -347,7 +347,8 @@ class StreamMessageInput extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.contentInsertionConfiguration}
   final ContentInsertionConfiguration? contentInsertionConfiguration;
 
-  /// Use native attachment picker on mobile instead of the inbuilt attachment picker
+  /// Forces use of native attachment picker on mobile instead of the custom
+  /// Stream attachment picker.
   final bool useNativeAttachmentPickerOnMobile;
 
   static String? _defaultHintGetter(


### PR DESCRIPTION
Adds the `useNativePickerOnMobile` boolean to force use of native picker on mobile platforms.