### PR TITLE
feat(llc): add support for system messages not updating `channel.lastMessageAt`

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
 
+✅ Added
+
+- [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
+
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Refactored identifying the `Attachment.uploadState` logic for local and remote attachments. Also updated the logic for determining the attachment type to check for ogScrapeUrl instead of `AttachmentType.giphy`.
 
+✅ Added
+
+- [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
+
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -13,10 +13,6 @@
 
 - [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
 
-✅ Added
-
-- [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
-
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2511,7 +2511,9 @@ class ChannelClientState {
     final currentUser = _channel._client.state.currentUser;
     final restrictedVisibility = message.restrictedVisibility;
     if (restrictedVisibility case final visibility?) {
-      if (!visibility.contains(currentUser?.id)) return false;
+      if (visibility.isNotEmpty && !visibility.contains(currentUser?.id)) {
+        return false;
+      }
     }
 
     return true;

--- a/packages/stream_chat/lib/src/core/models/channel_config.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_config.dart
@@ -24,6 +24,7 @@ class ChannelConfig {
     this.typingEvents = false,
     this.uploads = false,
     this.urlEnrichment = false,
+    this.skipLastMsgUpdateForSystemMsgs = false,
   })  : createdAt = createdAt ?? DateTime.now(),
         updatedAt = updatedAt ?? DateTime.now();
 
@@ -78,6 +79,13 @@ class ChannelConfig {
 
   /// True if urls appears as attachments
   final bool urlEnrichment;
+
+  /// If true the last message at date will not be updated when a system message
+  /// is added.
+  ///
+  /// This is useful for scenarios where you want to track the last time a user
+  /// message was added to the channel.
+  final bool skipLastMsgUpdateForSystemMsgs;
 
   /// Serialize to json
   Map<String, dynamic> toJson() => _$ChannelConfigToJson(this);

--- a/packages/stream_chat/lib/src/core/models/channel_config.g.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_config.g.dart
@@ -31,6 +31,8 @@ ChannelConfig _$ChannelConfigFromJson(Map<String, dynamic> json) =>
       typingEvents: json['typing_events'] as bool? ?? false,
       uploads: json['uploads'] as bool? ?? false,
       urlEnrichment: json['url_enrichment'] as bool? ?? false,
+      skipLastMsgUpdateForSystemMsgs:
+          json['skip_last_msg_update_for_system_msgs'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$ChannelConfigToJson(ChannelConfig instance) =>
@@ -51,4 +53,6 @@ Map<String, dynamic> _$ChannelConfigToJson(ChannelConfig instance) =>
       'typing_events': instance.typingEvents,
       'uploads': instance.uploads,
       'url_enrichment': instance.urlEnrichment,
+      'skip_last_msg_update_for_system_msgs':
+          instance.skipLastMsgUpdateForSystemMsgs,
     };

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -26,6 +26,7 @@ class Event {
     this.member,
     this.channelId,
     this.channelType,
+    this.channelLastMessageAt,
     this.parentId,
     this.hardDelete,
     this.aiState,
@@ -57,6 +58,9 @@ class Event {
 
   /// The channel type to which the event belongs
   final String? channelType;
+
+  /// The dateTime at which the last message was sent in the channel.
+  final DateTime? channelLastMessageAt;
 
   /// The connection id in which the event has been sent
   final String? connectionId;
@@ -168,6 +172,7 @@ class Event {
     'member',
     'channel_id',
     'channel_type',
+    'channel_last_message_at',
     'parent_id',
     'hard_delete',
     'is_local',
@@ -190,6 +195,7 @@ class Event {
     String? cid,
     String? channelId,
     String? channelType,
+    DateTime? channelLastMessageAt,
     String? connectionId,
     DateTime? createdAt,
     OwnUser? me,
@@ -231,6 +237,7 @@ class Event {
         member: member ?? this.member,
         channelId: channelId ?? this.channelId,
         channelType: channelType ?? this.channelType,
+        channelLastMessageAt: channelLastMessageAt ?? this.channelLastMessageAt,
         parentId: parentId ?? this.parentId,
         hardDelete: hardDelete ?? this.hardDelete,
         aiState: aiState ?? this.aiState,

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -42,6 +42,9 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
           : Member.fromJson(json['member'] as Map<String, dynamic>),
       channelId: json['channel_id'] as String?,
       channelType: json['channel_type'] as String?,
+      channelLastMessageAt: json['channel_last_message_at'] == null
+          ? null
+          : DateTime.parse(json['channel_last_message_at'] as String),
       parentId: json['parent_id'] as String?,
       hardDelete: json['hard_delete'] as bool?,
       aiState: $enumDecodeNullable(_$AITypingStateEnumMap, json['ai_state'],
@@ -62,6 +65,8 @@ Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
       'cid': instance.cid,
       'channel_id': instance.channelId,
       'channel_type': instance.channelType,
+      'channel_last_message_at':
+          instance.channelLastMessageAt?.toIso8601String(),
       'connection_id': instance.connectionId,
       'created_at': instance.createdAt.toIso8601String(),
       'me': instance.me?.toJson(),

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -56,6 +56,7 @@ class Message extends Equatable {
     this.extraData = const {},
     this.state = const MessageState.initial(),
     this.i18n,
+    this.restrictedVisibility,
   })  : id = id ?? const Uuid().v4(),
         pinExpires = pinExpires?.toUtc(),
         remoteCreatedAt = createdAt,
@@ -237,6 +238,15 @@ class Message extends Equatable {
   String? get pollId => _pollId ?? poll?.id;
   final String? _pollId;
 
+  /// The list of those users who have restricted visibility for this message.
+  final List<String>? restrictedVisibility;
+
+  /// Returns true if the message has restricted visibility.
+  bool get hasRestrictedVisibility {
+    final visibility = restrictedVisibility;
+    return visibility != null && visibility.isNotEmpty;
+  }
+
   /// Message custom extraData.
   final Map<String, Object?> extraData;
 
@@ -291,6 +301,7 @@ class Message extends Equatable {
     'i18n',
     'poll',
     'poll_id',
+    'restricted_visibility',
   ];
 
   /// Serialize to json.
@@ -335,6 +346,7 @@ class Message extends Equatable {
     Map<String, Object?>? extraData,
     MessageState? state,
     Map<String, String>? i18n,
+    List<String>? restrictedVisibility,
   }) {
     assert(() {
       if (pinExpires is! DateTime &&
@@ -408,6 +420,7 @@ class Message extends Equatable {
       extraData: extraData ?? this.extraData,
       state: state ?? this.state,
       i18n: i18n ?? this.i18n,
+      restrictedVisibility: restrictedVisibility ?? this.restrictedVisibility,
     );
   }
 
@@ -450,6 +463,7 @@ class Message extends Equatable {
       extraData: other.extraData,
       state: other.state,
       i18n: other.i18n,
+      restrictedVisibility: other.restrictedVisibility,
     );
   }
 
@@ -512,5 +526,6 @@ class Message extends Equatable {
         extraData,
         state,
         i18n,
+        restrictedVisibility,
       ];
 }

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -241,12 +241,6 @@ class Message extends Equatable {
   /// The list of those users who have restricted visibility for this message.
   final List<String>? restrictedVisibility;
 
-  /// Returns true if the message has restricted visibility.
-  bool get hasRestrictedVisibility {
-    final visibility = restrictedVisibility;
-    return visibility != null && visibility.isNotEmpty;
-  }
-
   /// Message custom extraData.
   final Map<String, Object?> extraData;
 

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -239,6 +239,7 @@ class Message extends Equatable {
   final String? _pollId;
 
   /// The list of those users who have restricted visibility for this message.
+  @JsonKey(includeToJson: false)
   final List<String>? restrictedVisibility;
 
   /// Message custom extraData.

--- a/packages/stream_chat/lib/src/core/models/message.g.dart
+++ b/packages/stream_chat/lib/src/core/models/message.g.dart
@@ -76,6 +76,9 @@ Message _$MessageFromJson(Map<String, dynamic> json) => Message(
       i18n: (json['i18n'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
+      restrictedVisibility: (json['restricted_visibility'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
@@ -91,5 +94,6 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'pinned': instance.pinned,
       'pin_expires': instance.pinExpires?.toIso8601String(),
       'poll_id': instance.pollId,
+      'restricted_visibility': instance.restrictedVisibility,
       'extra_data': instance.extraData,
     };

--- a/packages/stream_chat/lib/src/core/models/message.g.dart
+++ b/packages/stream_chat/lib/src/core/models/message.g.dart
@@ -94,6 +94,5 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'pinned': instance.pinned,
       'pin_expires': instance.pinExpires?.toIso8601String(),
       'poll_id': instance.pollId,
-      'restricted_visibility': instance.restrictedVisibility,
       'extra_data': instance.extraData,
     };

--- a/packages/stream_chat/test/fixtures/channel_state.json
+++ b/packages/stream_chat/test/fixtures/channel_state.json
@@ -1,4 +1,3 @@
-
 {
   "channel": {
     "id": "dev",
@@ -79,7 +78,10 @@
       "pinned_at": null,
       "pin_expires": null,
       "pinned_by": null,
-      "poll_id": null
+      "poll_id": null,
+      "restricted_visibility": [
+        "user-id-3"
+      ]
     },
     {
       "id": "dry-meadow-0-e8e74482-b4cd-48db-9d1e-30e6c191786f",

--- a/packages/stream_chat/test/fixtures/event.json
+++ b/packages/stream_chat/test/fixtures/event.json
@@ -29,5 +29,6 @@
   "ai_state": "AI_STATE_THINKING",
   "ai_message": "Some message",
   "unread_thread_messages": 2,
-  "unread_threads": 3
+  "unread_threads": 3,
+  "channel_last_message_at": "2019-03-27T17:40:17.155892Z"
 }

--- a/packages/stream_chat/test/fixtures/message.json
+++ b/packages/stream_chat/test/fixtures/message.json
@@ -62,5 +62,8 @@
   "reply_count": 0,
   "created_at": "2020-01-28T22:17:31.107978Z",
   "updated_at": "2020-01-28T22:17:31.130506Z",
-  "mentioned_users": []
+  "mentioned_users": [],
+  "restricted_visibility": [
+    "user-id-3"
+  ]
 }

--- a/packages/stream_chat/test/fixtures/message_to_json.json
+++ b/packages/stream_chat/test/fixtures/message_to_json.json
@@ -23,8 +23,5 @@
   "pin_expires": null,
   "poll_id": null,
   "show_in_channel": true,
-  "restricted_visibility": [
-    "user-id-3"
-  ],
   "hey": "test"
 }

--- a/packages/stream_chat/test/fixtures/message_to_json.json
+++ b/packages/stream_chat/test/fixtures/message_to_json.json
@@ -23,5 +23,8 @@
   "pin_expires": null,
   "poll_id": null,
   "show_in_channel": true,
+  "restricted_visibility": [
+    "user-id-3"
+  ],
   "hey": "test"
 }

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -2952,7 +2952,7 @@ void main() {
         );
 
         test(
-          "should update 'channel.lastMessageAt' when Message has restricted visibility but not for current user",
+          "should update 'channel.lastMessageAt' when Message has restricted visibility only for the current user",
           () async {
             expect(channel.lastMessageAt, equals(initialLastMessageAt));
 
@@ -3045,7 +3045,7 @@ void main() {
         );
 
         test(
-          "should not update 'channel.lastMessageAt' when Message has restricted visibility",
+          "should not update 'channel.lastMessageAt' when Message has restricted visibility but not for the current user",
           () async {
             expect(channel.lastMessageAt, equals(initialLastMessageAt));
 

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -2952,6 +2952,30 @@ void main() {
         );
 
         test(
+          "should update 'channel.lastMessageAt' when Message has restricted visibility but not for current user",
+          () async {
+            expect(channel.lastMessageAt, equals(initialLastMessageAt));
+
+            final message = Message(
+              id: 'test-message-id',
+              user: client.state.currentUser,
+              // Message is visible to the current user.
+              restrictedVisibility: [client.state.currentUser!.id],
+              createdAt: initialLastMessageAt.add(const Duration(seconds: 3)),
+            );
+
+            final newMessageEvent = createNewMessageEvent(message);
+            eventController.add(newMessageEvent);
+
+            // Wait for the event to get processed
+            await Future.delayed(Duration.zero);
+
+            expect(channel.lastMessageAt, equals(message.createdAt));
+            expect(channel.lastMessageAt, isNot(initialLastMessageAt));
+          },
+        );
+
+        test(
           "should not update 'channel.lastMessageAt' when 'message.createdAt' is older",
           () async {
             expect(channel.lastMessageAt, equals(initialLastMessageAt));
@@ -3028,6 +3052,7 @@ void main() {
             final message = Message(
               id: 'test-message-id',
               user: client.state.currentUser,
+              // Message is only visible to user-1 not the current user.
               restrictedVisibility: const ['user-1'],
               createdAt: initialLastMessageAt.add(const Duration(seconds: 3)),
             );

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'package:mocktail/mocktail.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/client/retry_policy.dart';

--- a/packages/stream_chat/test/src/core/models/channel_state_test.dart
+++ b/packages/stream_chat/test/src/core/models/channel_state_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:stream_chat/stream_chat.dart';
 import 'package:test/test.dart';
 

--- a/packages/stream_chat/test/src/core/models/channel_state_test.dart
+++ b/packages/stream_chat/test/src/core/models/channel_state_test.dart
@@ -42,6 +42,10 @@ void main() {
         DateTime.parse('2020-01-29T03:23:02.843948Z'),
       );
       expect(channelState.messages![0].user, isA<User>());
+      expect(
+        channelState.messages![0].restrictedVisibility,
+        isA<List<String>>(),
+      );
       expect(channelState.watcherCount, 5);
     });
 
@@ -58,8 +62,6 @@ void main() {
         pinnedMessages: [],
         watchers: [],
       );
-
-      print(jsonEncode(channelState.messages?.first));
 
       expect(
         channelState.toJson(),

--- a/packages/stream_chat/test/src/core/models/event_test.dart
+++ b/packages/stream_chat/test/src/core/models/event_test.dart
@@ -18,6 +18,7 @@ void main() {
       expect(event.aiMessage, 'Some message');
       expect(event.unreadThreadMessages, 2);
       expect(event.unreadThreads, 3);
+      expect(event.channelLastMessageAt, isA<DateTime>());
     });
 
     test('should serialize to json correctly', () {
@@ -36,6 +37,7 @@ void main() {
         messageId: 'messageId',
         unreadThreadMessages: 2,
         unreadThreads: 3,
+        channelLastMessageAt: DateTime.parse('2019-03-27T17:40:17.155892Z'),
       );
 
       expect(
@@ -66,6 +68,7 @@ void main() {
           'thread': null,
           'unread_thread_messages': 2,
           'unread_threads': 3,
+          'channel_last_message_at': '2019-03-27T17:40:17.155892Z',
         },
       );
     });
@@ -82,6 +85,7 @@ void main() {
       expect(newEvent.isLocal, false);
       expect(newEvent.unreadThreadMessages, 2);
       expect(newEvent.unreadThreads, 3);
+      expect(newEvent.channelLastMessageAt, isA<DateTime>());
 
       newEvent = event.copyWith(
         type: 'test',
@@ -94,6 +98,7 @@ void main() {
         channelType: 'testtype',
         unreadThreadMessages: 6,
         unreadThreads: 7,
+        channelLastMessageAt: DateTime.parse('2020-01-29T03:22:47.636130Z'),
       );
 
       expect(newEvent.channelType, 'testtype');
@@ -106,6 +111,10 @@ void main() {
       expect(newEvent.user!.id, 'test');
       expect(newEvent.unreadThreadMessages, 6);
       expect(newEvent.unreadThreads, 7);
+      expect(
+        newEvent.channelLastMessageAt,
+        DateTime.parse('2020-01-29T03:22:47.636130Z'),
+      );
     });
   });
 }

--- a/packages/stream_chat/test/src/core/models/message_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(message.pinExpires, null);
       expect(message.pinnedBy, null);
       expect(message.i18n, null);
+      expect(message.restrictedVisibility, isA<List<String>>());
     });
 
     test('should serialize to json correctly', () {
@@ -55,6 +56,7 @@ void main() {
         ],
         showInChannel: true,
         parentId: 'parentId',
+        restrictedVisibility: const ['user-id-3'],
         extraData: const {'hey': 'test'},
       );
 


### PR DESCRIPTION
This pull request includes several changes to the `stream_chat` package, focusing on improving the handling of system messages, updating the logic for message visibility, and enhancing the persistence of channel states. Below are the most important changes:

### Enhancements to System Messages Handling:

* Added support for system messages not updating `channel.lastMessageAt` in `CHANGELOG.md`.
* Introduced a new method `_shouldUpdateChannelLastMessageAt` in `ChannelClientState` to determine if the last message time should be updated based on message properties.

### Updates to Channel State Persistence:

* Refactored the debounced update logic for channel state persistence in `ChannelClientState` to use a more concise `debounce` function.
* Modified the logic to calculate the new last message time in `ChannelClientState`, ensuring it only updates when necessary.

### Changes to Data Models:

* Added `skipLastMsgUpdateForSystemMsgs` to `ChannelConfig` to control whether system messages update the last message time. [[1]](diffhunk://#diff-806676a5e951784eadc73852aaddcd862bd4993f15f3839b4f4b775ffc0e7b6eR27) [[2]](diffhunk://#diff-806676a5e951784eadc73852aaddcd862bd4993f15f3839b4f4b775ffc0e7b6eR83-R89)
* Included `restrictedVisibility` in the `Message` model to manage message visibility for specific users. [[1]](diffhunk://#diff-d3e3b9e6b3253e66b920f443ff73bdc4c0a0c082d38c6cefb05cc866792cf3b4R59) [[2]](diffhunk://#diff-d3e3b9e6b3253e66b920f443ff73bdc4c0a0c082d38c6cefb05cc866792cf3b4R241-R244)

### JSON Serialization Updates:

* Updated `ChannelConfig` and `Event` models to include new fields in their JSON serialization and deserialization methods. [[1]](diffhunk://#diff-45f41aff24bdd37d294cfc954ab7fe1c9ec534668f006a989a127b4504b3fc0dR34-R35) [[2]](diffhunk://#diff-45f41aff24bdd37d294cfc954ab7fe1c9ec534668f006a989a127b4504b3fc0dR56-R57) [[3]](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441R45-R47) [[4]](diffhunk://#diff-8fb00cad47f9b31445873bf8e446e977fb942c259f4f889390b4f23bebd3d441R68-R69)
* Added `restrictedVisibility` to the `Message` model's JSON serialization and deserialization methods. [[1]](diffhunk://#diff-f07d92699dc45c9d655202504c0d519dac5d114b0b9803bdef2a740000061a0cR79-R81) [[2]](diffhunk://#diff-b9870f336c4f07377ca5a0ed36a20eb881141396c848880083076acfe0306b72L82-R84) [[3]](diffhunk://#diff-dba832c33065c34ddffe35de6ce8d3a3b1cb4bcfb8b53ff8c1e71c61b30227c2L65-R68)

### Test Updates:

* Updated test fixtures and test cases to reflect changes in channel state and message visibility handling. [[1]](diffhunk://#diff-b9870f336c4f07377ca5a0ed36a20eb881141396c848880083076acfe0306b72L82-R84) [[2]](diffhunk://#diff-b634559566463f671317de6b2e84fc0f8037515dce8e06e3188cf28776a82c44L32-R33) [[3]](diffhunk://#diff-e7303cca5b1f6b82cd210208685bc79d17f48bc5225d9e23c2971f0d4a769152R1-R4) [[4]](diffhunk://#diff-e7303cca5b1f6b82cd210208685bc79d17f48bc5225d9e23c2971f0d4a769152R18) [[5]](diffhunk://#diff-e7303cca5b1f6b82cd210208685bc79d17f48bc5225d9e23c2971f0d4a769152R31)