### PR TITLE
fix: update image_gallery_saver_plus

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -52,7 +52,7 @@ command:
       get_thumbnail_video: ^0.7.3
       go_router: ^14.6.2
       http_parser: ^4.0.2
-      image_gallery_saver_plus: ^3.0.5
+      image_gallery_saver_plus: ^4.0.0-0.alpha
       image_picker: ^1.1.2
       image_size_getter: ^2.3.0
       jiffy: ^6.2.1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 🔄 Changed
 
 - Updated minimum Flutter version to 3.27.4 for the SDK.
+- Updated version of image_gallery_saver_plus to `^4.0.0-0.alpha`
 
 ## 9.3.0
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   get_thumbnail_video: ^0.7.3
   http_parser: ^4.0.2
-  image_gallery_saver_plus: ^3.0.5
+  image_gallery_saver_plus: ^4.0.0-0.alpha
   image_picker: ^1.1.2
   image_size_getter: ^2.3.0
   jiffy: ^6.2.1


### PR DESCRIPTION
old version is incompatible with Flutter 3.29

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The old version (3.x) of image_gallery_saver_plus is incompatible with Flutter 3.29 as it still supports V1 plugin embedding which is removed in Flutter 3.29. As this upgrades towards an alpha version it should be a temporary fix and we should look for alternatives.
