### PR TITLE
fix(ui): workaround for `cached_network_image` on web.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.1.1
+
+🐞 Fixed
+
+- [[#2067]](https://github.com/GetStream/stream-chat-flutter/issues/2067) Fixed Cached Network Image not working in Flutter 3.27 web. Temporary workaround.
+
 ## 9.1.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/giphy_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/giphy_attachment_thumbnail.dart
@@ -71,6 +71,7 @@ class StreamGiphyAttachmentThumbnail extends StatelessWidget {
     }
 
     return CachedNetworkImage(
+      imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
       imageUrl: info.url,
       width: width,
       height: height,

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/giphy_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/giphy_attachment_thumbnail.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/image_attachment_thumbnail.dart';

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
@@ -1,6 +1,7 @@
 import 'dart:io' show File;
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/thumbnail_error.dart';

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
@@ -179,6 +179,7 @@ class _RemoteImageAttachment extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CachedNetworkImage(
+      imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
       imageUrl: url,
       width: width,
       height: height,

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/video_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/video_attachment_thumbnail.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/thumbnail_error.dart';

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/video_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/video_attachment_thumbnail.dart
@@ -57,6 +57,7 @@ class StreamVideoAttachmentThumbnail extends StatelessWidget {
     final thumbUrl = video.thumbUrl;
     if (thumbUrl != null) {
       return CachedNetworkImage(
+        imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
         imageUrl: thumbUrl,
         width: width,
         height: height,

--- a/packages/stream_chat_flutter/lib/src/avatars/user_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/avatars/user_avatar.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 

--- a/packages/stream_chat_flutter/lib/src/avatars/user_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/avatars/user_avatar.dart
@@ -98,6 +98,7 @@ class StreamUserAvatar extends StatelessWidget {
             streamChatTheme.ownMessageTheme.avatarTheme?.constraints,
         child: hasImage
             ? CachedNetworkImage(
+                imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
                 fit: BoxFit.cover,
                 filterQuality: FilterQuality.high,
                 imageUrl: user.image!,

--- a/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 

--- a/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_channel_avatar.dart
@@ -131,6 +131,7 @@ class StreamChannelAvatar extends StatelessWidget {
               child: channelImage.isEmpty
                   ? fallbackWidget
                   : CachedNetworkImage(
+                      imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
                       imageUrl: channelImage,
                       errorWidget: (_, __, ___) => fallbackWidget,
                       fit: BoxFit.cover,

--- a/packages/stream_chat_flutter/lib/src/gallery/gallery_footer.dart
+++ b/packages/stream_chat_flutter/lib/src/gallery/gallery_footer.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';

--- a/packages/stream_chat_flutter/lib/src/gallery/gallery_footer.dart
+++ b/packages/stream_chat_flutter/lib/src/gallery/gallery_footer.dart
@@ -240,6 +240,7 @@ class _StreamGalleryFooterState extends State<StreamGalleryFooter> {
                           child: AspectRatio(
                             aspectRatio: 1,
                             child: CachedNetworkImage(
+                              imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
                               imageUrl: attachment.imageUrl ??
                                   attachment.assetUrl ??
                                   attachment.thumbUrl!,

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK. Build your own chat experience using Dart and Flutter.
-version: 9.1.0
+version: 9.1.1
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -22,7 +22,8 @@ environment:
   flutter: ">=3.24.5"
 
 dependencies:
-  cached_network_image: ^3.3.1
+  cached_network_image: ^3.4.1
+  cached_network_image_platform_interface: ^4.1.1
   chewie: ^1.8.1
   collection: ^1.17.2
   contextmenu: ^3.0.0


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
- [ ] fixes #2067
Wasm based Flutter web engine has image loading `cors` issue. This patch is temporary workaround for `cached_network_image` package until Flutter or `cached_network_image` will be fixed.