### PR TITLE
ci(repo): update min coverage for llc

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -112,7 +112,7 @@ jobs:
         uses: VeryGoodOpenSource/very_good_coverage@v3.0.0
         with:
           path: packages/stream_chat/coverage/lcov.info
-          min_coverage: 79
+          min_coverage: 70
       - name: "Stream Chat Localizations Coverage Check"
         uses: VeryGoodOpenSource/very_good_coverage@v3.0.0
         with:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/stream_flutter_workflow.yml` file. The change reduces the minimum coverage threshold for the Stream Chat package from 79% to 70%.

* [`.github/workflows/stream_flutter_workflow.yml`](diffhunk://#diff-9960b9c55cd9e93e8569eeff325f7266be775b264b2fb1a4fda10ead963bf694L115-R115): Reduced the `min_coverage` value from 79 to 70 for the Stream Chat package.