### PR TITLE
feat(ui): introduce useSystemAttachmentPicker for system media picker support

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -7,12 +7,12 @@
 
 ✅ Added
 
-- Introduced `StreamMessageInput.useNativeAttachmentPicker` for system media picker support.
+- Introduced `StreamMessageInput.useSystemAttachmentPicker` for system media picker support.
 
 🔄 Changed
 
 - Updated the message list view to prevent pinning messages that have restricted visibility.
-- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of `StreamMessageInput.useNativeAttachmentPicker`.
+- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of `StreamMessageInput.useSystemAttachmentPicker`.
 
 ## 9.4.0
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Fixed `StreamMessageInput` not able to edit the ogAttachments.
 - Fixed `MessageWidget` showing pinned background for deleted messages.
 
+✅ Added
+
+- Introduced `StreamMessageInput.useNativeAttachmentPicker` for system media picker support.
+
+🔄 Changed
+
+- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of `StreamMessageInput.useNativeAttachmentPicker`.
+
 ## 9.4.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
@@ -79,8 +79,8 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
-  bool useNativeAttachmentPicker = false,
-  @Deprecated("Use 'useNativeAttachmentPicker' instead.")
+  bool useSystemAttachmentPicker = false,
+  @Deprecated("Use 'useSystemAttachmentPicker' instead.")
   bool useNativeAttachmentPickerOnMobile = false,
   RouteSettings? routeSettings,
   AnimationController? transitionAnimationController,
@@ -123,10 +123,10 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
             _ => false,
           };
 
-          final useNativePicker = useNativeAttachmentPicker || //
+          final useSystemPicker = useSystemAttachmentPicker || //
               useNativeAttachmentPickerOnMobile;
 
-          if (useNativePicker || isWebOrDesktop) {
+          if (useSystemPicker || isWebOrDesktop) {
             return webOrDesktopAttachmentPickerBuilder.call(
               context: context,
               onError: onError,

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -80,6 +79,8 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
+  bool useNativeAttachmentPicker = false,
+  @Deprecated("Use 'useNativeAttachmentPicker' instead.")
   bool useNativeAttachmentPickerOnMobile = false,
   RouteSettings? routeSettings,
   AnimationController? transitionAnimationController,
@@ -113,13 +114,19 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
         initialPoll: initialPoll,
         initialAttachments: initialAttachments,
         builder: (context, controller, child) {
-          final currentPlatform = defaultTargetPlatform;
-          final isWebOrDesktop = kIsWeb ||
-              currentPlatform == TargetPlatform.macOS ||
-              currentPlatform == TargetPlatform.linux ||
-              currentPlatform == TargetPlatform.windows;
+          final isWebOrDesktop = switch (CurrentPlatform.type) {
+            PlatformType.web ||
+            PlatformType.macOS ||
+            PlatformType.linux ||
+            PlatformType.windows =>
+              true,
+            _ => false,
+          };
 
-          if (isWebOrDesktop || useNativeAttachmentPickerOnMobile) {
+          final useNativePicker = useNativeAttachmentPicker || //
+              useNativeAttachmentPickerOnMobile;
+
+          if (useNativePicker || isWebOrDesktop) {
             return webOrDesktopAttachmentPickerBuilder.call(
               context: context,
               onError: onError,

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -157,9 +157,15 @@ class StreamMessageInput extends StatefulWidget {
     this.ogPreviewFilter = _defaultOgPreviewFilter,
     this.hintGetter = _defaultHintGetter,
     this.contentInsertionConfiguration,
-    this.useNativeAttachmentPickerOnMobile = false,
+    bool useNativeAttachmentPicker = false,
+    @Deprecated(
+      'Use useNativeAttachmentPicker instead. '
+      'This feature was deprecated after v9.4.0',
+    )
+    bool useNativeAttachmentPickerOnMobile = false,
     this.pollConfig,
-  });
+  }) : useNativeAttachmentPicker = useNativeAttachmentPicker || //
+            useNativeAttachmentPickerOnMobile;
 
   /// The predicate used to send a message on desktop/web
   final KeyEventPredicate sendMessageKeyPredicate;
@@ -374,9 +380,25 @@ class StreamMessageInput extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.contentInsertionConfiguration}
   final ContentInsertionConfiguration? contentInsertionConfiguration;
 
+  /// If True, allows you to use the system’s default media picker instead of
+  /// the custom media picker provided by the library. This can be beneficial
+  /// for several reasons:
+  ///
+  /// 1. Consistency: Provides a consistent user experience by using the
+  /// familiar system media picker.
+  /// 2. Permissions: Reduces the need for additional permissions, as the system
+  /// media picker handles permissions internally.
+  /// 3. Simplicity: Simplifies the implementation by leveraging the built-in
+  /// functionality of the system media picker.
+  final bool useNativeAttachmentPicker;
+
   /// Forces use of native attachment picker on mobile instead of the custom
   /// Stream attachment picker.
-  final bool useNativeAttachmentPickerOnMobile;
+  @Deprecated(
+    'Use useNativeAttachmentPicker instead. '
+    'This feature was deprecated after v9.4.0',
+  )
+  bool get useNativeAttachmentPickerOnMobile => useNativeAttachmentPicker;
 
   /// The configuration to use while creating a poll.
   ///
@@ -983,6 +1005,10 @@ class StreamMessageInputState extends State<StreamMessageInput>
         return true;
       });
 
+    final messageInputTheme = StreamMessageInputTheme.of(context);
+    final useNativePicker = widget.useNativeAttachmentPicker ||
+        (messageInputTheme.useNativeAttachmentPicker ?? false);
+
     final value = await showStreamAttachmentPickerModalBottomSheet(
       context: context,
       onError: widget.onError,
@@ -990,8 +1016,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       pollConfig: widget.pollConfig,
       initialPoll: initialPoll,
       initialAttachments: initialAttachments,
-      useNativeAttachmentPickerOnMobile:
-          widget.useNativeAttachmentPickerOnMobile,
+      useNativeAttachmentPicker: useNativePicker,
     );
 
     if (value == null || value is! AttachmentPickerValue) return;

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -157,14 +157,14 @@ class StreamMessageInput extends StatefulWidget {
     this.ogPreviewFilter = _defaultOgPreviewFilter,
     this.hintGetter = _defaultHintGetter,
     this.contentInsertionConfiguration,
-    bool useNativeAttachmentPicker = false,
+    bool useSystemAttachmentPicker = false,
     @Deprecated(
-      'Use useNativeAttachmentPicker instead. '
+      'Use useSystemAttachmentPicker instead. '
       'This feature was deprecated after v9.4.0',
     )
     bool useNativeAttachmentPickerOnMobile = false,
     this.pollConfig,
-  }) : useNativeAttachmentPicker = useNativeAttachmentPicker || //
+  }) : useSystemAttachmentPicker = useSystemAttachmentPicker || //
             useNativeAttachmentPickerOnMobile;
 
   /// The predicate used to send a message on desktop/web
