### PR TITLE
fix(ui): fix message input command, attachment button incorrect assertion

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 🐞 Fixed
 
-- [[#2137]](https://github.com/GetStream/stream-chat-flutter/issues/2137) Fixed invalid assertions
+- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed invalid assertions
   applied on message input command and attachment button.
 
 ## 9.6.0

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,6 +1,15 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#2137]](https://github.com/GetStream/stream-chat-flutter/issues/2137) Fixed invalid assertions
+  applied on message input command and attachment button.
+
 ## 9.6.0
 
-- [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed message input
+🐞 Fixed
+
+- [[#2137]](https://github.com/GetStream/stream-chat-flutter/issues/2137) Fixed message input
   buttons not being able to customized.
 - [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message order.
 

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_button.dart
@@ -13,11 +13,7 @@ class AttachmentButton extends StatelessWidget {
     this.color,
     this.icon,
     this.size = kDefaultMessageInputIconSize,
-  }) : assert(
-            (icon == null && color == null) ||
-                (icon != null && color == null) ||
-                (icon == null && color != null),
-            'Either icon or color should be provided');
+  });
 
   /// The color of the button.
   /// Should be set if no [icon] is provided.

--- a/packages/stream_chat_flutter/lib/src/message_input/command_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/command_button.dart
@@ -13,11 +13,7 @@ class CommandButton extends StatelessWidget {
     this.color,
     this.icon,
     this.size = kDefaultMessageInputIconSize,
-  }) : assert(
-            (icon == null && color == null) ||
-                (icon != null && color == null) ||
-                (icon == null && color != null),
-            'Either icon or color should be provided');
+  });
 
   /// The color of the button.
   /// Should be set if no [icon] is provided.

--- a/packages/stream_chat_flutter/test/src/message_input/attachment_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/attachment_button_test.dart
@@ -7,16 +7,14 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import '../material_app_wrapper.dart';
 
 void main() {
-  testWidgets('SendButton onPressed works', (tester) async {
+  testWidgets('AttachmentButton onPressed works', (tester) async {
     var count = 0;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: Center(
             child: AttachmentButton(
-              color: StreamChatThemeData.light()
-                  .messageInputTheme
-                  .actionButtonIdleColor,
+              color: Colors.red,
               onPressed: () {
                 count++;
               },
@@ -31,6 +29,45 @@ void main() {
     expect(find.byType(StreamSvgIcon), findsOneWidget);
     await tester.tap(button);
     expect(count, 1);
+  });
+
+  testWidgets('AttachmentButton should accept icon', (tester) async {
+    const icon = Icon(Icons.attachment);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AttachmentButton(
+              icon: icon,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.attachment), findsOneWidget);
+  });
+
+  testWidgets('AttachmentButton should accept color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AttachmentButton(
+              color: Colors.red,
+              onPressed: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final buttonFinder = find.byType(AttachmentButton);
+    expect(buttonFinder, findsOneWidget);
+
+    final button = tester.widget<AttachmentButton>(buttonFinder);
+    expect(button.color, Colors.red);
   });
 
   goldenTest(

--- a/packages/stream_chat_flutter/test/src/message_input/command_button_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/command_button_test.dart
@@ -44,32 +44,28 @@ void main() {
       ),
     );
 
-    final iconFound = find.byWidget(icon);
-    expect(iconFound, findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
   });
 
-  testWidgets('CommandButton should not accept both color and icon',
-      (tester) async {
-    expect(
-      () => MaterialApp(
+  testWidgets('CommandButton should accept color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
         home: Scaffold(
           body: Center(
             child: CommandButton(
               color: Colors.red,
-              icon: const Icon(Icons.add),
               onPressed: () {},
             ),
           ),
         ),
       ),
-      throwsA(
-        isA<AssertionError>().having(
-          (e) => e.message,
-          'message',
-          'Either icon or color should be provided',
-        ),
-      ),
     );
+
+    final buttonFinder = find.byType(CommandButton);
+    expect(buttonFinder, findsOneWidget);
+
+    final button = tester.widget<CommandButton>(buttonFinder);
+    expect(button.color, Colors.red);
   });
 
   goldenTest(


### PR DESCRIPTION
## Description of the pull request

* [`packages/stream_chat_flutter/CHANGELOG.md`](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R1-R12): Updated to include a fix for invalid assertions applied on message input command and attachment buttons.

Code Improvements:

* [`packages/stream_chat_flutter/lib/src/message_input/attachment_button.dart`](diffhunk://#diff-7f9a9a4aeed6f4e837d0309e3661b56f9a95136e7851cc484cac8031794ccd3bL16-R16): Removed invalid assertions from the `AttachmentButton` constructor.
* [`packages/stream_chat_flutter/lib/src/message_input/command_button.dart`](diffhunk://#diff-ddf6988dc7b791ffe7d215abe1f3aeb2daba027c038b187a1bb85f4818ff7f02L16-R16): Removed invalid assertions from the `CommandButton` constructor.

Testing Enhancements:

* [`packages/stream_chat_flutter/test/src/message_input/attachment_button_test.dart`](diffhunk://#diff-5d9dd73c2fcc6223e3fd8835b7045e92d1a751f9d45d4c5b16cede4565b83306L10-R17): Added new tests to verify that `AttachmentButton` accepts an icon and a color. [[1]](diffhunk://#diff-5d9dd73c2fcc6223e3fd8835b7045e92d1a751f9d45d4c5b16cede4565b83306L10-R17) [[2]](diffhunk://#diff-5d9dd73c2fcc6223e3fd8835b7045e92d1a751f9d45d4c5b16cede4565b83306R34-R72)
* [`packages/stream_chat_flutter/test/src/message_input/command_button_test.dart`](diffhunk://#diff-eb3204e6ee0cc359c33bf4241c2884c936193b4513680b94a3bedfd3a83524daL47-R68): Added new tests to verify that `CommandButton` accepts a color.
