### PR TITLE
fix(core): allow for device_info_plus v10

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -32,7 +32,7 @@ command:
       contextmenu: ^3.0.0
       cupertino_icons: ^1.0.3
       desktop_drop: ^0.5.0
-      device_info_plus: ^11.3.0
+      device_info_plus: '>=10.1.2 <12.0.0'
       diacritic: ^0.1.5
       dio: ^5.4.3+1
       drift: ^2.22.1

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.5.0+1
+- Increase range of allowed version `device_info_plus`.
+
 ## 9.5.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 9.5.0+1
+## Upcoming
+
+🔄 Changed
+
 - Increase range of allowed version `device_info_plus`.
 
 ## 9.5.0

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter_core
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK Core. Build your own chat experience using Dart and Flutter.
-version: 9.5.0
+version: 9.5.0+1
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
@@ -24,7 +24,7 @@ environment:
 dependencies:
   collection: ^1.17.2
   connectivity_plus: ^6.0.3
-  device_info_plus: ^11.3.0
+  device_info_plus: ">=10.1.2 <12.0.0"
   flutter:
     sdk: flutter
   freezed_annotation: ^2.4.1

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter_core
 homepage: https://github.com/GetStream/stream-chat-flutter
 description: Stream Chat official Flutter SDK Core. Build your own chat experience using Dart and Flutter.
-version: 9.5.0+1
+version: 9.5.0
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
I think [this is the breaking change in device_info_plus](https://github.com/fluttercommunity/plus_plugins/pull/3254/files#diff-b8d645085361575caa53bac8c308002b566d8d61aab91b189a158a39518c6e92), this is not relevant for us and it's better for customers if we allow for a broader range of dependencies so we don't conflict with other packages.