### PR TITLE
refactor(llc, ui): move slowMode logic inside StreamMessageInputController

### DIFF
--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -261,7 +261,7 @@ class Channel {
   /// Remaining cooldown duration in seconds for the channel.
   ///
   /// Returns 0 if there is no cooldown active.
-  int get remainingCooldown {
+  int getRemainingCooldown() {
     _checkInitialized();
 
     final cooldownDuration = cooldown;
@@ -283,7 +283,7 @@ class Channel {
     "Use a combination of 'remainingCooldown' and 'currentUserLastMessageAt'",
   )
   DateTime? get cooldownStartedAt {
-    if (remainingCooldown == 0) return null;
+    if (getRemainingCooldown() <= 0) return null;
     return currentUserLastMessageAt;
   }
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -258,8 +258,34 @@ class Channel {
     return state!.channelStateStream.map((cs) => cs.channel?.cooldown ?? 0);
   }
 
+  /// Remaining cooldown duration in seconds for the channel.
+  ///
+  /// Returns 0 if there is no cooldown active.
+  int get remainingCooldown {
+    _checkInitialized();
+
+    final cooldownDuration = cooldown;
+    if (cooldownDuration <= 0) return 0;
+
+    final userLastMessageAt = currentUserLastMessageAt;
+    if (userLastMessageAt == null) return 0;
+
+    if (ownCapabilities.contains(PermissionType.skipSlowMode)) return 0;
+
+    final currentTime = DateTime.timestamp();
+    final elapsedTime = currentTime.difference(userLastMessageAt).inSeconds;
+
+    return max(0, cooldownDuration - elapsedTime);
+  }
+
   /// Stores time at which cooldown was started
-  DateTime? cooldownStartedAt;
+  @Deprecated(
+    "Use a combination of 'remainingCooldown' and 'currentUserLastMessageAt'",
+  )
+  DateTime? get cooldownStartedAt {
+    if (remainingCooldown == 0) return null;
+    return currentUserLastMessageAt;
+  }
 
   /// Channel creation date.
   DateTime? get createdAt {
@@ -283,6 +309,47 @@ class Channel {
   Stream<DateTime?> get lastMessageAtStream {
     _checkInitialized();
     return state!.channelStateStream.map((cs) => cs.channel?.lastMessageAt);
+  }
+
+  DateTime? _currentUserLastMessageAt(List<Message>? messages) {
+    final currentUserId = client.state.currentUser?.id;
+    if (currentUserId == null) return null;
+
+    final validMessages = messages?.where((message) {
+      if (message.isEphemeral) return false;
+      if (message.user?.id != currentUserId) return false;
+      return true;
+    });
+
+    return validMessages?.map((m) => m.createdAt).max;
+  }
+
+  /// The date of the last message sent by the current user.
+  DateTime? get currentUserLastMessageAt {
+    _checkInitialized();
+
+    // If the channel is not up to date, we can't rely on the last message
+    // from the current user.
+    if (!state!.isUpToDate) return null;
+
+    final messages = state!.channelState.messages;
+    return _currentUserLastMessageAt(messages);
+  }
+
+  /// The date of the last message sent by the current user as a stream.
+  Stream<DateTime?> get currentUserLastMessageAtStream {
+    _checkInitialized();
+
+    return CombineLatestStream.combine2<bool, List<Message>?, DateTime?>(
+      state!.isUpToDateStream,
+      state!.channelStateStream.map((state) => state.messages),
+      (isUpToDate, messages) {
+        // If the channel is not up to date, we can't rely on the last message
+        // from the current user.
+        if (!isUpToDate) return null;
+        return _currentUserLastMessageAt(messages);
+      },
+    );
   }
 
   /// Channel updated date.
@@ -635,7 +702,7 @@ class Channel {
           );
 
       state!.updateMessage(sentMessage);
-      if (cooldown > 0) cooldownStartedAt = DateTime.now();
+
       return response;
     } catch (e) {
       if (e is StreamChatNetworkError && e.isRetriable) {

--- a/packages/stream_chat/lib/src/permission_type.dart
+++ b/packages/stream_chat/lib/src/permission_type.dart
@@ -32,6 +32,9 @@ class PermissionType {
   /// Allows to enable/disable slow mode in the channel
   static const String setChannelCooldown = 'set-channel-cooldown';
 
+  /// User has the ability to skip slow mode when it's active.
+  static const String skipSlowMode = 'skip-slow-mode';
+
   /// User has RemoveOwnChannelMembership or UpdateChannelMembers permission
   static const String leaveChannel = 'leave-channel';
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -532,7 +532,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       // Resumes the cooldown if the channel has currently an active cooldown.
       if (_isEditing case false) {
         final channel = StreamChannel.of(context).channel;
-        _effectiveController.startCooldown(channel.remainingCooldown);
+        _effectiveController.startCooldown(channel.getRemainingCooldown());
       }
     });
   }
@@ -1543,7 +1543,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       // We don't want to start the cooldown if an already sent message is
       // being edited.
       if (_isEditing case false) {
-        _effectiveController.startCooldown(channel.remainingCooldown);
+        _effectiveController.startCooldown(channel.getRemainingCooldown());
       }
 
       widget.onMessageSent?.call(resp.message);

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -530,7 +530,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       _onChangedDebounced.call();
 
       // Resumes the cooldown if the channel has currently an active cooldown.
-      if (_isEditing case false) {
+      if (!_isEditing) {
         final channel = StreamChannel.of(context).channel;
         _effectiveController.startCooldown(channel.getRemainingCooldown());
       }
@@ -1542,7 +1542,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
       // We don't want to start the cooldown if an already sent message is
       // being edited.
-      if (_isEditing case false) {
+      if (!_isEditing) {
         _effectiveController.startCooldown(channel.getRemainingCooldown());
       }
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -598,6 +598,8 @@ class StreamMessageInputState extends State<StreamMessageInput>
   // ignore: no-empty-block
   void _focusNodeListener() {}
 
+  PermissionState? _permissionState;
+
   @override
   Widget build(BuildContext context) {
     final channel = StreamChannel.of(context).channel;

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -509,10 +509,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
     _effectiveController
       ..removeListener(_onChangedDebounced)
       ..addListener(_onChangedDebounced);
-
-    // Call the listener once to make sure the initial state is reflected
-    // correctly in the UI.
-    _onChangedDebounced.call();
   }
 
   @override
@@ -526,11 +522,18 @@ class StreamMessageInputState extends State<StreamMessageInput>
     }
     _effectiveFocusNode.addListener(_focusNodeListener);
 
-    // Resumes the cooldown if the channel has currently an active cooldown.
     WidgetsBinding.instance.endOfFrame.then((_) {
-      if (!mounted || _isEditing) return;
-      final channel = StreamChannel.of(context).channel;
-      _effectiveController.startCooldown(channel.remainingCooldown);
+      if (!mounted) return;
+
+      // Call the listener once to make sure the initial state is reflected
+      // correctly in the UI.
+      _onChangedDebounced.call();
+
+      // Resumes the cooldown if the channel has currently an active cooldown.
+      if (_isEditing case false) {
+        final channel = StreamChannel.of(context).channel;
+        _effectiveController.startCooldown(channel.remainingCooldown);
+      }
     });
   }
 
@@ -1571,8 +1574,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
   @override
   void dispose() {
-    _effectiveController.cancelCooldown();
-    // ignore: cascade_invocations
     _effectiveController.removeListener(_onChangedDebounced);
     _controller?.dispose();
     _effectiveFocusNode.removeListener(_focusNodeListener);

--- a/packages/stream_chat_flutter/test/src/bottom_sheets/edit_message_sheet_test.dart
+++ b/packages/stream_chat_flutter/test/src/bottom_sheets/edit_message_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:alchemist/alchemist.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 import '../material_app_wrapper.dart';
@@ -33,6 +34,9 @@ void main() {
     });
 
     testWidgets('appears on tap', (tester) async {
+      final channel = MockChannel();
+      when(() => channel.remainingCooldown).thenReturn(0);
+
       await tester.pumpWidget(
         MaterialApp(
           builder: (context, child) => StreamChat(
@@ -48,7 +52,7 @@ void main() {
                     onPressed: () => showModalBottomSheet(
                       context: context,
                       builder: (_) => EditMessageSheet(
-                        channel: MockChannel(),
+                        channel: channel,
                         message: Message(id: 'msg123', text: 'Hello World!'),
                       ),
                     ),
@@ -72,18 +76,23 @@ void main() {
       'golden test for EditMessageSheet',
       fileName: 'edit_message_sheet_0',
       constraints: const BoxConstraints.tightFor(width: 300, height: 300),
-      builder: () => MaterialAppWrapper(
-        builder: (context, child) => StreamChat(
-          client: MockClient(),
-          child: child,
-        ),
-        home: Scaffold(
-          bottomSheet: EditMessageSheet(
-            channel: MockChannel(),
-            message: Message(id: 'msg123', text: 'Hello World!'),
+      builder: () {
+        final channel = MockChannel();
+        when(() => channel.remainingCooldown).thenReturn(0);
+
+        return MaterialAppWrapper(
+          builder: (context, child) => StreamChat(
+            client: MockClient(),
+            child: child,
           ),
-        ),
-      ),
+          home: Scaffold(
+            bottomSheet: EditMessageSheet(
+              channel: channel,
+              message: Message(id: 'msg123', text: 'Hello World!'),
+            ),
+          ),
+        );
+      },
     );
 
     tearDown(() {

--- a/packages/stream_chat_flutter/test/src/bottom_sheets/edit_message_sheet_test.dart
+++ b/packages/stream_chat_flutter/test/src/bottom_sheets/edit_message_sheet_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     testWidgets('appears on tap', (tester) async {
       final channel = MockChannel();
-      when(() => channel.remainingCooldown).thenReturn(0);
+      when(channel.getRemainingCooldown).thenReturn(0);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -78,7 +78,7 @@ void main() {
       constraints: const BoxConstraints.tightFor(width: 300, height: 300),
       builder: () {
         final channel = MockChannel();
-        when(() => channel.remainingCooldown).thenReturn(0);
+        when(channel.getRemainingCooldown).thenReturn(0);
 
         return MaterialAppWrapper(
           builder: (context, child) => StreamChat(

--- a/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
@@ -386,6 +386,7 @@ void main() {
       when(() => client.state).thenReturn(clientState);
       when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
       when(() => channel.state).thenReturn(channelState);
+      when(() => channel.remainingCooldown).thenReturn(0);
 
       final themeData = ThemeData();
       final streamTheme = StreamChatThemeData.fromTheme(themeData);

--- a/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
@@ -386,7 +386,7 @@ void main() {
       when(() => client.state).thenReturn(clientState);
       when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
       when(() => channel.state).thenReturn(channelState);
-      when(() => channel.remainingCooldown).thenReturn(0);
+      when(channel.getRemainingCooldown).thenReturn(0);
 
       final themeData = ThemeData();
       final streamTheme = StreamChatThemeData.fromTheme(themeData);

--- a/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
@@ -20,7 +20,7 @@ void main() {
       when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
       when(() => channel.state).thenReturn(channelState);
       when(() => channel.client).thenReturn(client);
-      when(() => channel.remainingCooldown).thenReturn(0);
+      when(channel.getRemainingCooldown).thenReturn(0);
       when(() => channel.isMuted).thenReturn(false);
       when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));
       when(() => channel.extraDataStream).thenAnswer(
@@ -90,7 +90,7 @@ void main() {
       when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
       when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
       when(() => channel.state).thenReturn(channelState);
-      when(() => channel.remainingCooldown).thenReturn(10);
+      when(channel.getRemainingCooldown).thenReturn(10);
       when(() => channel.client).thenReturn(client);
       when(() => channel.isMuted).thenReturn(false);
       when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));

--- a/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
@@ -20,6 +20,7 @@ void main() {
       when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
       when(() => channel.state).thenReturn(channelState);
       when(() => channel.client).thenReturn(client);
+      when(() => channel.remainingCooldown).thenReturn(0);
       when(() => channel.isMuted).thenReturn(false);
       when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));
       when(() => channel.extraDataStream).thenAnswer(

--- a/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
@@ -89,8 +89,7 @@ void main() {
       when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
       when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
       when(() => channel.state).thenReturn(channelState);
-      when(() => channel.cooldown).thenReturn(10);
-      when(() => channel.cooldownStartedAt).thenReturn(DateTime.now());
+      when(() => channel.remainingCooldown).thenReturn(10);
       when(() => channel.client).thenReturn(client);
       when(() => channel.isMuted).thenReturn(false);
       when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));
@@ -131,17 +130,21 @@ void main() {
         ]),
       );
 
-      await tester.pumpWidget(MaterialApp(
-        home: StreamChat(
-          client: client,
-          child: StreamChannel(
-            channel: channel,
-            child: const Scaffold(
-              body: StreamMessageInput(),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: StreamChannel(
+              channel: channel,
+              child: const Scaffold(
+                body: StreamMessageInput(),
+              ),
             ),
           ),
         ),
-      ));
+      );
+
+      await tester.pump(Duration.zero);
 
       expect(find.text('Slow mode ON'), findsOneWidget);
     },

--- a/packages/stream_chat_flutter_core/lib/src/stream_message_input_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_message_input_controller.dart
@@ -327,6 +327,8 @@ class StreamMessageInputController extends ValueNotifier<Message> {
 
   @override
   void dispose() {
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
     _textFieldController
       ..removeListener(_textFieldListener)
       ..dispose();

--- a/packages/stream_chat_flutter_core/lib/src/stream_message_input_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_message_input_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show Timer;
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
@@ -108,6 +109,44 @@ class StreamMessageInputController extends ValueNotifier<Message> {
   /// Sets the text of the message.
   set text(String text) {
     _textFieldController.text = text;
+  }
+
+  /// The current [cooldownTimeOut] of the slow mode.
+  ///
+  /// Defaults to 0, which means slow mode is not active.
+  int get cooldownTimeOut => _cooldownTimeOut;
+  int _cooldownTimeOut = 0;
+
+  Timer? _cooldownTimer;
+
+  /// Starts the slow mode timer.
+  void startCooldown(int cooldown) {
+    if (cooldown <= 0) return;
+
+    // Start the slow mode timer.
+    _cooldownTimer ??= _setPeriodicTimer(
+      immediate: true,
+      const Duration(seconds: 1),
+      (timer) {
+        final elapsed = timer.tick;
+        if (elapsed >= cooldown) return cancelCooldown();
+
+        final updatedTimeOut = cooldown - elapsed;
+        if (_cooldownTimeOut == updatedTimeOut) return;
+
+        _cooldownTimeOut = updatedTimeOut;
+        if (hasListeners) notifyListeners();
+      },
+    );
+  }
+
+  /// Cancels the slow mode timer.
+  void cancelCooldown() {
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+
+    _cooldownTimeOut = 0;
+    if (hasListeners) notifyListeners();
   }
 
   /// The currently selected [text].
@@ -331,4 +370,14 @@ class StreamRestorableMessageInputController
 
   @override
   String toPrimitives() => json.encode(value.message);
+}
+
+Timer _setPeriodicTimer(
+  Duration duration,
+  void Function(Timer) callback, {
+  bool immediate = false,
+}) {
+  final timer = Timer.periodic(duration, callback);
+  if (immediate) callback.call(timer);
+  return timer;
 }


### PR DESCRIPTION
Resolves: FLU-68

## Description of the pull request

The PR aims to move the slow mode logic from the `StreamMessageInput` widget to the `StreamMessageInputController` so that it can be directly accessed and handled through the controller.

Additionally, it improves the current cooldown logic in Channel and maintains the cooldown through out the app restart.


https://github.com/user-attachments/assets/a71fdf2e-631d-4f8d-86f4-ebb5bb934f3a
