### PR TITLE
fix(ui): fix message input buttons not customizable

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed `StreamMessageInput` not able to edit the ogAttachments.
 - Fixed `MessageWidget` showing pinned background for deleted messages.
-- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed message input buttons not being able to customized.
+- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed an issue where message input buttons could not be customized.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `StreamMessageInput` not able to edit the ogAttachments.
 - Fixed `MessageWidget` showing pinned background for deleted messages.
+- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed message input buttons not being able to customized.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed message input
+  buttons not being able to customized.
+
 ## 9.5.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_button.dart
@@ -13,11 +13,7 @@ class AttachmentButton extends StatelessWidget {
     this.color,
     this.icon,
     this.size = kDefaultMessageInputIconSize,
-  }) : assert(
-            (icon == null && color == null) ||
-                (icon != null && color == null) ||
-                (icon == null && color != null),
-            'Either icon or color should be provided');
+  });
 
   /// The color of the button.
   /// Should be set if no [icon] is provided.

--- a/packages/stream_chat_flutter/lib/src/message_input/command_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/command_button.dart
@@ -13,11 +13,7 @@ class CommandButton extends StatelessWidget {
     this.color,
     this.icon,
     this.size = kDefaultMessageInputIconSize,
-  }) : assert(
-            (icon == null && color == null) ||
-                (icon != null && color == null) ||
-                (icon == null && color != null),
-            'Either icon or color should be provided');
+  });
 
   /// The color of the button.
   /// Should be set if no [icon] is provided.

--- a/packages/stream_chat_flutter/lib/src/message_input/countdown_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/countdown_button.dart
@@ -16,14 +16,17 @@ class StreamCountdownButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: StreamChatTheme.of(context).colorTheme.disabled,
-      ),
-      child: SizedBox.square(
-        dimension: kDefaultMessageInputIconSize,
-        child: Center(child: Text('$count')),
+    return Padding(
+      padding: const EdgeInsets.all(kDefaultMessageInputIconPadding),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: StreamChatTheme.of(context).colorTheme.disabled,
+        ),
+        child: SizedBox.square(
+          dimension: kDefaultMessageInputIconSize,
+          child: Center(child: Text('$count')),
+        ),
       ),
     );
   }

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -601,8 +601,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
   // ignore: no-empty-block
   void _focusNodeListener() {}
 
-  PermissionState? _permissionState;
-
   @override
   Widget build(BuildContext context) {
     final channel = StreamChannel.of(context).channel;
@@ -1574,6 +1572,8 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
   @override
   void dispose() {
+    _effectiveController.cancelCooldown();
+    // ignore: cascade_invocations
     _effectiveController.removeListener(_onChangedDebounced);
     _controller?.dispose();
     _effectiveFocusNode.removeListener(_focusNodeListener);

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:photo_manager/photo_manager.dart';
 import 'package:stream_chat_flutter/platform_widget_builder/src/platform_widget_builder.dart';
 import 'package:stream_chat_flutter/src/message_input/attachment_button.dart';
 import 'package:stream_chat_flutter/src/message_input/command_button.dart';
@@ -125,8 +124,10 @@ class StreamMessageInput extends StatefulWidget {
     this.hideSendAsDm = false,
     this.enableVoiceRecording = false,
     this.sendVoiceRecordingAutomatically = false,
-    this.idleSendButton,
-    this.activeSendButton,
+    Widget? idleSendIcon,
+    @Deprecated("Use 'idleSendIcon' instead") Widget? idleSendButton,
+    Widget? activeSendIcon,
+    @Deprecated("Use 'activeSendIcon' instead") Widget? activeSendButton,
     this.showCommandsButton = true,
     this.userMentionsTileBuilder,
     this.maxAttachmentSize = kDefaultMaxAttachmentSize,
@@ -164,7 +165,17 @@ class StreamMessageInput extends StatefulWidget {
     )
     bool useNativeAttachmentPickerOnMobile = false,
     this.pollConfig,
-  }) : useSystemAttachmentPicker = useSystemAttachmentPicker || //
+  })  : assert(
+          idleSendIcon == null || idleSendButton == null,
+          'idleSendIcon and idleSendButton cannot be used together',
+        ),
+        idleSendIcon = idleSendIcon ?? idleSendButton,
+        assert(
+          activeSendIcon == null || activeSendButton == null,
+          'activeSendIcon and activeSendButton cannot be used together',
+        ),
+        activeSendIcon = activeSendIcon ?? activeSendButton,
+        useSystemAttachmentPicker = useSystemAttachmentPicker || //
             useNativeAttachmentPickerOnMobile;
 
   /// The predicate used to send a message on desktop/web
