### PR TITLE
feat(llc): add AI events

### DIFF
--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -1158,6 +1158,16 @@ class Channel {
     }
   }
 
+  /// Sends an event to stop AI response generation, leaving the message in
+  /// its current state.
+  Future<EmptyResponse> stopAIResponse() async {
+    return sendEvent(
+      Event(
+        type: EventType.aiIndicatorStop,
+      ),
+    );
+  }
+
   /// Update the channel's [name].
   ///
   /// This is the same as calling [updatePartial] and providing a map with a
@@ -1961,8 +1971,8 @@ class ChannelClientState {
           final existingWatchers = channelState.watchers;
           updateChannelState(channelState.copyWith(
             watchers: [
-              ...?existingWatchers,
               watcher,
+              ...?existingWatchers?.where((user) => user.id != watcher.id),
             ],
           ));
         }
@@ -1977,9 +1987,9 @@ class ChannelClientState {
         if (watcher != null) {
           final existingWatchers = channelState.watchers;
           updateChannelState(channelState.copyWith(
-            watchers: existingWatchers
-                ?.where((user) => user.id != watcher.id)
-                .toList(growable: false),
+            watchers: [
+              ...?existingWatchers?.where((user) => user.id != watcher.id)
+            ],
           ));
         }
       }),
@@ -2367,7 +2377,7 @@ class ChannelClientState {
         channelStateStream.map((cs) => cs.members),
         _channel.client.state.usersStream,
         (members, users) =>
-            members!.map((e) => e!.copyWith(user: users[e.user!.id])).toList(),
+            [...?members?.map((e) => e!.copyWith(user: users[e.user!.id]))],
       ).distinct(const ListEquality().equals);
 
   /// Channel watcher count.
@@ -2387,7 +2397,7 @@ class ChannelClientState {
           List<User>?, Map<String?, User?>, List<User>>(
         channelStateStream.map((cs) => cs.watchers),
         _channel.client.state.usersStream,
-        (watchers, users) => watchers!.map((e) => users[e.id] ?? e).toList(),
+        (watchers, users) => [...?watchers?.map((e) => users[e.id] ?? e)],
       ).distinct(const ListEquality().equals);
 
   /// Channel member for the current user.

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -26,6 +26,9 @@ class Event {
     this.channelType,
     this.parentId,
     this.hardDelete,
+    this.aiState,
+    this.aiMessage,
+    this.messageId,
     this.extraData = const {},
     this.isLocal = true,
   }) : createdAt = createdAt?.toUtc() ?? DateTime.now().toUtc();
@@ -94,6 +97,16 @@ class Event {
   @JsonKey(includeIfNull: false)
   final bool? hardDelete;
 
+  /// The current state of the AI assistant.
+  @JsonKey(unknownEnumValue: AITypingState.idle)
+  final AITypingState? aiState;
+
+  /// Additional message from the AI assistant.
+  final String? aiMessage;
+
+  /// The message id to which the event belongs.
+  final String? messageId;
+
   /// Map of custom channel extraData
   final Map<String, Object?> extraData;
 
@@ -136,6 +149,9 @@ class Event {
     'parent_id',
     'hard_delete',
     'is_local',
+    'ai_state',
+    'ai_message',
+    'message_id',
   ];
 
   /// Serialize to json
@@ -162,6 +178,9 @@ class Event {
     bool? online,
     String? parentId,
     bool? hardDelete,
+    AITypingState? aiState,
+    String? aiMessage,
+    String? messageId,
     Map<String, Object?>? extraData,
   }) =>
       Event(
@@ -183,14 +202,15 @@ class Event {
         parentId: parentId ?? this.parentId,
         hardDelete: hardDelete ?? this.hardDelete,
         extraData: extraData ?? this.extraData,
+        aiState: aiState ?? this.aiState,
+        aiMessage: aiMessage ?? this.aiMessage,
+        messageId: messageId ?? this.messageId,
         isLocal: isLocal,
       );
 }
 
 /// The channel embedded in the event object
-@JsonSerializable(
-  createToJson: false,
-)
+@JsonSerializable(createToJson: false)
 class EventChannel extends ChannelModel {
   /// Constructor used for json serialization
   EventChannel({
@@ -207,12 +227,12 @@ class EventChannel extends ChannelModel {
     required DateTime super.updatedAt,
     super.deletedAt,
     super.memberCount,
-    Map<String, Object?>? extraData,
     super.cooldown,
     super.team,
     super.disabled,
     super.hidden,
     super.truncatedAt,
+    Map<String, Object?>? extraData,
   }) : super(extraData: extraData ?? {});
 
   /// Create a new instance from a json
@@ -231,4 +251,32 @@ class EventChannel extends ChannelModel {
     'members',
     ...ChannelModel.topLevelFields,
   ];
+}
+
+/// {@template aiState}
+/// The current typing state of the AI assistant.
+///
+/// This is used to determine the state of the AI assistant when it's generating
+/// a response for the provided query.
+/// {@endtemplate}
+enum AITypingState {
+  /// The AI assistant is idle.
+  @JsonValue('AI_STATE_IDLE')
+  idle,
+
+  /// The AI assistant is in an error state.
+  @JsonValue('AI_STATE_ERROR')
+  error,
+
+  /// The AI assistant is checking external sources.
+  @JsonValue('AI_STATE_CHECKING_SOURCES')
+  checkingSources,
+
+  /// The AI assistant is thinking.
+  @JsonValue('AI_STATE_THINKING')
+  thinking,
+
+  /// The AI assistant is generating a response.
+  @JsonValue('AI_STATE_GENERATING')
+  generating,
 }

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -38,6 +38,10 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
       channelType: json['channel_type'] as String?,
       parentId: json['parent_id'] as String?,
       hardDelete: json['hard_delete'] as bool?,
+      aiState: $enumDecodeNullable(_$AITypingStateEnumMap, json['ai_state'],
+          unknownValue: AITypingState.idle),
+      aiMessage: json['ai_message'] as String?,
+      messageId: json['message_id'] as String?,
       extraData: json['extra_data'] as Map<String, dynamic>? ?? const {},
       isLocal: json['is_local'] as bool? ?? false,
     );