@@ -390,15 +390,15 @@ class StreamMessageInput extends StatefulWidget {
   /// media picker handles permissions internally.
   /// 3. Simplicity: Simplifies the implementation by leveraging the built-in
   /// functionality of the system media picker.
-  final bool useNativeAttachmentPicker;
+  final bool useSystemAttachmentPicker;
 
   /// Forces use of native attachment picker on mobile instead of the custom
   /// Stream attachment picker.
   @Deprecated(
-    'Use useNativeAttachmentPicker instead. '
+    'Use useSystemAttachmentPicker instead. '
     'This feature was deprecated after v9.4.0',
   )
-  bool get useNativeAttachmentPickerOnMobile => useNativeAttachmentPicker;
+  bool get useNativeAttachmentPickerOnMobile => useSystemAttachmentPicker;
 
   /// The configuration to use while creating a poll.
   ///
@@ -1006,8 +1006,8 @@ class StreamMessageInputState extends State<StreamMessageInput>
       });
 
     final messageInputTheme = StreamMessageInputTheme.of(context);
-    final useNativePicker = widget.useNativeAttachmentPicker ||
-        (messageInputTheme.useNativeAttachmentPicker ?? false);
+    final useSystemPicker = widget.useSystemAttachmentPicker ||
+        (messageInputTheme.useSystemAttachmentPicker ?? false);
 
     final value = await showStreamAttachmentPickerModalBottomSheet(
       context: context,
@@ -1016,7 +1016,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       pollConfig: widget.pollConfig,
       initialPoll: initialPoll,
       initialAttachments: initialAttachments,
-      useNativeAttachmentPicker: useNativePicker,
+      useSystemAttachmentPicker: useSystemPicker,
     );
 
     if (value == null || value is! AttachmentPickerValue) return;

--- a/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
@@ -75,6 +75,7 @@ class StreamMessageInputThemeData with Diagnosticable {
     this.enableSafeArea,
     this.elevation,
     this.shadow,
+    this.useNativeAttachmentPicker,
   });
 
   /// Duration of the [MessageInput] send button animation