@@ -292,10 +303,18 @@ class StreamMessageInput extends StatefulWidget {
   final bool autofocus;
 
   /// Send button widget in an idle state
-  final Widget? idleSendButton;
+  final Widget? idleSendIcon;
+
+  /// Send button widget in an idle state
+  @Deprecated("Use 'idleSendIcon' instead")
+  Widget? get idleSendButton => idleSendIcon;
 
   /// Send button widget in an active state
-  final Widget? activeSendButton;
+  final Widget? activeSendIcon;
+
+  /// Send button widget in an active state
+  @Deprecated("Use 'activeSendIcon' instead")
+  Widget? get activeSendButton => activeSendIcon;
 
   /// Customize the tile for the mentions overlay.
   final UserMentionTileBuilder? userMentionsTileBuilder;
@@ -470,7 +489,7 @@ class StreamMessageInput extends StatefulWidget {
 
 /// State of [StreamMessageInput]
 class StreamMessageInputState extends State<StreamMessageInput>
-    with RestorationMixin<StreamMessageInput>, WidgetsBindingObserver {
+    with RestorationMixin<StreamMessageInput> {
   bool get _commandEnabled => _effectiveController.message.command != null;
 
   bool _actionsShrunk = false;
@@ -514,7 +533,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     if (widget.messageInputController == null) {
       _createLocalController();
     } else {
@@ -542,29 +560,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
     _streamChatTheme = StreamChatTheme.of(context);
     _messageInputTheme = StreamMessageInputTheme.of(context);
     super.didChangeDependencies();
-  }
-
-  bool _askingForPermission = false;
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) async {
-    if (state == AppLifecycleState.resumed &&
-        _permissionState != null &&
-        !_askingForPermission) {
-      _askingForPermission = true;
-
-      try {
-        final newPermissionState = await PhotoManager.requestPermissionExtend();
-        if (newPermissionState != _permissionState && mounted) {
-          setState(() {
-            _permissionState = newPermissionState;
-          });
-        }
-      } catch (_) {}
-
-      _askingForPermission = false;
-    }
-    super.didChangeAppLifecycleState(state);
   }
 
   @override
@@ -838,16 +833,16 @@ class StreamMessageInputState extends State<StreamMessageInput>
   }
 
   Widget _buildSendButton(BuildContext context) {
-    if (widget.sendButtonBuilder != null) {
-      return widget.sendButtonBuilder!(context, _effectiveController);
+    if (widget.sendButtonBuilder case final builder?) {
+      return builder(context, _effectiveController);
     }
 
     return StreamMessageSendButton(
       onSendMessage: sendMessage,
       timeOut: _effectiveController.cooldownTimeOut,
       isIdle: !widget.validator(_effectiveController.message),
-      idleSendButton: widget.idleSendButton,
-      activeSendButton: widget.activeSendButton,
+      idleSendIcon: widget.idleSendIcon,
+      activeSendIcon: widget.activeSendIcon,
     );
   }
 
@@ -1580,7 +1575,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
     _focusNode?.dispose();
     _onChangedDebounced.cancel();
     _audioRecorderController.dispose();
-    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 }

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_send_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_send_button.dart
@@ -15,10 +15,21 @@ class StreamMessageSendButton extends StatelessWidget {
     this.isCommandEnabled = false,
     @Deprecated('Will be removed in the next major version')
     this.isEditEnabled = false,
-    this.idleSendButton,
-    this.activeSendButton,
+    Widget? idleSendIcon,
+    @Deprecated("Use 'idleSendIcon' instead") Widget? idleSendButton,
+    Widget? activeSendIcon,
+    @Deprecated("Use 'activeSendIcon' instead") Widget? activeSendButton,
     required this.onSendMessage,
-  });
+  })  : assert(
+          idleSendIcon == null || idleSendButton == null,
+          'idleSendIcon and idleSendButton cannot be used together',
+        ),
+        idleSendIcon = idleSendIcon ?? idleSendButton,
+        assert(
+          activeSendIcon == null || activeSendButton == null,
+          'activeSendIcon and activeSendButton cannot be used together',
+        ),
+        activeSendIcon = activeSendIcon ?? activeSendButton;
 
   /// Time out related to slow mode.
   final int timeOut;
