### PR TITLE
fix(ui): fix StreamChannel not available in various poll dialogs

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -95,6 +95,9 @@ jobs:
           channel: stable
           cache: true
           cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+      # This step is needed due to https://github.com/actions/runner-images/issues/11279
+      - name: Install SQLite3
+        run: sudo apt-get update && sudo apt-get install -y sqlite3 libsqlite3-dev
       - name: "Install Tools"
         run: |
           flutter pub global activate melos

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `StreamChannel` not available in the widget tree for various Poll options.
+
 ## 9.1.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 🐞 Fixed
 
-- Fixed `StreamChannel` not available in the widget tree for various Poll options.
+- Fixed `StreamChannel` not available in the widget tree for various poll-related dialogs.
 
 ## 9.1.0
 

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_comments_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_comments_dialog.dart
@@ -21,31 +21,34 @@ Future<T?> showStreamPollCommentsDialog<T extends Object?>({
   return navigator.push(
     MaterialPageRoute(
       fullscreenDialog: true,
-      builder: (_) => ValueListenableBuilder(
-        valueListenable: messageNotifier,
-        builder: (context, message, child) {
-          final poll = message.poll;
-          if (poll == null) return const SizedBox.shrink();
+      builder: (_) => StreamChannel(
+        channel: StreamChannel.of(context).channel,
+        child: ValueListenableBuilder(
+          valueListenable: messageNotifier,
+          builder: (context, message, child) {
+            final poll = message.poll;
+            if (poll == null) return const SizedBox.shrink();
 
-          final channel = StreamChannel.of(context).channel;
+            final channel = StreamChannel.of(context).channel;
 
-          Future<void> onUpdateComment() async {
-            final commentText = await showPollAddCommentDialog(
-              context: context,
-              // We use the first answer as the initial value because the
-              // user can only add one comment per poll.
-              initialValue: poll.ownAnswers.firstOrNull?.answerText ?? '',
+            Future<void> onUpdateComment() async {
+              final commentText = await showPollAddCommentDialog(
+                context: context,
+                // We use the first answer as the initial value because the
+                // user can only add one comment per poll.
+                initialValue: poll.ownAnswers.firstOrNull?.answerText ?? '',
+              );
+
+              if (commentText == null) return;
+              channel.addPollAnswer(message, poll, answerText: commentText);
+            }
+
+            return StreamPollCommentsDialog(
+              poll: poll,
+              onUpdateComment: onUpdateComment,
             );
-
-            if (commentText == null) return;
-            channel.addPollAnswer(message, poll, answerText: commentText);
-          }
-
-          return StreamPollCommentsDialog(
-            poll: poll,
-            onUpdateComment: onUpdateComment,
-          );
-        },
+          },
+        ),
       ),
     ),
   );

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_option_votes_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_option_votes_dialog.dart
@@ -20,19 +20,22 @@ Future<T?> showStreamPollOptionVotesDialog<T extends Object?>({
   return navigator.push(
     MaterialPageRoute(
       fullscreenDialog: true,
-      builder: (_) => ValueListenableBuilder(
-        valueListenable: messageNotifier,
-        builder: (context, message, child) {
-          final poll = message.poll;
-          if (poll == null) return const SizedBox.shrink();
-          if (option.id == null) return const SizedBox.shrink();
+      builder: (_) => StreamChannel(
+        channel: StreamChannel.of(context).channel,
+        child: ValueListenableBuilder(
+          valueListenable: messageNotifier,
+          builder: (context, message, child) {
+            final poll = message.poll;
+            if (poll == null) return const SizedBox.shrink();
+            if (option.id == null) return const SizedBox.shrink();
 
-          return StreamPollOptionVotesDialog(
-            poll: poll,
-            option: option,
-            pollVotesCount: poll.voteCountsByOption[option.id],
-          );
-        },
+            return StreamPollOptionVotesDialog(
+              poll: poll,
+              option: option,
+              pollVotesCount: poll.voteCountsByOption[option.id],
+            );
+          },
+        ),
       ),
     ),
   );

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_options_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_options_dialog.dart
@@ -18,8 +18,9 @@ Future<T?> showStreamPollOptionsDialog<T extends Object?>({
   return navigator.push(
     MaterialPageRoute(
       fullscreenDialog: true,
-      builder: (context) {
-        return ValueListenableBuilder(
+      builder: (_) => StreamChannel(
+        channel: StreamChannel.of(context).channel,
+        child: ValueListenableBuilder(
           valueListenable: messageNotifier,
           builder: (context, message, child) {
             final poll = message.poll;
@@ -41,8 +42,8 @@ Future<T?> showStreamPollOptionsDialog<T extends Object?>({
               onRemoveVote: onRemoveVote,
             );
           },
-        );
-      },
+        ),
+      ),
     ),
   );
 }

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_results_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_results_dialog.dart
@@ -29,26 +29,29 @@ Future<T?> showStreamPollResultsDialog<T extends Object?>({
   return navigator.push(
     MaterialPageRoute(
       fullscreenDialog: true,
-      builder: (_) => ValueListenableBuilder(
-        valueListenable: messageNotifier,
-        builder: (context, message, child) {
-          final poll = message.poll;
-          if (poll == null) return const SizedBox.shrink();
+      builder: (_) => StreamChannel(
+        channel: StreamChannel.of(context).channel,
+        child: ValueListenableBuilder(
+          valueListenable: messageNotifier,
+          builder: (context, message, child) {
+            final poll = message.poll;
+            if (poll == null) return const SizedBox.shrink();
 
-          void onShowAllVotesPressed(PollOption option) {
-            showStreamPollOptionVotesDialog(
-              context: context,
-              messageNotifier: messageNotifier,
-              option: option,
+            void onShowAllVotesPressed(PollOption option) {
+              showStreamPollOptionVotesDialog(
+                context: context,
+                messageNotifier: messageNotifier,
+                option: option,
+              );
+            }
+
+            return StreamPollResultsDialog(
+              poll: poll,
+              visibleVotesCount: 5,
+              onShowAllVotesPressed: onShowAllVotesPressed,
             );
-          }
-
-          return StreamPollResultsDialog(
-            poll: poll,
-            visibleVotesCount: 5,
-            onShowAllVotesPressed: onShowAllVotesPressed,
-          );
-        },
+          },
+        ),
       ),
     ),
   );


### PR DESCRIPTION
This pull request addresses a bug fix in the `stream_chat_flutter` package, ensuring that the `StreamChannel` is properly available in the widget tree for various poll-related dialogs. The changes primarily involve wrapping the `ValueListenableBuilder` in a `StreamChannel` widget to provide the necessary context.

Bug Fixes:

* [`packages/stream_chat_flutter/CHANGELOG.md`](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R1-R6): Added a note about the fix for `StreamChannel` not being available in the widget tree for various poll options.

Poll Dialogs:

* [`packages/stream_chat_flutter/lib/src/poll/stream_poll_comments_dialog.dart`](diffhunk://#diff-db24a6040b0156cdcaa6d62816f3b22cc0336ed4e2984184b60551f25f2fc7ecL24-R26): Wrapped `ValueListenableBuilder` in a `StreamChannel` widget to ensure the channel context is available. [[1]](diffhunk://#diff-db24a6040b0156cdcaa6d62816f3b22cc0336ed4e2984184b60551f25f2fc7ecL24-R26) [[2]](diffhunk://#diff-db24a6040b0156cdcaa6d62816f3b22cc0336ed4e2984184b60551f25f2fc7ecR53)
* [`packages/stream_chat_flutter/lib/src/poll/stream_poll_option_votes_dialog.dart`](diffhunk://#diff-aa0db5fe993d25da9bda5c06e8d8d9003c4b95aa7dfa437b271d2f9c70244d59L23-R25): Wrapped `ValueListenableBuilder` in a `StreamChannel` widget to ensure the channel context is available. [[1]](diffhunk://#diff-aa0db5fe993d25da9bda5c06e8d8d9003c4b95aa7dfa437b271d2f9c70244d59L23-R25) [[2]](diffhunk://#diff-aa0db5fe993d25da9bda5c06e8d8d9003c4b95aa7dfa437b271d2f9c70244d59R40)
* [`packages/stream_chat_flutter/lib/src/poll/stream_poll_options_dialog.dart`](diffhunk://#diff-6aa399833ee3d9f962e71b23ce3f39b27bef0828beba383a1c9fe0f770fca703L21-R23): Wrapped `ValueListenableBuilder` in a `StreamChannel` widget to ensure the channel context is available. [[1]](diffhunk://#diff-6aa399833ee3d9f962e71b23ce3f39b27bef0828beba383a1c9fe0f770fca703L21-R23) [[2]](diffhunk://#diff-6aa399833ee3d9f962e71b23ce3f39b27bef0828beba383a1c9fe0f770fca703L44-R46)
* [`packages/stream_chat_flutter/lib/src/poll/stream_poll_results_dialog.dart`](diffhunk://#diff-d9789cfff11ecf918627ad1b57f78b3d11184803c643fde9c9bd0119a57d786fL32-R34): Wrapped `ValueListenableBuilder` in a `StreamChannel` widget to ensure the channel context is available. [[1]](diffhunk://#diff-d9789cfff11ecf918627ad1b57f78b3d11184803c643fde9c9bd0119a57d786fL32-R34) [[2]](diffhunk://#diff-d9789cfff11ecf918627ad1b57f78b3d11184803c643fde9c9bd0119a57d786fR56)