@@ -125,6 +126,18 @@ class StreamMessageInputThemeData with Diagnosticable {
   /// Shadow for the [MessageInput] widget
   final BoxShadow? shadow;
 
+  /// If True, allows you to use the system’s default media picker instead of
+  /// the custom media picker provided by the library. This can be beneficial
+  /// for several reasons:
+  ///
+  /// 1. Consistency: Provides a consistent user experience by using the
+  /// familiar system media picker.
+  /// 2. Permissions: Reduces the need for additional permissions, as the system
+  /// media picker handles permissions internally.
+  /// 3. Simplicity: Simplifies the implementation by leveraging the built-in
+  /// functionality of the system media picker.
+  final bool? useNativeAttachmentPicker;
+
   /// Returns a new [StreamMessageInputThemeData]
   /// replacing some of its properties
   StreamMessageInputThemeData copyWith({
@@ -144,6 +157,7 @@ class StreamMessageInputThemeData with Diagnosticable {
     bool? enableSafeArea,
     double? elevation,
     BoxShadow? shadow,
+    bool? useNativeAttachmentPicker,
   }) {
     return StreamMessageInputThemeData(
       sendAnimationDuration:
@@ -164,6 +178,8 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: enableSafeArea ?? this.enableSafeArea,
       elevation: elevation ?? this.elevation,
       shadow: shadow ?? this.shadow,
+      useNativeAttachmentPicker:
+          useNativeAttachmentPicker ?? this.useNativeAttachmentPicker,
     );
   }
 
@@ -183,6 +199,8 @@ class StreamMessageInputThemeData with Diagnosticable {
       borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
       expandButtonColor:
           Color.lerp(a.expandButtonColor, b.expandButtonColor, t),
+      linkHighlightColor:
+          Color.lerp(a.linkHighlightColor, b.linkHighlightColor, t),
       idleBorderGradient:
           Gradient.lerp(a.idleBorderGradient, b.idleBorderGradient, t),
       inputBackgroundColor:
@@ -196,6 +214,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: a.enableSafeArea,
       elevation: lerpDouble(a.elevation, b.elevation, t),
       shadow: BoxShadow.lerp(a.shadow, b.shadow, t),
+      useNativeAttachmentPicker: b.useNativeAttachmentPicker,
     );
   }
 
@@ -221,6 +240,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: other.enableSafeArea,
       elevation: other.elevation,
       shadow: other.shadow,
+      useNativeAttachmentPicker: other.useNativeAttachmentPicker,
     );
   }
 
@@ -244,7 +264,8 @@ class StreamMessageInputThemeData with Diagnosticable {
           linkHighlightColor == other.linkHighlightColor &&
           enableSafeArea == other.enableSafeArea &&
           elevation == other.elevation &&
-          shadow == other.shadow;
+          shadow == other.shadow &&
+          useNativeAttachmentPicker == other.useNativeAttachmentPicker;
 
   @override
   int get hashCode =>
@@ -263,7 +284,8 @@ class StreamMessageInputThemeData with Diagnosticable {
       linkHighlightColor.hashCode ^
       elevation.hashCode ^
       shadow.hashCode ^
-      enableSafeArea.hashCode;
+      enableSafeArea.hashCode ^
+      useNativeAttachmentPicker.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -284,6 +306,8 @@ class StreamMessageInputThemeData with Diagnosticable {
       ..add(ColorProperty('linkHighlightColor', linkHighlightColor))
       ..add(DiagnosticsProperty('elevation', elevation))
       ..add(DiagnosticsProperty('shadow', shadow))
-      ..add(DiagnosticsProperty('enableSafeArea', enableSafeArea));
+      ..add(DiagnosticsProperty('enableSafeArea', enableSafeArea))
+      ..add(DiagnosticsProperty(
+          'useNativeAttachmentPicker', useNativeAttachmentPicker));
   }
 }

--- a/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/message_input_theme.dart
@@ -75,7 +75,7 @@ class StreamMessageInputThemeData with Diagnosticable {
     this.enableSafeArea,
     this.elevation,
     this.shadow,
-    this.useNativeAttachmentPicker,
+    this.useSystemAttachmentPicker,
   });
 
   /// Duration of the [MessageInput] send button animation
@@ -136,7 +136,7 @@ class StreamMessageInputThemeData with Diagnosticable {
   /// media picker handles permissions internally.
   /// 3. Simplicity: Simplifies the implementation by leveraging the built-in
   /// functionality of the system media picker.
-  final bool? useNativeAttachmentPicker;
+  final bool? useSystemAttachmentPicker;
 
   /// Returns a new [StreamMessageInputThemeData]
   /// replacing some of its properties
@@ -157,7 +157,7 @@ class StreamMessageInputThemeData with Diagnosticable {
     bool? enableSafeArea,
     double? elevation,
     BoxShadow? shadow,
-    bool? useNativeAttachmentPicker,
+    bool? useSystemAttachmentPicker,
   }) {
     return StreamMessageInputThemeData(
       sendAnimationDuration:
@@ -178,8 +178,8 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: enableSafeArea ?? this.enableSafeArea,
       elevation: elevation ?? this.elevation,
       shadow: shadow ?? this.shadow,
-      useNativeAttachmentPicker:
-          useNativeAttachmentPicker ?? this.useNativeAttachmentPicker,
+      useSystemAttachmentPicker:
+          useSystemAttachmentPicker ?? this.useSystemAttachmentPicker,
     );
   }
 