@@ -34,11 +45,19 @@ class StreamMessageSendButton extends StatelessWidget {
   @Deprecated('It will be removed in the next major version')
   final bool isEditEnabled;
 
+  /// The icon to display when the button is idle.
+  final Widget? idleSendIcon;
+
   /// The widget to display when the button is disabled.
-  final Widget? idleSendButton;
+  @Deprecated("Use 'idleSendIcon' instead")
+  Widget? get idleSendButton => idleSendIcon;
+
+  /// The icon to display when the button is active.
+  final Widget? activeSendIcon;
 
   /// The widget to display when the button is enabled.
-  final Widget? activeSendButton;
+  @Deprecated("Use 'activeSendIcon' instead")
+  Widget? get activeSendButton => activeSendIcon;
 
   /// The callback to call when the button is pressed.
   final VoidCallback onSendMessage;
@@ -62,18 +81,18 @@ class StreamMessageSendButton extends StatelessWidget {
       );
     }
 
-    final idleSendIcon = switch (idleSendButton) {
-      final idleButton? => idleButton,
+    final idleIcon = switch (idleSendIcon) {
+      final idleIcon? => idleIcon,
       _ => const StreamSvgIcon(icon: StreamSvgIcons.sendMessage),
     };
 
-    final activeSendIcon = switch (activeSendButton) {
-      final activeButton? => activeButton,
+    final activeIcon = switch (activeSendIcon) {
+      final activeIcon? => activeIcon,
       _ => const StreamSvgIcon(icon: StreamSvgIcons.circleUp),
     };
 
     final theme = StreamMessageInputTheme.of(context);
-    final icon = isIdle ? idleSendIcon : activeSendIcon;
+    final icon = isIdle ? idleIcon : activeIcon;
     final onPressed = isIdle ? null : onSendMessage;
     return StreamMessageInputIconButton(
       key: const Key('send_button'),

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_send_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_send_button.dart
@@ -62,19 +62,25 @@ class StreamMessageSendButton extends StatelessWidget {
       );
     }
 
+    final idleSendIcon = switch (idleSendButton) {
+      final idleButton? => idleButton,
+      _ => const StreamSvgIcon(icon: StreamSvgIcons.sendMessage),
+    };
+
+    final activeSendIcon = switch (activeSendButton) {
+      final activeButton? => activeButton,
+      _ => const StreamSvgIcon(icon: StreamSvgIcons.circleUp),
+    };
+
     final theme = StreamMessageInputTheme.of(context);
+    final icon = isIdle ? idleSendIcon : activeSendIcon;
     final onPressed = isIdle ? null : onSendMessage;
     return StreamMessageInputIconButton(
       key: const Key('send_button'),
-      icon: StreamSvgIcon(icon: _sendButtonIcon),
+      icon: icon,
       color: theme.sendButtonColor,
       disabledColor: theme.sendButtonIdleColor,
       onPressed: onPressed,
     );
-  }
-
-  StreamSvgIconData get _sendButtonIcon {
-    if (isIdle) return StreamSvgIcons.sendMessage;
-    return StreamSvgIcons.circleUp;
   }
 }

