### PR TITLE
fix(llc): fix failed to execute 'close' on 'WebSocket'

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#1774]](https://github.com/GetStream/stream-chat-flutter/issues/1774) Fixed failed to execute 'close' on 'WebSocket'.
+
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -120,8 +120,7 @@ class WebSocket with TimerHelper {
     _logger?.info('Closing connection with $baseUrl');
     if (_webSocketChannel != null) {
       _unsubscribeFromWebSocketChannel();
-      _webSocketChannel?.sink
-          .close(_manuallyClosed ? status.normalClosure : status.goingAway);
+      _webSocketChannel?.sink.close(status.normalClosure, 'Closing connection');
       _webSocketChannel = null;
     }
   }


### PR DESCRIPTION
This pull request addresses a bug fix related to the WebSocket connection in the `stream_chat` package. The most important changes include updating the changelog and modifying the WebSocket closure logic.

### Bug Fixes:

* [`packages/stream_chat/CHANGELOG.md`](diffhunk://#diff-0a4071421926a484a5e4e46567cd96230a5754549ea0a7198146eced8598442dR1-R6): Added an entry for the upcoming release, noting the fix for the issue where the WebSocket failed to execute 'close'.

### Code Changes:

* [`packages/stream_chat/lib/src/ws/websocket.dart`](diffhunk://#diff-5cd843052c1fa125f2775a9aa69368f5294d6517910a85f2cfdc7ab43f705753L123-R123): Modified the WebSocket closure logic to always use `status.normalClosure` and include a reason for closing the connection.