@@ -214,7 +214,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: a.enableSafeArea,
       elevation: lerpDouble(a.elevation, b.elevation, t),
       shadow: BoxShadow.lerp(a.shadow, b.shadow, t),
-      useNativeAttachmentPicker: b.useNativeAttachmentPicker,
+      useSystemAttachmentPicker: b.useSystemAttachmentPicker,
     );
   }
 
@@ -240,7 +240,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       enableSafeArea: other.enableSafeArea,
       elevation: other.elevation,
       shadow: other.shadow,
-      useNativeAttachmentPicker: other.useNativeAttachmentPicker,
+      useSystemAttachmentPicker: other.useSystemAttachmentPicker,
     );
   }
 
@@ -265,7 +265,7 @@ class StreamMessageInputThemeData with Diagnosticable {
           enableSafeArea == other.enableSafeArea &&
           elevation == other.elevation &&
           shadow == other.shadow &&
-          useNativeAttachmentPicker == other.useNativeAttachmentPicker;
+          useSystemAttachmentPicker == other.useSystemAttachmentPicker;
 
   @override
   int get hashCode =>
@@ -285,7 +285,7 @@ class StreamMessageInputThemeData with Diagnosticable {
       elevation.hashCode ^
       shadow.hashCode ^
       enableSafeArea.hashCode ^
-      useNativeAttachmentPicker.hashCode;
+      useSystemAttachmentPicker.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -308,6 +308,6 @@ class StreamMessageInputThemeData with Diagnosticable {
       ..add(DiagnosticsProperty('shadow', shadow))
       ..add(DiagnosticsProperty('enableSafeArea', enableSafeArea))
       ..add(DiagnosticsProperty(
-          'useNativeAttachmentPicker', useNativeAttachmentPicker));
+          'useSystemAttachmentPicker', useSystemAttachmentPicker));
   }
 }

--- a/packages/stream_chat_flutter/lib/src/theme/stream_chat_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/stream_chat_theme.dart
@@ -308,7 +308,7 @@ class StreamChatThemeData {
             colorTheme.disabled,
           ],
         ),
-        useNativeAttachmentPicker: false,
+        useSystemAttachmentPicker: false,
       ),
       galleryHeaderTheme: StreamGalleryHeaderThemeData(
         closeButtonColor: colorTheme.textHighEmphasis,

--- a/packages/stream_chat_flutter/lib/src/theme/stream_chat_theme.dart
+++ b/packages/stream_chat_flutter/lib/src/theme/stream_chat_theme.dart
@@ -308,6 +308,7 @@ class StreamChatThemeData {
             colorTheme.disabled,
           ],
         ),
+        useNativeAttachmentPicker: false,
       ),
       galleryHeaderTheme: StreamGalleryHeaderThemeData(
         closeButtonColor: colorTheme.textHighEmphasis,


### PR DESCRIPTION
This pull request introduces a new feature for the `StreamMessageInput` component to support using the system's default media picker. Additionally, it includes various updates to the theme data to support this new feature.

### New Feature:
* Introduced `StreamMessageInput.useSystemAttachmentPicker` to allow using the system's default media picker for attachment selection. This provides a consistent user experience, reduces the need for additional permissions, and simplifies implementation. [[1]](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R8-R15) [[2]](diffhunk://#diff-7087319571f4a5913a123c0f9cbe924de54094ccf1831840a225e2afff17d040R82-R83) [[3]](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3L160-R168) [[4]](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3R383-R401) [[5]](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3R1008-R1019)

### Deprecation:
* Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of the new `useSystemAttachmentPicker`. [[1]](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R8-R15) [[2]](diffhunk://#diff-7087319571f4a5913a123c0f9cbe924de54094ccf1831840a225e2afff17d040R82-R83) [[3]](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3L160-R168) [[4]](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3R383-R401)

### Theme Updates:
* Added `useSystemAttachmentPicker` property to `StreamMessageInputThemeData` to support the new system media picker feature. [[1]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R78) [[2]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R129-R140) [[3]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R160) [[4]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R181-R182) [[5]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R202-R203) [[6]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R217) [[7]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950R243) [[8]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950L247-R268) [[9]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950L266-R288) [[10]](diffhunk://#diff-88515162a12ba1141dae97df0189123c1b1536d25a1214369f9e746f3efc3950L287-R311)
* Set default value for `useSystemAttachmentPicker` in `StreamChatThemeData`.