### PR TITLE
fix(ui): fix deleted messages showing pinned background.

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 🐞 Fixed
 
 - Fixed `StreamMessageInput` not able to edit the ogAttachments.
+- Fixed `MessageWidget` showing pinned background for deleted messages.
 
 ## 9.4.0
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -605,7 +605,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
   /// {@template isPinned}
   /// Whether [StreamMessageWidget.message] is pinned or not.
   /// {@endtemplate}
-  bool get isPinned => widget.message.pinned;
+  bool get isPinned => widget.message.pinned && !widget.message.isDeleted;
 
   /// {@template shouldShowReactions}
   /// Should show message reactions if [StreamMessageWidget.showReactions] is
@@ -680,7 +680,7 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
         type: MaterialType.transparency,
         child: AnimatedContainer(
           duration: const Duration(seconds: 1),
-          color: widget.message.pinned && widget.showPinHighlight
+          color: isPinned && widget.showPinHighlight
               ? _streamChatTheme.colorTheme.highlight
               // ignore: deprecated_member_use
               : _streamChatTheme.colorTheme.barsBg.withOpacity(0),
@@ -891,13 +891,13 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
           ),
           title: Text(
             context.translations.togglePinUnpinText(
-              pinned: widget.message.pinned,
+              pinned: isPinned,
             ),
           ),
           onClick: () async {
             Navigator.of(context, rootNavigator: true).pop();
             try {
-              if (!widget.message.pinned) {
+              if (!isPinned) {
                 await channel.pinMessage(widget.message);
               } else {
                 await channel.unpinMessage(widget.message);

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart
@@ -259,9 +259,7 @@ class MessageWidgetContent extends StatelessWidget {
                     reverse ? CrossAxisAlignment.end : CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (message.pinned &&
-                      message.pinnedBy != null &&
-                      showPinHighlight)
+                  if (isPinned && message.pinnedBy != null && showPinHighlight)
                     PinnedMessage(
                       pinnedBy: message.pinnedBy!,
                       currentUser: streamChat.currentUser!,


### PR DESCRIPTION
Fixes a part of https://getstream.zendesk.com/agent/tickets/60177

This pull request includes changes to fix a bug in the `StreamMessageWidget` and improve the handling of pinned messages. The most important changes are related to ensuring that deleted messages do not show as pinned and updating the conditions for displaying pinned message highlights.

Bug fixes and improvements:

* [`packages/stream_chat_flutter/CHANGELOG.md`](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R6): Added a note about fixing the `MessageWidget` showing pinned background for deleted messages.
* [`packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart`](diffhunk://#diff-fa3baf3c1e6d70317fe6b3b7eb39de4182546c0664d17ff6095cd4368107b380L608-R608): Updated the `isPinned` getter to ensure it returns `false` for deleted messages.
* [`packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart`](diffhunk://#diff-fa3baf3c1e6d70317fe6b3b7eb39de4182546c0664d17ff6095cd4368107b380L683-R683): Modified the color condition in the `AnimatedContainer` to use the updated `isPinned` getter.
* [`packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart`](diffhunk://#diff-fa3baf3c1e6d70317fe6b3b7eb39de4182546c0664d17ff6095cd4368107b380L894-R900): Updated the `togglePinUnpinText` and pin/unpin logic to use the updated `isPinned` getter.
* [`packages/stream_chat_flutter/lib/src/message_widget/message_widget_content.dart`](diffhunk://#diff-1b6a3a92dd3f95dc9fabeb6755de984caf65b09bda7b1d7a32b99b78180ef1a0L262-R262): Changed the condition for displaying the `PinnedMessage` widget to use the updated `isPinned` getter.

| Demo |
|--------|
| <video src="https://github.com/user-attachments/assets/6b750ef0-685f-40e8-966a-1e13b28458fe" width="300" /> |