@@ -70,9 +74,20 @@ Map<String, dynamic> _$EventToJson(Event instance) {
   }
 
   writeNotNull('hard_delete', instance.hardDelete);
+  val['ai_state'] = _$AITypingStateEnumMap[instance.aiState];
+  val['ai_message'] = instance.aiMessage;
+  val['message_id'] = instance.messageId;
   val['extra_data'] = instance.extraData;
   return val;
 }
+
+const _$AITypingStateEnumMap = {
+  AITypingState.idle: 'AI_STATE_IDLE',
+  AITypingState.error: 'AI_STATE_ERROR',
+  AITypingState.checkingSources: 'AI_STATE_CHECKING_SOURCES',
+  AITypingState.thinking: 'AI_STATE_THINKING',
+  AITypingState.generating: 'AI_STATE_GENERATING',
+};
 
 EventChannel _$EventChannelFromJson(Map<String, dynamic> json) => EventChannel(
       members: (json['members'] as List<dynamic>?)
@@ -98,7 +113,7 @@ EventChannel _$EventChannelFromJson(Map<String, dynamic> json) => EventChannel(
           ? null
           : DateTime.parse(json['deleted_at'] as String),
       memberCount: (json['member_count'] as num?)?.toInt() ?? 0,
-      extraData: json['extra_data'] as Map<String, dynamic>?,
       cooldown: (json['cooldown'] as num?)?.toInt() ?? 0,
       team: json['team'] as String?,
+      extraData: json['extra_data'] as Map<String, dynamic>?,
     );

--- a/packages/stream_chat/lib/src/event_type.dart
+++ b/packages/stream_chat/lib/src/event_type.dart
@@ -112,4 +112,13 @@ class EventType {
 
   /// Event sent when the user's mutes list is updated
   static const String notificationMutesUpdated = 'notification.mutes_updated';
+
+  /// Event sent when the AI indicator is updated
+  static const String aiIndicatorUpdate = 'ai_indicator.update';
+
+  /// Event sent when the AI indicator is stopped
+  static const String aiIndicatorStop = 'ai_indicator.stop';
+
+  /// Event sent when the AI indicator is cleared
+  static const String aiIndicatorClear = 'ai_indicator.clear';
 }


### PR DESCRIPTION
This pull request introduces several changes to the `stream_chat` package, primarily focusing on adding support for AI assistant states and enhancing watcher handling in channels. The most important changes include adding new AI-related fields and methods, updating the handling of channel watchers, and modifying the `Event` class to support AI states.

### AI Assistant Integration:

* [`packages/stream_chat/lib/src/client/channel.dart`](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbR1161-R1170): Added a new method `stopAIResponse` to send an event to stop AI response generation.
* [`packages/stream_chat/lib/src/core/models/event.dart`](diffhunk://#diff-a8691c1f219d39a00e1a92f5c7be36c9253bb40f306a5901293f58ced64169fdR100-R109): Introduced new fields `aiState`, `aiMessage`, and `messageId` to the `Event` class to track the AI assistant's state and messages. [[1]](diffhunk://#diff-a8691c1f219d39a00e1a92f5c7be36c9253bb40f306a5901293f58ced64169fdR100-R109) [[2]](diffhunk://#diff-a8691c1f219d39a00e1a92f5c7be36c9253bb40f306a5901293f58ced64169fdR152-R154) [[3]](diffhunk://#diff-a8691c1f219d39a00e1a92f5c7be36c9253bb40f306a5901293f58ced64169fdR181-R183) [[4]](diffhunk://#diff-a8691c1f219d39a00e1a92f5c7be36c9253bb40f306a5901293f58ced64169fdR205-R213)
* [`packages/stream_chat/lib/src/event_type.dart`](diffhunk://#diff-d071e187462ae688fb1a2edb8bd0aa24133609c4611f9c38ed8ba13fcba3447eR115-R123): Added new event types for AI indicator updates, stops, and clears.

### Channel Watcher Handling:

* [`packages/stream_chat/lib/src/client/channel.dart`](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL1964-R1975): Improved the logic for updating the list of channel watchers to avoid duplicates and ensure proper state updates. [[1]](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL1964-R1975) [[2]](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL1980-R1992) [[3]](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL2370-R2380) [[4]](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL2390-R2400)

### Serialization Updates:

* [`packages/stream_chat/lib/src/core/models/event.g.dart`](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441R41-R44): Updated serialization logic to include the new AI-related fields in the `Event` class. [[1]](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441R41-R44) [[2]](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441R77-R91) [[3]](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441L101-R118)

These changes enhance the functionality of the `stream_chat` package by integrating AI assistant features and improving the handling of channel watchers.