### PR TITLE
chore(repo): add .gitattributes to skip generated files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+# Skip generated files from showing up in diffs.
 **/*.g.dart linguist-generated=true
 **/*.freezed.dart linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/*.g.dart linguist-generated=true
+**/*.freezed.dart linguist-generated=true


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file to improve the handling of generated files in diffs. The change ensures that generated files are skipped from showing up in diffs.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R3): Added rules to mark `*.g.dart` and `*.freezed.dart` files as generated, preventing them from appearing in diffs.