### PR TITLE
fix(core): move get currentChannels before async

### DIFF
--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -6,6 +6,9 @@
   and directly working with the attachments list.
 - Added proper userAgent and systemEnvironment information for better diagnostics and analytics.
 
+🐞 Fixed
+- type '_$Loading<int, Channel>' is not a subtype of type 'Success<int, Channel>' in type cast [#1894](https://github.com/GetStream/stream-chat-flutter/issues/1894)
+
 ## 9.4.0
 
 - Updated minimum Flutter version to 3.27.4 for the SDK.

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel_list_event_handler.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel_list_event_handler.dart
@@ -67,12 +67,12 @@ mixin class StreamChannelListEventHandler {
 
     if (channelId == null || channelType == null) return;
 
+    final currentChannels = [...controller.currentItems];
+
     final channel = await controller.getChannel(
       id: channelId,
       type: channelType,
     );
-
-    final currentChannels = [...controller.currentItems];
 
     final updatedChannels = [
       channel,


### PR DESCRIPTION
# Submit a pull request

FLU-58
Fixes #1894

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
When we enter `onChannelVisible` we are sure that the state is a Success state. However, when we call `controller.getChannel` we can go to loading state. So by moving the `controller.currentItems` before the `getChannel` we are always in a Success state.