### PR TITLE
feat(llc, ui, persistence): add support for private messages

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -12,6 +12,7 @@
 ✅ Added
 
 - [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`
+- Added support for sending private or restricted visibility messages.
 
 ## 9.4.0
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2508,12 +2508,9 @@ class ChannelClientState {
       return false;
     }
 
-    final currentUser = _channel._client.state.currentUser;
-    final restrictedVisibility = message.restrictedVisibility;
-    if (restrictedVisibility case final visibility?) {
-      if (visibility.isNotEmpty && !visibility.contains(currentUser?.id)) {
-        return false;
-      }
+    final currentUserId = _channel._client.state.currentUser?.id;
+    if (currentUserId case final userId? when message.isNotVisibleTo(userId)) {
+      return false;
     }
 
     return true;

--- a/packages/stream_chat/lib/src/core/models/message.g.dart
+++ b/packages/stream_chat/lib/src/core/models/message.g.dart
@@ -94,5 +94,7 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'pinned': instance.pinned,
       'pin_expires': instance.pinExpires?.toIso8601String(),
       'poll_id': instance.pollId,
+      if (instance.restrictedVisibility case final value?)
+        'restricted_visibility': value,
       'extra_data': instance.extraData,
     };

--- a/packages/stream_chat/test/fixtures/channel_state_to_json.json
+++ b/packages/stream_chat/test/fixtures/channel_state_to_json.json
@@ -25,7 +25,10 @@
       "silent": false,
       "pinned": false,
       "pin_expires": null,
-      "poll_id": null
+      "poll_id": null,
+      "restricted_visibility": [
+        "user-id-3"
+      ]
     },
     {
       "id": "dry-meadow-0-e8e74482-b4cd-48db-9d1e-30e6c191786f",

--- a/packages/stream_chat/test/fixtures/message_to_json.json
+++ b/packages/stream_chat/test/fixtures/message_to_json.json
@@ -23,5 +23,8 @@
   "pin_expires": null,
   "poll_id": null,
   "show_in_channel": true,
+  "restricted_visibility": [
+    "user-id-3"
+  ],
   "hey": "test"
 }

--- a/packages/stream_chat/test/src/core/models/channel_test.dart
+++ b/packages/stream_chat/test/src/core/models/channel_test.dart
@@ -61,7 +61,6 @@ void main() {
 
     expect(channel.hidden, false);
     expect(channel.extraData['hidden'], false);
-    print(channel.toJson());
     expect(channel.toJson(), {
       'id': 'cid',
       'type': 'test',
@@ -105,7 +104,6 @@ void main() {
 
     expect(channel.disabled, false);
     expect(channel.extraData['disabled'], false);
-    print(channel.toJson());
     expect(channel.toJson(), {
       'id': 'cid',
       'type': 'test',
@@ -150,7 +148,6 @@ void main() {
 
     expect(channel.truncatedAt, currentDate);
     expect(channel.extraData['truncated_at'], currentDate.toIso8601String());
-    print(channel.toJson());
     expect(channel.toJson(), {
       'id': 'cid',
       'type': 'test',

--- a/packages/stream_chat/test/src/core/models/message_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'package:stream_chat/src/core/models/attachment.dart';
 import 'package:stream_chat/src/core/models/message.dart';
 import 'package:stream_chat/src/core/models/reaction.dart';
@@ -64,6 +66,88 @@ void main() {
         message.toJson(),
         jsonFixture('message_to_json.json'),
       );
+    });
+  });
+
+  group('MessageVisibility Extension Tests', () {
+    group('hasRestrictedVisibility', () {
+      test('should return false when restrictedVisibility is null', () {
+        final message = Message(restrictedVisibility: null);
+        expect(message.hasRestrictedVisibility, false);
+      });
+
+      test('should return false when restrictedVisibility is empty', () {
+        final message = Message(restrictedVisibility: const []);
+        expect(message.hasRestrictedVisibility, false);
+      });
+
+      test('should return true when restrictedVisibility has entries', () {
+        final message = Message(restrictedVisibility: const ['user1', 'user2']);
+        expect(message.hasRestrictedVisibility, true);
+      });
+    });
+
+    group('isVisibleTo', () {
+      test('should return true when restrictedVisibility is null', () {
+        final message = Message(restrictedVisibility: null);
+        expect(message.isVisibleTo('anyUser'), true);
+      });
+
+      test('should return true when restrictedVisibility is empty', () {
+        final message = Message(restrictedVisibility: const []);
+        expect(message.isVisibleTo('anyUser'), true);
+      });
+
+      test('should return true when user is in restrictedVisibility list', () {
+        final message =
+            Message(restrictedVisibility: const ['user1', 'user2', 'user3']);
+        expect(message.isVisibleTo('user2'), true);
+      });
+
+      test('should return false when user is not in restrictedVisibility list',
+          () {
+        final message =
+            Message(restrictedVisibility: const ['user1', 'user2', 'user3']);
+        expect(message.isVisibleTo('user4'), false);
+      });
+
+      test('should handle case sensitivity correctly', () {
+        final message = Message(restrictedVisibility: const ['User1', 'USER2']);
+        expect(message.isVisibleTo('user1'), false,
+            reason: 'Should be case sensitive');
+        expect(message.isVisibleTo('User1'), true);
+      });
+    });
+
+    group('isNotVisibleTo', () {
+      test('should return false when restrictedVisibility is null', () {
+        final message = Message(restrictedVisibility: null);
+        expect(message.isNotVisibleTo('anyUser'), false);
+      });
+
+      test('should return false when restrictedVisibility is empty', () {
+        final message = Message(restrictedVisibility: const []);
+        expect(message.isNotVisibleTo('anyUser'), false);
+      });
+
+      test('should return false when user is in restrictedVisibility list', () {
+        final message =
+            Message(restrictedVisibility: const ['user1', 'user2', 'user3']);
+        expect(message.isNotVisibleTo('user2'), false);
+      });
+
+      test('should return true when user is not in restrictedVisibility list',
+          () {
+        final message =
+            Message(restrictedVisibility: const ['user1', 'user2', 'user3']);
+        expect(message.isNotVisibleTo('user4'), true);
+      });
+
+      test('should be the exact opposite of isVisibleTo', () {
+        final message = Message(restrictedVisibility: const ['user1', 'user2']);
+        const userId = 'testUser';
+        expect(message.isNotVisibleTo(userId), !message.isVisibleTo(userId));
+      });
     });
   });
 }

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fixed `StreamMessageInput` not able to edit the ogAttachments.
 - Fixed `MessageWidget` showing pinned background for deleted messages.
 
+🔄 Changed
+
+- Updated the message list view to prevent pinning messages that have restricted visibility.
+
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -1095,7 +1095,12 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
         FocusScope.of(context).unfocus();
       },
       showPinButton: currentUserMember != null &&
-          _userPermissions.contains(PermissionType.pinMessage),
+          _userPermissions.contains(PermissionType.pinMessage) &&
+          // Pinning a restricted visibility message is not allowed, simply
+          // because pinning a message is meant to bring attention to that
+          // message, that is not possible with a message that is only visible
+          // to a subset of users.
+          !message.hasRestrictedVisibility,
     );
 
     if (widget.parentMessageBuilder != null) {
@@ -1453,7 +1458,12 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
         FocusScope.of(context).unfocus();
       },
       showPinButton: currentUserMember != null &&
-          _userPermissions.contains(PermissionType.pinMessage),
+          _userPermissions.contains(PermissionType.pinMessage) &&
+          // Pinning a restricted visibility message is not allowed, simply
+          // because pinning a message is meant to bring attention to that
+          // message, that is not possible with a message that is only visible
+          // to a subset of users.
+          !message.hasRestrictedVisibility,
     );
 
     if (widget.messageBuilder != null) {

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Added support for `Message.restrictedVisibility` field.
+
 ## 9.4.0
 
 - Updated minimum Flutter version to 3.27.4 for the SDK.

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -53,7 +53,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => 17;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -863,6 +863,15 @@ class $MessagesTable extends Messages
       i18n = GeneratedColumn<String>('i18n', aliasedName, true,
               type: DriftSqlType.string, requiredDuringInsert: false)
           .withConverter<Map<String, String>?>($MessagesTable.$converteri18n);
+  static const VerificationMeta _restrictedVisibilityMeta =
+      const VerificationMeta('restrictedVisibility');
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>?, String>
+      restrictedVisibility = GeneratedColumn<String>(
+              'restricted_visibility', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<List<String>?>(
+              $MessagesTable.$converterrestrictedVisibilityn);
   static const VerificationMeta _extraDataMeta =
       const VerificationMeta('extraData');
   @override
@@ -902,6 +911,7 @@ class $MessagesTable extends Messages
         pinnedByUserId,
         channelCid,
         i18n,
+        restrictedVisibility,
         extraData
       ];
   @override
@@ -1048,6 +1058,8 @@ class $MessagesTable extends Messages
       context.missing(_channelCidMeta);
     }
     context.handle(_i18nMeta, const VerificationResult.success());
+    context.handle(
+        _restrictedVisibilityMeta, const VerificationResult.success());
     context.handle(_extraDataMeta, const VerificationResult.success());
     return context;
   }
@@ -1121,6 +1133,9 @@ class $MessagesTable extends Messages
           .read(DriftSqlType.string, data['${effectivePrefix}channel_cid'])!,
       i18n: $MessagesTable.$converteri18n.fromSql(attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}i18n'])),
+      restrictedVisibility: $MessagesTable.$converterrestrictedVisibilityn
+          .fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string,
+              data['${effectivePrefix}restricted_visibility'])),
       extraData: $MessagesTable.$converterextraDatan.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}extra_data'])),
@@ -1146,6 +1161,10 @@ class $MessagesTable extends Messages
       NullAwareTypeConverter.wrap($converterreactionScores);
   static TypeConverter<Map<String, String>?, String?> $converteri18n =
       NullableMapConverter<String>();
+  static TypeConverter<List<String>, String> $converterrestrictedVisibility =
+      ListConverter<String>();
+  static TypeConverter<List<String>?, String?> $converterrestrictedVisibilityn =
+      NullAwareTypeConverter.wrap($converterrestrictedVisibility);
   static TypeConverter<Map<String, dynamic>, String> $converterextraData =
       MapConverter();
   static TypeConverter<Map<String, dynamic>?, String?> $converterextraDatan =
@@ -1241,6 +1260,9 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
   /// A Map of [messageText] translations.
   final Map<String, String>? i18n;
 
+  /// The list of user ids that should be able to see the message.
+  final List<String>? restrictedVisibility;
+
   /// Message custom extraData
   final Map<String, dynamic>? extraData;
   const MessageEntity(
@@ -1273,6 +1295,7 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       this.pinnedByUserId,
       required this.channelCid,
       this.i18n,
+      this.restrictedVisibility,
       this.extraData});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1356,6 +1379,11 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
     if (!nullToAbsent || i18n != null) {
       map['i18n'] = Variable<String>($MessagesTable.$converteri18n.toSql(i18n));
     }
+    if (!nullToAbsent || restrictedVisibility != null) {
+      map['restricted_visibility'] = Variable<String>($MessagesTable
+          .$converterrestrictedVisibilityn
+          .toSql(restrictedVisibility));
+    }
     if (!nullToAbsent || extraData != null) {
       map['extra_data'] = Variable<String>(
           $MessagesTable.$converterextraDatan.toSql(extraData));
@@ -1399,6 +1427,8 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       pinnedByUserId: serializer.fromJson<String?>(json['pinnedByUserId']),
       channelCid: serializer.fromJson<String>(json['channelCid']),
       i18n: serializer.fromJson<Map<String, String>?>(json['i18n']),
+      restrictedVisibility:
+          serializer.fromJson<List<String>?>(json['restrictedVisibility']),
       extraData: serializer.fromJson<Map<String, dynamic>?>(json['extraData']),
     );
   }
@@ -1436,6 +1466,8 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       'pinnedByUserId': serializer.toJson<String?>(pinnedByUserId),
       'channelCid': serializer.toJson<String>(channelCid),
       'i18n': serializer.toJson<Map<String, String>?>(i18n),
+      'restrictedVisibility':
+          serializer.toJson<List<String>?>(restrictedVisibility),
       'extraData': serializer.toJson<Map<String, dynamic>?>(extraData),
     };
   }
@@ -1470,6 +1502,7 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           Value<String?> pinnedByUserId = const Value.absent(),
           String? channelCid,
           Value<Map<String, String>?> i18n = const Value.absent(),
+          Value<List<String>?> restrictedVisibility = const Value.absent(),
           Value<Map<String, dynamic>?> extraData = const Value.absent()}) =>
       MessageEntity(
         id: id ?? this.id,
@@ -1518,6 +1551,9 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
             pinnedByUserId.present ? pinnedByUserId.value : this.pinnedByUserId,
         channelCid: channelCid ?? this.channelCid,
         i18n: i18n.present ? i18n.value : this.i18n,
+        restrictedVisibility: restrictedVisibility.present
+            ? restrictedVisibility.value
+            : this.restrictedVisibility,
         extraData: extraData.present ? extraData.value : this.extraData,
       );
   MessageEntity copyWithCompanion(MessagesCompanion data) {
@@ -1582,6 +1618,9 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       channelCid:
           data.channelCid.present ? data.channelCid.value : this.channelCid,
       i18n: data.i18n.present ? data.i18n.value : this.i18n,
+      restrictedVisibility: data.restrictedVisibility.present
+          ? data.restrictedVisibility.value
+          : this.restrictedVisibility,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
     );
   }
@@ -1618,6 +1657,7 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           ..write('pinnedByUserId: $pinnedByUserId, ')
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
+          ..write('restrictedVisibility: $restrictedVisibility, ')
           ..write('extraData: $extraData')
           ..write(')'))
         .toString();
@@ -1654,6 +1694,7 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
         pinnedByUserId,
         channelCid,
         i18n,
+        restrictedVisibility,
         extraData
       ]);
   @override
@@ -1689,6 +1730,7 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           other.pinnedByUserId == this.pinnedByUserId &&
           other.channelCid == this.channelCid &&
           other.i18n == this.i18n &&
+          other.restrictedVisibility == this.restrictedVisibility &&
           other.extraData == this.extraData);
 }
 
@@ -1722,6 +1764,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
   final Value<String?> pinnedByUserId;
   final Value<String> channelCid;
   final Value<Map<String, String>?> i18n;
+  final Value<List<String>?> restrictedVisibility;
   final Value<Map<String, dynamic>?> extraData;
   final Value<int> rowid;
   const MessagesCompanion({
@@ -1754,6 +1797,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     this.pinnedByUserId = const Value.absent(),
     this.channelCid = const Value.absent(),
     this.i18n = const Value.absent(),
+    this.restrictedVisibility = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -1787,6 +1831,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     this.pinnedByUserId = const Value.absent(),
     required String channelCid,
     this.i18n = const Value.absent(),
+    this.restrictedVisibility = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -1824,6 +1869,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     Expression<String>? pinnedByUserId,
     Expression<String>? channelCid,
     Expression<String>? i18n,
+    Expression<String>? restrictedVisibility,
     Expression<String>? extraData,
     Expression<int>? rowid,
   }) {
@@ -1858,6 +1904,8 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       if (pinnedByUserId != null) 'pinned_by_user_id': pinnedByUserId,
       if (channelCid != null) 'channel_cid': channelCid,
       if (i18n != null) 'i18n': i18n,
+      if (restrictedVisibility != null)
+        'restricted_visibility': restrictedVisibility,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
     });
@@ -1893,6 +1941,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       Value<String?>? pinnedByUserId,
       Value<String>? channelCid,
       Value<Map<String, String>?>? i18n,
+      Value<List<String>?>? restrictedVisibility,
       Value<Map<String, dynamic>?>? extraData,
       Value<int>? rowid}) {
     return MessagesCompanion(
@@ -1925,6 +1974,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       pinnedByUserId: pinnedByUserId ?? this.pinnedByUserId,
       channelCid: channelCid ?? this.channelCid,
       i18n: i18n ?? this.i18n,
+      restrictedVisibility: restrictedVisibility ?? this.restrictedVisibility,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
     );
@@ -2026,6 +2076,11 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       map['i18n'] =
           Variable<String>($MessagesTable.$converteri18n.toSql(i18n.value));
     }
+    if (restrictedVisibility.present) {
+      map['restricted_visibility'] = Variable<String>($MessagesTable
+          .$converterrestrictedVisibilityn
+          .toSql(restrictedVisibility.value));
+    }
     if (extraData.present) {
       map['extra_data'] = Variable<String>(
           $MessagesTable.$converterextraDatan.toSql(extraData.value));
@@ -2068,6 +2123,7 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
           ..write('pinnedByUserId: $pinnedByUserId, ')
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
+          ..write('restrictedVisibility: $restrictedVisibility, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -2274,6 +2330,15 @@ class $PinnedMessagesTable extends PinnedMessages
               type: DriftSqlType.string, requiredDuringInsert: false)
           .withConverter<Map<String, String>?>(
               $PinnedMessagesTable.$converteri18n);
+  static const VerificationMeta _restrictedVisibilityMeta =
+      const VerificationMeta('restrictedVisibility');
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>?, String>
+      restrictedVisibility = GeneratedColumn<String>(
+              'restricted_visibility', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<List<String>?>(
+              $PinnedMessagesTable.$converterrestrictedVisibilityn);
   static const VerificationMeta _extraDataMeta =
       const VerificationMeta('extraData');
   @override
@@ -2313,6 +2378,7 @@ class $PinnedMessagesTable extends PinnedMessages
         pinnedByUserId,
         channelCid,
         i18n,
+        restrictedVisibility,
         extraData
       ];
   @override
@@ -2460,6 +2526,8 @@ class $PinnedMessagesTable extends PinnedMessages
       context.missing(_channelCidMeta);
     }
     context.handle(_i18nMeta, const VerificationResult.success());
+    context.handle(
+        _restrictedVisibilityMeta, const VerificationResult.success());
     context.handle(_extraDataMeta, const VerificationResult.success());
     return context;
   }
@@ -2534,6 +2602,9 @@ class $PinnedMessagesTable extends PinnedMessages
       i18n: $PinnedMessagesTable.$converteri18n.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}i18n'])),
+      restrictedVisibility: $PinnedMessagesTable.$converterrestrictedVisibilityn
+          .fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string,
+              data['${effectivePrefix}restricted_visibility'])),
       extraData: $PinnedMessagesTable.$converterextraDatan.fromSql(
           attachedDatabase.typeMapping
               .read(DriftSqlType.string, data['${effectivePrefix}extra_data'])),
@@ -2559,6 +2630,10 @@ class $PinnedMessagesTable extends PinnedMessages
       NullAwareTypeConverter.wrap($converterreactionScores);
   static TypeConverter<Map<String, String>?, String?> $converteri18n =
       NullableMapConverter<String>();
+  static TypeConverter<List<String>, String> $converterrestrictedVisibility =
+      ListConverter<String>();
+  static TypeConverter<List<String>?, String?> $converterrestrictedVisibilityn =
+      NullAwareTypeConverter.wrap($converterrestrictedVisibility);
   static TypeConverter<Map<String, dynamic>, String> $converterextraData =
       MapConverter();
   static TypeConverter<Map<String, dynamic>?, String?> $converterextraDatan =
@@ -2655,6 +2730,9 @@ class PinnedMessageEntity extends DataClass
   /// A Map of [messageText] translations.
   final Map<String, String>? i18n;
 
+  /// The list of user ids that should be able to see the message.
+  final List<String>? restrictedVisibility;
+
   /// Message custom extraData
   final Map<String, dynamic>? extraData;
   const PinnedMessageEntity(
@@ -2687,6 +2765,7 @@ class PinnedMessageEntity extends DataClass
       this.pinnedByUserId,
       required this.channelCid,
       this.i18n,
+      this.restrictedVisibility,
       this.extraData});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -2771,6 +2850,11 @@ class PinnedMessageEntity extends DataClass
       map['i18n'] =
           Variable<String>($PinnedMessagesTable.$converteri18n.toSql(i18n));
     }
+    if (!nullToAbsent || restrictedVisibility != null) {
+      map['restricted_visibility'] = Variable<String>($PinnedMessagesTable
+          .$converterrestrictedVisibilityn
+          .toSql(restrictedVisibility));
+    }
     if (!nullToAbsent || extraData != null) {
       map['extra_data'] = Variable<String>(
           $PinnedMessagesTable.$converterextraDatan.toSql(extraData));
@@ -2814,6 +2898,8 @@ class PinnedMessageEntity extends DataClass
       pinnedByUserId: serializer.fromJson<String?>(json['pinnedByUserId']),
       channelCid: serializer.fromJson<String>(json['channelCid']),
       i18n: serializer.fromJson<Map<String, String>?>(json['i18n']),
+      restrictedVisibility:
+          serializer.fromJson<List<String>?>(json['restrictedVisibility']),
       extraData: serializer.fromJson<Map<String, dynamic>?>(json['extraData']),
     );
   }
@@ -2851,6 +2937,8 @@ class PinnedMessageEntity extends DataClass
       'pinnedByUserId': serializer.toJson<String?>(pinnedByUserId),
       'channelCid': serializer.toJson<String>(channelCid),
       'i18n': serializer.toJson<Map<String, String>?>(i18n),
+      'restrictedVisibility':
+          serializer.toJson<List<String>?>(restrictedVisibility),
       'extraData': serializer.toJson<Map<String, dynamic>?>(extraData),
     };
   }
@@ -2885,6 +2973,7 @@ class PinnedMessageEntity extends DataClass
           Value<String?> pinnedByUserId = const Value.absent(),
           String? channelCid,
           Value<Map<String, String>?> i18n = const Value.absent(),
+          Value<List<String>?> restrictedVisibility = const Value.absent(),
           Value<Map<String, dynamic>?> extraData = const Value.absent()}) =>
       PinnedMessageEntity(
         id: id ?? this.id,
@@ -2933,6 +3022,9 @@ class PinnedMessageEntity extends DataClass
             pinnedByUserId.present ? pinnedByUserId.value : this.pinnedByUserId,
         channelCid: channelCid ?? this.channelCid,
         i18n: i18n.present ? i18n.value : this.i18n,
+        restrictedVisibility: restrictedVisibility.present
+            ? restrictedVisibility.value
+            : this.restrictedVisibility,
         extraData: extraData.present ? extraData.value : this.extraData,
       );
   PinnedMessageEntity copyWithCompanion(PinnedMessagesCompanion data) {
@@ -2997,6 +3089,9 @@ class PinnedMessageEntity extends DataClass
       channelCid:
           data.channelCid.present ? data.channelCid.value : this.channelCid,
       i18n: data.i18n.present ? data.i18n.value : this.i18n,
+      restrictedVisibility: data.restrictedVisibility.present
+          ? data.restrictedVisibility.value
+          : this.restrictedVisibility,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
     );
   }
@@ -3033,6 +3128,7 @@ class PinnedMessageEntity extends DataClass
           ..write('pinnedByUserId: $pinnedByUserId, ')
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
+          ..write('restrictedVisibility: $restrictedVisibility, ')
           ..write('extraData: $extraData')
           ..write(')'))
         .toString();
@@ -3069,6 +3165,7 @@ class PinnedMessageEntity extends DataClass
         pinnedByUserId,
         channelCid,
         i18n,
+        restrictedVisibility,
         extraData
       ]);
   @override
@@ -3104,6 +3201,7 @@ class PinnedMessageEntity extends DataClass
           other.pinnedByUserId == this.pinnedByUserId &&
           other.channelCid == this.channelCid &&
           other.i18n == this.i18n &&
+          other.restrictedVisibility == this.restrictedVisibility &&
           other.extraData == this.extraData);
 }
 
@@ -3137,6 +3235,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
   final Value<String?> pinnedByUserId;
   final Value<String> channelCid;
   final Value<Map<String, String>?> i18n;
+  final Value<List<String>?> restrictedVisibility;
   final Value<Map<String, dynamic>?> extraData;
   final Value<int> rowid;
   const PinnedMessagesCompanion({
@@ -3169,6 +3268,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     this.pinnedByUserId = const Value.absent(),
     this.channelCid = const Value.absent(),
     this.i18n = const Value.absent(),
+    this.restrictedVisibility = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -3202,6 +3302,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     this.pinnedByUserId = const Value.absent(),
     required String channelCid,
     this.i18n = const Value.absent(),
+    this.restrictedVisibility = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -3239,6 +3340,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     Expression<String>? pinnedByUserId,
     Expression<String>? channelCid,
     Expression<String>? i18n,
+    Expression<String>? restrictedVisibility,
     Expression<String>? extraData,
     Expression<int>? rowid,
   }) {
@@ -3273,6 +3375,8 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       if (pinnedByUserId != null) 'pinned_by_user_id': pinnedByUserId,
       if (channelCid != null) 'channel_cid': channelCid,
       if (i18n != null) 'i18n': i18n,
+      if (restrictedVisibility != null)
+        'restricted_visibility': restrictedVisibility,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
     });
@@ -3308,6 +3412,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       Value<String?>? pinnedByUserId,
       Value<String>? channelCid,
       Value<Map<String, String>?>? i18n,
+      Value<List<String>?>? restrictedVisibility,
       Value<Map<String, dynamic>?>? extraData,
       Value<int>? rowid}) {
     return PinnedMessagesCompanion(
@@ -3340,6 +3445,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       pinnedByUserId: pinnedByUserId ?? this.pinnedByUserId,
       channelCid: channelCid ?? this.channelCid,
       i18n: i18n ?? this.i18n,
+      restrictedVisibility: restrictedVisibility ?? this.restrictedVisibility,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
     );
@@ -3444,6 +3550,11 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       map['i18n'] = Variable<String>(
           $PinnedMessagesTable.$converteri18n.toSql(i18n.value));
     }
+    if (restrictedVisibility.present) {
+      map['restricted_visibility'] = Variable<String>($PinnedMessagesTable
+          .$converterrestrictedVisibilityn
+          .toSql(restrictedVisibility.value));
+    }
     if (extraData.present) {
       map['extra_data'] = Variable<String>(
           $PinnedMessagesTable.$converterextraDatan.toSql(extraData.value));
@@ -3486,6 +3597,7 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
           ..write('pinnedByUserId: $pinnedByUserId, ')
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
+          ..write('restrictedVisibility: $restrictedVisibility, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -8091,6 +8203,7 @@ typedef $$MessagesTableCreateCompanionBuilder = MessagesCompanion Function({
   Value<String?> pinnedByUserId,
   required String channelCid,
   Value<Map<String, String>?> i18n,
+  Value<List<String>?> restrictedVisibility,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -8124,6 +8237,7 @@ typedef $$MessagesTableUpdateCompanionBuilder = MessagesCompanion Function({
   Value<String?> pinnedByUserId,
   Value<String> channelCid,
   Value<Map<String, String>?> i18n,
+  Value<List<String>?> restrictedVisibility,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -8272,6 +8386,11 @@ class $$MessagesTableFilterComposer
           String>
       get i18n => $composableBuilder(
           column: $table.i18n,
+          builder: (column) => ColumnWithTypeConverterFilters(column));
+
+  ColumnWithTypeConverterFilters<List<String>?, List<String>, String>
+      get restrictedVisibility => $composableBuilder(
+          column: $table.restrictedVisibility,
           builder: (column) => ColumnWithTypeConverterFilters(column));
 
   ColumnWithTypeConverterFilters<Map<String, dynamic>?, Map<String, dynamic>,
@@ -8428,6 +8547,10 @@ class $$MessagesTableOrderingComposer
   ColumnOrderings<String> get i18n => $composableBuilder(
       column: $table.i18n, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get restrictedVisibility => $composableBuilder(
+      column: $table.restrictedVisibility,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get extraData => $composableBuilder(
       column: $table.extraData, builder: (column) => ColumnOrderings(column));
 
@@ -8549,6 +8672,10 @@ class $$MessagesTableAnnotationComposer
   GeneratedColumnWithTypeConverter<Map<String, String>?, String> get i18n =>
       $composableBuilder(column: $table.i18n, builder: (column) => column);
 
+  GeneratedColumnWithTypeConverter<List<String>?, String>
+      get restrictedVisibility => $composableBuilder(
+          column: $table.restrictedVisibility, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       get extraData => $composableBuilder(
           column: $table.extraData, builder: (column) => column);
@@ -8647,6 +8774,7 @@ class $$MessagesTableTableManager extends RootTableManager<
             Value<String?> pinnedByUserId = const Value.absent(),
             Value<String> channelCid = const Value.absent(),
             Value<Map<String, String>?> i18n = const Value.absent(),
+            Value<List<String>?> restrictedVisibility = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -8680,6 +8808,7 @@ class $$MessagesTableTableManager extends RootTableManager<
             pinnedByUserId: pinnedByUserId,
             channelCid: channelCid,
             i18n: i18n,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -8713,6 +8842,7 @@ class $$MessagesTableTableManager extends RootTableManager<
             Value<String?> pinnedByUserId = const Value.absent(),
             required String channelCid,
             Value<Map<String, String>?> i18n = const Value.absent(),
+            Value<List<String>?> restrictedVisibility = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -8746,6 +8876,7 @@ class $$MessagesTableTableManager extends RootTableManager<
             pinnedByUserId: pinnedByUserId,
             channelCid: channelCid,
             i18n: i18n,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -8847,6 +8978,7 @@ typedef $$PinnedMessagesTableCreateCompanionBuilder = PinnedMessagesCompanion
   Value<String?> pinnedByUserId,
   required String channelCid,
   Value<Map<String, String>?> i18n,
+  Value<List<String>?> restrictedVisibility,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -8881,6 +9013,7 @@ typedef $$PinnedMessagesTableUpdateCompanionBuilder = PinnedMessagesCompanion
   Value<String?> pinnedByUserId,
   Value<String> channelCid,
   Value<Map<String, String>?> i18n,
+  Value<List<String>?> restrictedVisibility,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -9026,6 +9159,11 @@ class $$PinnedMessagesTableFilterComposer
           column: $table.i18n,
           builder: (column) => ColumnWithTypeConverterFilters(column));
 
+  ColumnWithTypeConverterFilters<List<String>?, List<String>, String>
+      get restrictedVisibility => $composableBuilder(
+          column: $table.restrictedVisibility,
+          builder: (column) => ColumnWithTypeConverterFilters(column));
+
   ColumnWithTypeConverterFilters<Map<String, dynamic>?, Map<String, dynamic>,
           String>
       get extraData => $composableBuilder(
@@ -9165,6 +9303,10 @@ class $$PinnedMessagesTableOrderingComposer
   ColumnOrderings<String> get i18n => $composableBuilder(
       column: $table.i18n, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get restrictedVisibility => $composableBuilder(
+      column: $table.restrictedVisibility,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get extraData => $composableBuilder(
       column: $table.extraData, builder: (column) => ColumnOrderings(column));
 }
@@ -9269,6 +9411,10 @@ class $$PinnedMessagesTableAnnotationComposer
   GeneratedColumnWithTypeConverter<Map<String, String>?, String> get i18n =>
       $composableBuilder(column: $table.i18n, builder: (column) => column);
 
+  GeneratedColumnWithTypeConverter<List<String>?, String>
+      get restrictedVisibility => $composableBuilder(
+          column: $table.restrictedVisibility, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       get extraData => $composableBuilder(
           column: $table.extraData, builder: (column) => column);
@@ -9350,6 +9496,7 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             Value<String?> pinnedByUserId = const Value.absent(),
             Value<String> channelCid = const Value.absent(),
             Value<Map<String, String>?> i18n = const Value.absent(),
+            Value<List<String>?> restrictedVisibility = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -9383,6 +9530,7 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             pinnedByUserId: pinnedByUserId,
             channelCid: channelCid,
             i18n: i18n,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -9416,6 +9564,7 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             Value<String?> pinnedByUserId = const Value.absent(),
             required String channelCid,
             Value<Map<String, String>?> i18n = const Value.absent(),
+            Value<List<String>?> restrictedVisibility = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -9449,6 +9598,7 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             pinnedByUserId: pinnedByUserId,
             channelCid: channelCid,
             i18n: i18n,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData,
             rowid: rowid,
           ),

--- a/packages/stream_chat_persistence/lib/src/entity/messages.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/messages.dart
@@ -126,6 +126,10 @@ class Messages extends Table {
   TextColumn get i18n =>
       text().nullable().map(NullableMapConverter<String>())();
 
+  /// The list of user ids that should be able to see the message.
+  TextColumn get restrictedVisibility =>
+      text().nullable().map(ListConverter<String>())();
+
   /// Message custom extraData
   TextColumn get extraData => text().nullable().map(MapConverter())();
 

--- a/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
@@ -52,6 +52,7 @@ extension MessageEntityX on MessageEntity {
         mentionedUsers:
             mentionedUsers.map((e) => User.fromJson(jsonDecode(e))).toList(),
         i18n: i18n,
+        restrictedVisibility: restrictedVisibility,
       );
 }
 
@@ -89,5 +90,6 @@ extension MessageX on Message {
         pinExpires: pinExpires,
         pinnedByUserId: pinnedBy?.id,
         i18n: i18n,
+        restrictedVisibility: restrictedVisibility,
       );
 }

--- a/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
@@ -52,6 +52,7 @@ extension PinnedMessageEntityX on PinnedMessageEntity {
         mentionedUsers:
             mentionedUsers.map((e) => User.fromJson(jsonDecode(e))).toList(),
         i18n: i18n,
+        restrictedVisibility: restrictedVisibility,
       );
 }
 
@@ -90,5 +91,6 @@ extension PMessageX on Message {
         pinExpires: pinExpires,
         pinnedByUserId: pinnedBy?.id,
         i18n: i18n,
+        restrictedVisibility: restrictedVisibility,
       );
 }

--- a/packages/stream_chat_persistence/test/src/mapper/message_mapper_test.dart
+++ b/packages/stream_chat_persistence/test/src/mapper/message_mapper_test.dart
@@ -81,6 +81,7 @@ void main() {
         'hi_text': 'नमस्ते',
         'language': 'en',
       },
+      restrictedVisibility: const ['user-id-2'],
     );
     final message = entity.toMessage(
       user: user,
@@ -137,6 +138,7 @@ void main() {
       expect(messageAttachment.type, entityAttachment.type);
       expect(messageAttachment.assetUrl, entityAttachment.assetUrl);
     }
+    expect(message.restrictedVisibility, entity.restrictedVisibility);
   });
 
   test('toEntity should map message into MessageEntity', () {
@@ -210,6 +212,7 @@ void main() {
         'hi_text': 'नमस्ते',
         'language': 'en',
       },
+      restrictedVisibility: const ['user-id-2'],
     );
     final entity = message.toEntity(cid: cid);
     expect(entity, isA<MessageEntity>());
@@ -251,5 +254,6 @@ void main() {
       message.attachments.map((it) => jsonEncode(it.toData())).toList(),
     );
     expect(entity.i18n, message.i18n);
+    expect(entity.restrictedVisibility, message.restrictedVisibility);
   });
 }

--- a/packages/stream_chat_persistence/test/src/mapper/pinned_message_mapper_test.dart
+++ b/packages/stream_chat_persistence/test/src/mapper/pinned_message_mapper_test.dart
@@ -81,6 +81,7 @@ void main() {
         'hi_text': 'नमस्ते',
         'language': 'en',
       },
+      restrictedVisibility: const ['user-id-2'],
     );
     final message = entity.toMessage(
       user: user,
@@ -137,6 +138,7 @@ void main() {
       expect(messageAttachment.type, entityAttachment.type);
       expect(messageAttachment.assetUrl, entityAttachment.assetUrl);
     }
+    expect(message.restrictedVisibility, entity.restrictedVisibility);
   });
 
   test('toEntity should map message into MessageEntity', () {
@@ -210,6 +212,7 @@ void main() {
         'hi_text': 'नमस्ते',
         'language': 'en',
       },
+      restrictedVisibility: const ['user-id-2'],
     );
     final entity = message.toPinnedEntity(cid: cid);
     expect(entity, isA<PinnedMessageEntity>());
@@ -251,5 +254,6 @@ void main() {
       message.attachments.map((it) => jsonEncode(it.toData())).toList(),
     );
     expect(entity.i18n, message.i18n);
+    expect(entity.restrictedVisibility, message.restrictedVisibility);
   });
 }


### PR DESCRIPTION
Fixes: [FLU-29](https://linear.app/stream/issue/FLU-29)

This pull request introduces support for sending private or restricted visibility messages in the `stream_chat` package. The changes include updates to the message visibility logic, serialization, and the user interface to handle these new message types.

Key changes:

### New Feature: Restricted Visibility Messages

* [`packages/stream_chat/CHANGELOG.md`](diffhunk://#diff-0a4071421926a484a5e4e46567cd96230a5754549ea0a7198146eced8598442dR15): Added support for sending private or restricted visibility messages.
* [`packages/stream_chat/lib/src/core/models/message.dart`](diffhunk://#diff-d3e3b9e6b3253e66b920f443ff73bdc4c0a0c082d38c6cefb05cc866792cf3b4L241-R246): Updated the `Message` class to include a `restrictedVisibility` field and added an extension for visibility control methods. [[1]](diffhunk://#diff-d3e3b9e6b3253e66b920f443ff73bdc4c0a0c082d38c6cefb05cc866792cf3b4L241-R246) [[2]](diffhunk://#diff-d3e3b9e6b3253e66b920f443ff73bdc4c0a0c082d38c6cefb05cc866792cf3b4R531-R582)
* [`packages/stream_chat/lib/src/core/models/message.g.dart`](diffhunk://#diff-f07d92699dc45c9d655202504c0d519dac5d114b0b9803bdef2a740000061a0cR97-R98): Modified the JSON serialization logic to include the `restrictedVisibility` field when it is not null.

### Code Refactoring

* [`packages/stream_chat/lib/src/client/channel.dart`](diffhunk://#diff-f5b3c73311cd4ed2f91bb08aff0ca7385d4494f7e44294e082a0eb3aefee58cbL2511-L2517): Refactored the visibility check logic to use the new `isNotVisibleTo` method from the `MessageVisibility` extension.

### User Interface Adjustments

* [`packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart`](diffhunk://#diff-50fa0fcd0d85868ea01fb20e321e823e11ba9cb018c1405b10fba9dd31be4ac5L1098-R1103): Updated the message list view to prevent pinning messages that have restricted visibility. [[1]](diffhunk://#diff-50fa0fcd0d85868ea01fb20e321e823e11ba9cb018c1405b10fba9dd31be4ac5L1098-R1103) [[2]](diffhunk://#diff-50fa0fcd0d85868ea01fb20e321e823e11ba9cb018c1405b10fba9dd31be4ac5L1456-R1466)

These changes enhance the functionality of the `stream_chat` package by allowing messages to be visible only to specific users, improving privacy and control over message visibility.