### PR TITLE
feat(repo): bump min flutter version to 3.27.4

### DIFF
--- a/.github/workflows/legacy_version_analyze.yml
+++ b/.github/workflows/legacy_version_analyze.yml
@@ -3,7 +3,7 @@ name: legacy_version_analyze
 env:
   # Note: The versions below should be manually updated after a new stable
   # version comes out.
-  flutter_version: "3.24.5"
+  flutter_version: "3.27.4"
 
 on:
   push:

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,9 +18,9 @@ command:
   bootstrap:
     # Dart and Flutter environment used in the project.
     environment:
-      sdk: ^3.5.4
+      sdk: ^3.6.2
       # We are not using carat '^' syntax here because flutter don't follow semantic versioning.
-      flutter: ">=3.24.5"
+      flutter: ">=3.27.4"
 
     # List of all the dependencies used in the project.
     dependencies:

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Updated minimum Flutter version to 3.27.4 for the SDK.
+
 ## 9.3.0
 
 ✅ Added

--- a/packages/stream_chat/example/pubspec.yaml
+++ b/packages/stream_chat/example/pubspec.yaml
@@ -17,8 +17,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -18,7 +18,7 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
+  sdk: ^3.6.2
 
 dependencies:
   async: ^2.11.0

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Updated minimum Flutter version to 3.27.4 for the SDK.
+
 ## 9.3.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/example/pubspec.yaml
+++ b/packages/stream_chat_flutter/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.17.2

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_loading.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_loading.dart
@@ -23,6 +23,7 @@ class StreamVoiceRecordingLoading extends StatelessWidget {
         height: theme.size!.height,
         width: theme.size!.width,
         child: CircularProgressIndicator(
+          // ignore: unnecessary_null_checks
           strokeWidth: theme.strokeWidth!,
           color: theme.color,
         ),

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_text_field.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_text_field.dart
@@ -705,6 +705,7 @@ class _StreamMessageTextFieldState extends State<StreamMessageTextField>
         autofillHints: widget.autofillHints,
         clipBehavior: widget.clipBehavior,
         restorationId: widget.restorationId,
+        // ignore: deprecated_member_use
         scribbleEnabled: widget.scribbleEnabled,
         enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
         contentInsertionConfiguration: widget.contentInsertionConfiguration,

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   cached_network_image: ^3.3.1

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Updated minimum Flutter version to 3.27.4 for the SDK.
+
 ## 9.3.0
 
 - Updated `stream_chat` dependency to [`9.3.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_flutter_core/example/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.17.2

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Updated minimum Flutter version to 3.27.4 for the SDK.
+
 ## 9.3.0
 
 - Added translations for new `slideToCancelLabel` label.

--- a/packages/stream_chat_localizations/example/pubspec.yaml
+++ b/packages/stream_chat_localizations/example/pubspec.yaml
@@ -17,8 +17,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_localizations/pubspec.yaml
+++ b/packages/stream_chat_localizations/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   flutter:

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Updated minimum Flutter version to 3.27.4 for the SDK.
+
 ## 9.3.0
 
 - Updated `stream_chat` dependency to [`9.3.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_persistence/example/pubspec.yaml
+++ b/packages/stream_chat_persistence/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_persistence/pubspec.yaml
+++ b/packages/stream_chat_persistence/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   drift: ^2.22.1

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -16,8 +16,8 @@ version: 2.2.0
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.5.4
-  flutter: ">=3.24.5"
+  sdk: ^3.6.2
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.17.2


### PR DESCRIPTION
This pull request includes updates to the Flutter SDK and Dart SDK versions across various files, along with some minor code improvements and documentation updates. The most important changes include updating the minimum Flutter version to 3.27.4 and Dart SDK version to 3.6.2, as well as some minor code comments for deprecated and unnecessary null checks.

### SDK Version Updates:
* Updated `flutter_version` to "3.27.4" in `.github/workflows/legacy_version_analyze.yml`.
* Updated `sdk` to ^3.6.2 and `flutter` to ">=3.27.4" in `melos.yaml`.
* Updated `sdk` to ^3.6.2 and `flutter` to ">=3.27.4" in `packages/stream_chat/example/pubspec.yaml`.
* Updated `sdk` to ^3.6.2 and `flutter` to ">=3.27.4" in `packages/stream_chat_flutter/example/pubspec.yaml`.
* Updated `sdk` to ^3.6.2 and `flutter` to ">=3.27.4" in `sample_app/pubspec.yaml`.

### Changelog Updates:
* Added entries for the updated minimum Flutter version to 3.27.4 in `packages/stream_chat/CHANGELOG.md`.
* Added entries for the updated minimum Flutter version to 3.27.4 in `packages/stream_chat_flutter/CHANGELOG.md`.
* Added entries for the updated minimum Flutter version to 3.27.4 in `packages/stream_chat_flutter_core/CHANGELOG.md`.
* Added entries for the updated minimum Flutter version to 3.27.4 in `packages/stream_chat_localizations/CHANGELOG.md`.
* Added entries for the updated minimum Flutter version to 3.27.4 in `packages/stream_chat_persistence/CHANGELOG.md`.

### Minor Code Improvements:
* Added a comment to ignore unnecessary null checks in `packages/stream_chat_flutter/lib/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_loading.dart`.
* Added a comment to ignore deprecated member use in `packages/stream_chat_flutter/lib/src/message_input/stream_message_text_field.dart`.