### PR TITLE
fix(ui, localization): remove redundant platform configuration

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 🐞 Fixed
 
+- [[#2055]](https://github.com/GetStream/stream-chat-flutter/issues/2055) Fixed default plugin warnings.
+
 - [[#2030]](https://github.com/GetStream/stream-chat-flutter/issues/2030) Fixed `video_thumbnail`
   Namespace not specified.
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -49,21 +49,6 @@ dependencies:
   video_player: ^2.8.7
 
 flutter:
-  plugin:
-    platforms:
-      android:
-        default_package: stream_chat_flutter
-      ios:
-        default_package: stream_chat_flutter
-      windows:
-        default_package: stream_chat_flutter
-      linux:
-        default_package: stream_chat_flutter
-      macos:
-        default_package: stream_chat_flutter
-      web:
-        default_package: stream_chat_flutter
-
   assets:
     - images/
     - svgs/

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#2055]](https://github.com/GetStream/stream-chat-flutter/issues/2055) Fixed default plugin warnings.
+
 ## 8.2.0
 
 - Updated `stream_chat_flutter` dependency to [`8.2.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_localizations/pubspec.yaml
+++ b/packages/stream_chat_localizations/pubspec.yaml
@@ -19,19 +19,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:
-  plugin:
-    platforms:
-      android:
-        default_package: stream_chat_localizations
-      ios:
-        default_package: stream_chat_localizations
-      windows:
-        default_package: stream_chat_localizations
-      linux:
-        default_package: stream_chat_localizations
-      macos:
-        default_package: stream_chat_localizations
-      web:
-        default_package: stream_chat_localizations


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

```
Package stream_chat_flutter:windows references stream_chat_flutter:windows as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of stream_chat_flutter to either avoid referencing a default implementation via `platforms: windows: default_package: stream_chat_flutter` or add an inline implementation to stream_chat_flutter via `platforms: windows:` `pluginClass` or `dartPluginClass`.
Package stream_chat_flutter:android references stream_chat_flutter:android as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of stream_chat_flutter to either avoid referencing a default implementation via `platforms: android: default_package: stream_chat_flutter` or add an inline implementation to stream_chat_flutter via `platforms: android:` `pluginClass` or `dartPluginClass`.
Package stream_chat_flutter:ios references stream_chat_flutter:ios as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of stream_chat_flutter to either avoid referencing a default implementation via `platforms: ios: default_package: stream_chat_flutter` or add an inline implementation to stream_chat_flutter via `platforms: ios:` `pluginClass` or `dartPluginClass`.
Package stream_chat_flutter:linux references stream_chat_flutter:linux as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of stream_chat_flutter to either avoid referencing a default implementation via `platforms: linux: default_package: stream_chat_flutter` or add an inline implementation to stream_chat_flutter via `platforms: linux:` `pluginClass` or `dartPluginClass`.
Package stream_chat_flutter:macos references stream_chat_flutter:macos as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of stream_chat_flutter to either avoid referencing a default implementation via `platforms: macos: default_package: stream_chat_flutter` or add an inline implementation to stream_chat_flutter via `platforms: macos:` `pluginClass` or `dartPluginClass`.
Package stream_chat_flutter:windows references stream_chat_flutter:windows as the default plugin, but it does not provide an inline implementation.
```


Similar to:

- https://github.com/MaikuB/flutter_local_notifications/issues/2368
- https://github.com/Abdelazeem777/cached_network_svg_image/pull/12/files