--- a/packages/stream_chat_flutter/test/src/message_input/attachment_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/attachment_button_test.dart
@@ -7,16 +7,14 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import '../material_app_wrapper.dart';
 
 void main() {
-  testWidgets('SendButton onPressed works', (tester) async {
+  testWidgets('AttachmentButton onPressed works', (tester) async {
     var count = 0;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: Center(
             child: AttachmentButton(
-              color: StreamChatThemeData.light()
-                  .messageInputTheme
-                  .actionButtonIdleColor,
+              color: Colors.red,
               onPressed: () {
                 count++;
               },
@@ -31,6 +29,45 @@ void main() {
     expect(find.byType(StreamSvgIcon), findsOneWidget);
     await tester.tap(button);
     expect(count, 1);
+  });
+
+  testWidgets('AttachmentButton should accept icon', (tester) async {
+    const icon = Icon(Icons.attachment);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AttachmentButton(
+              icon: icon,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.attachment), findsOneWidget);
+  });
+
+  testWidgets('AttachmentButton should accept color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AttachmentButton(
+              color: Colors.red,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final buttonFinder = find.byType(AttachmentButton);
+    expect(buttonFinder, findsOneWidget);
+
+    final button = tester.widget<AttachmentButton>(buttonFinder);
+    expect(button.color, Colors.red);
   });
 
   goldenTest(

--- a/packages/stream_chat_flutter/test/src/message_input/command_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/command_button_test.dart
@@ -44,32 +44,28 @@ void main() {
       ),
     );
 
-    final iconFound = find.byWidget(icon);
-    expect(iconFound, findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
   });
 
-  testWidgets('CommandButton should not accept both color and icon',
-      (tester) async {
-    expect(
-      () => MaterialApp(
+  testWidgets('CommandButton should accept color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
         home: Scaffold(
           body: Center(
             child: CommandButton(
               color: Colors.red,
-              icon: const Icon(Icons.add),
               onPressed: () {},
             ),
           ),
         ),
       ),
-      throwsA(
-        isA<AssertionError>().having(
-          (e) => e.message,
-          'message',
-          'Either icon or color should be provided',
-        ),
-      ),
     );
+
+    final buttonFinder = find.byType(CommandButton);
+    expect(buttonFinder, findsOneWidget);
+
+    final button = tester.widget<CommandButton>(buttonFinder);
+    expect(button.color, Colors.red);
   });
 
   goldenTest(

--- a/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/message_input/stream_message_input_icon_button.dart';
+import 'package:stream_chat_flutter/src/message_input/stream_message_send_button.dart';
+import 'package:stream_chat_flutter/src/theme/message_input_theme.dart';
+import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
+
+import '../utils/finders.dart';
+
+void main() {
+  group('StreamMessageSendButton', () {
+    testWidgets(
+      'renders countdown button when timeout > 0',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              timeOut: 5,
+              onSendMessage: () {},
+            ),
+          ),
+        );
+
+        expect(find.byKey(const Key('countdown_button')), findsOneWidget);
+        expect(find.byKey(const Key('send_button')), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'renders idle send button when isIdle is true',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              isIdle: true,
+              onSendMessage: () {},
+            ),
+          ),
+        );
+
+        final button = find.byKey(const Key('send_button'));
+        expect(button, findsOneWidget);
+
+        // Verify the button is disabled
+        final iconButton = tester.widget<StreamMessageInputIconButton>(button);
+        expect(iconButton.onPressed, isNull);
+
+        // Verify default idle icon is shown
+        expect(find.bySvgIcon(StreamSvgIcons.sendMessage), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders active send button when isIdle is false',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              isIdle: false,
+              onSendMessage: () {},
+            ),
+          ),
+        );
+
+        final button = find.byKey(const Key('send_button'));
+        expect(button, findsOneWidget);
+
+        // Verify the button is enabled
+        final iconButton = tester.widget<StreamMessageInputIconButton>(button);
+        expect(iconButton.onPressed, isNotNull);
+
+        // Verify default active icon is shown
+        expect(find.bySvgIcon(StreamSvgIcons.circleUp), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'uses custom idle button when provided',
+      (tester) async {
+        final customIdleButton = Container(key: const Key('custom_idle'));
+
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              isIdle: true,
+              idleSendButton: customIdleButton,
+              onSendMessage: () {},
+            ),
+          ),
+        );
+
+        expect(find.byKey(const Key('custom_idle')), findsOneWidget);
+        expect(find.byType(StreamSvgIcon), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'uses custom active button when provided',
+      (tester) async {
+        final customActiveButton = Container(key: const Key('custom_active'));
+
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              isIdle: false,
+              activeSendButton: customActiveButton,
+              onSendMessage: () {},
+            ),
+          ),
+        );
+
+        expect(find.byKey(const Key('custom_active')), findsOneWidget);
+        expect(find.byType(StreamSvgIcon), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'calls onSendMessage when active button is pressed',
+      (tester) async {
+        var wasPressed = false;
+
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageSendButton(
+              isIdle: false,
+              onSendMessage: () => wasPressed = true,
+            ),
+          ),
+        );
+
+        await tester.tap(find.byKey(const Key('send_button')));
+        expect(wasPressed, isTrue);
+      },
+    );
+
+    testWidgets(
+      'applies theme colors correctly',
+      (tester) async {
+        const theme = StreamMessageInputThemeData(
+          sendButtonColor: Colors.blue,
+          sendButtonIdleColor: Colors.grey,
+          sendAnimationDuration: Duration(milliseconds: 100),
+        );
+
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamMessageInputTheme(
+              data: theme,
+              child: StreamMessageSendButton(
+                isIdle: false,
+                onSendMessage: () {},
+              ),
+            ),
+          ),
+        );
+
+        final iconButton = tester.widget<StreamMessageInputIconButton>(
+          find.byKey(const Key('send_button')),
+        );
+
+        expect(iconButton.color, Colors.blue);
+        expect(iconButton.disabledColor, Colors.grey);
+      },
+    );
+  });
+}
+
+Widget _wrapWithStreamChatApp(
+  Widget widget, {
+  Brightness? brightness,
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    home: StreamChatTheme(
+      data: StreamChatThemeData(brightness: brightness),
+      child: Builder(builder: (context) {
+        final theme = StreamChatTheme.of(context);
+        return Scaffold(
+          backgroundColor: theme.colorTheme.appBg,
+          bottomNavigationBar: Material(
+            elevation: 10,
+            color: theme.colorTheme.barsBg,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: widget,
+            ),
+          ),
+        );
+      }),
+    ),
+  );
+}

--- a/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
@@ -86,7 +86,7 @@ void main() {
           _wrapWithStreamChatApp(
             StreamMessageSendButton(
               isIdle: true,
-              idleSendButton: customIdleButton,
+              idleSendIcon: customIdleButton,
               onSendMessage: () {},
             ),
           ),
@@ -106,7 +106,7 @@ void main() {
           _wrapWithStreamChatApp(
             StreamMessageSendButton(
               isIdle: false,
-              activeSendButton: customActiveButton,
+              activeSendIcon: customActiveButton,
               onSendMessage: () {},
             ),
           ),

--- a/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/stream_message_send_button_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';


### PR DESCRIPTION
Resolves: FLU-27

This pull request includes several changes to the `stream_chat_flutter` package, focusing on fixing a bug, improving button customization, and adding tests. The most important changes include fixing a customization issue with message input buttons, removing assertions in button constructors, and adding comprehensive tests for the `StreamMessageSendButton` component.

Bug Fixes:
* Fixed message input buttons not being customizable in the `CHANGELOG.md` file.

Code Improvements:
* Removed assertions in the constructors of `AttachmentButton` and `CommandButton` to simplify the code and allow more flexible button customization. [[1]](diffhunk://#diff-7f9a9a4aeed6f4e837d0309e3661b56f9a95136e7851cc484cac8031794ccd3bL16-R16) [[2]](diffhunk://#diff-ddf6988dc7b791ffe7d215abe1f3aeb2daba027c038b187a1bb85f4818ff7f02L16-R16)

Feature Enhancements:
* Enhanced the `StreamMessageSendButton` to support customizable idle and active send icons, improving the flexibility of the button's appearance.

Testing:
* Added a comprehensive set of widget tests for the `StreamMessageSendButton` to ensure correct rendering and behavior under various conditions.