### PR TITLE
refactor(ui): replace SizedBox.shrink(), Container() with Empty widget

### DIFF
--- a/packages/stream_chat_flutter/lib/platform_widget_builder/src/desktop_widget.dart
+++ b/packages/stream_chat_flutter/lib/platform_widget_builder/src/desktop_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:stream_chat_flutter/platform_widget_builder/src/desktop_widget_base.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 
 /// A widget that will only be built for the specified desktop Platforms.
 ///
@@ -26,13 +27,13 @@ class DesktopWidget extends DesktopWidgetBase<Widget, Widget, Widget> {
 
   @override
   Widget createMacosWidget(BuildContext context) =>
-      macOS?.call(context) ?? const SizedBox.shrink();
+      macOS?.call(context) ?? const Empty();
 
   @override
   Widget createWindowsWidget(BuildContext context) =>
-      windows?.call(context) ?? const SizedBox.shrink();
+      windows?.call(context) ?? const Empty();
 
   @override
   Widget createLinuxWidget(BuildContext context) =>
-      linux?.call(context) ?? const SizedBox.shrink();
+      linux?.call(context) ?? const Empty();
 }

--- a/packages/stream_chat_flutter/lib/platform_widget_builder/src/platform_widget.dart
+++ b/packages/stream_chat_flutter/lib/platform_widget_builder/src/platform_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:stream_chat_flutter/platform_widget_builder/src/platform_widget_base.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 
 /// A widget that will only be built for the specific Platforms:
 ///
@@ -26,13 +27,13 @@ class PlatformWidget extends PlatformWidgetBase<Widget, Widget, Widget> {
 
   @override
   Widget createDesktopWidget(BuildContext context) =>
-      desktop?.call(context) ?? const SizedBox.shrink();
+      desktop?.call(context) ?? const Empty();
 
   @override
   Widget createMobileWidget(BuildContext context) =>
-      mobile?.call(context) ?? const SizedBox.shrink();
+      mobile?.call(context) ?? const Empty();
 
   @override
   Widget createWebWidget(BuildContext context) =>
-      web?.call(context) ?? const SizedBox.shrink();
+      web?.call(context) ?? const Empty();
 }

--- a/packages/stream_chat_flutter/lib/src/attachment/attachment_upload_state_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/attachment_upload_state_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamAttachmentUploadStateBuilder}
@@ -37,7 +38,7 @@ class StreamAttachmentUploadStateBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (message.state.isCompleted) {
-      return const Offstage();
+      return const Empty();
     }
 
     final messageId = message.id;

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/attachment_widget_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 part 'fallback_attachment_builder.dart';

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/fallback_attachment_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/fallback_attachment_builder.dart
@@ -28,6 +28,6 @@ class FallbackAttachmentBuilder extends StreamAttachmentWidgetBuilder {
   ) {
     // Returns an empty widget because this builder will be used as a fallback
     // when no other builder can handle the attachments.
-    return const SizedBox.shrink();
+    return const Empty();
   }
 }

--- a/packages/stream_chat_flutter/lib/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_player.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_player.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat_flutter/src/attachment/builder/voice_recording_attachment_builder/stream_voice_recording_slider.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template StreamVoiceRecordingPlayer}
@@ -222,7 +223,7 @@ class _StreamVoiceRecordingPlayerState
         style: theme.fileSizeTextStyle,
       );
     } else {
-      return const SizedBox.shrink();
+      return const Empty();
     }
   }
 

--- a/packages/stream_chat_flutter/lib/src/attachment/voice_recording_attachment_playlist.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/voice_recording_attachment_playlist.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/attachment/voice_recording_attachment.dart';
 import 'package:stream_chat_flutter/src/audio/audio_playlist_controller.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -52,7 +53,7 @@ class StreamVoiceRecordingAttachmentPlaylist extends StatefulWidget {
     BuildContext context,
     int index,
   ) {
-    return const SizedBox.shrink();
+    return const Empty();
   }
 
   @override

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
@@ -228,7 +228,7 @@ class StreamAutocomplete extends StatefulWidget {
   /// place the text field in the AppBar and the options below in the main body.
   ///
   /// When following this pattern, [fieldViewBuilder] can return
-  /// `SizedBox.shrink()` so that nothing is drawn where the text field would
+  /// `EmptyWidget()` so that nothing is drawn where the text field would
   /// normally be. A separate text field can be created elsewhere, and a
   /// FocusNode and StreamMessageEditingController can be passed both to that
   /// text field and to StreamAutocomplete.

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template commands_overlay}
@@ -31,7 +32,7 @@ class StreamCommandAutocompleteOptions extends StatelessWidget {
       return normalizedName.contains(normalizedQuery);
     });
 
-    if (commands == null || commands.isEmpty) return const SizedBox.shrink();
+    if (commands == null || commands.isEmpty) return const Empty();
 
     final streamChatTheme = StreamChatTheme.of(context);
     final colorTheme = streamChatTheme.colorTheme;

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_mention_autocomplete_options.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_mention_autocomplete_options.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template user_mentions_overlay}
@@ -78,8 +79,8 @@ class _StreamMentionAutocompleteOptionsState
     return FutureBuilder<List<User>>(
       future: userMentionsFuture,
       builder: (context, snapshot) {
-        if (snapshot.hasError) return const SizedBox.shrink();
-        if (!snapshot.hasData) return const SizedBox.shrink();
+        if (snapshot.hasError) return const Empty();
+        if (!snapshot.hasData) return const Empty();
         final users = snapshot.data!;
 
         return StreamAutocompleteOptions<User>(

--- a/packages/stream_chat_flutter/lib/src/channel/channel_info.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/channel_info.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamChannelInfo}
@@ -115,7 +116,7 @@ class _ConnectedTitleState extends StatelessWidget {
     }
 
     if (!showTypingIndicator) {
-      return alternativeWidget ?? const Offstage();
+      return alternativeWidget ?? const Empty();
     }
 
     return StreamTypingIndicator(

--- a/packages/stream_chat_flutter/lib/src/channel/channel_list_header.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/channel_list_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamChannelListHeader}
@@ -155,7 +156,7 @@ class StreamChannelListHeader extends StatelessWidget
                           constraints: channelListHeaderThemeData
                               .avatarTheme?.constraints,
                         )
-                      : const Offstage(),
+                      : const Empty(),
                 ),
             actions: actions ??
                 [
@@ -198,7 +199,7 @@ class StreamChannelListHeader extends StatelessWidget
                     }
                   },
                 ),
-                subtitle ?? const Offstage(),
+                subtitle ?? const Empty(),
               ],
             ),
           ),

--- a/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media.dart
+++ b/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/full_screen_media_widget.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/gallery_navigation_item.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import 'package:video_player/video_player.dart';
 
@@ -325,7 +326,7 @@ class _FullScreenMediaState extends State<StreamFullScreenMedia> {
                             );
                           }
 
-                          return const SizedBox();
+                          return const Empty();
                         },
                       ),
                     );

--- a/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media_desktop.dart
+++ b/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media_desktop.dart
@@ -6,6 +6,7 @@ import 'package:photo_view/photo_view.dart';
 import 'package:stream_chat_flutter/src/context_menu_items/download_menu_item.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/full_screen_media_widget.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/gallery_navigation_item.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Returns an instance of [FullScreenMediaDesktop].
@@ -369,7 +370,7 @@ class _FullScreenMediaDesktopState extends State<FullScreenMediaDesktop> {
                           );
                         }
 
-                        return const SizedBox();
+                        return const Empty();
                       },
                     ),
                   );

--- a/packages/stream_chat_flutter/lib/src/gallery/gallery_header.dart
+++ b/packages/stream_chat_flutter/lib/src/gallery/gallery_header.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:stream_chat_flutter/src/attachment_actions_modal/attachment_actions_modal.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/src/theme/themes.dart';
 import 'package:stream_chat_flutter/src/utils/utils.dart';
@@ -95,7 +96,7 @@ class StreamGalleryHeader extends StatelessWidget
               ),
               onPressed: onBackPressed,
             )
-          : const SizedBox(),
+          : const Empty(),
       surfaceTintColor:
           backgroundColor ?? galleryHeaderThemeData.backgroundColor,
       backgroundColor:
@@ -133,7 +134,7 @@ class StreamGalleryHeader extends StatelessWidget
                 ),
               ),
             )
-          : const SizedBox(),
+          : const Empty(),
     );
   }
 

--- a/packages/stream_chat_flutter/lib/src/indicators/sending_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/sending_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamSendingIndicator}
@@ -45,6 +46,6 @@ class StreamSendingIndicator extends StatelessWidget {
         color: StreamChatTheme.of(context).colorTheme.textLowEmphasis,
       );
     }
-    return const SizedBox();
+    return const Empty();
   }
 }

--- a/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamTypingIndicator}
@@ -36,7 +37,7 @@ class StreamTypingIndicator extends StatelessWidget {
     final channelState =
         channel?.state ?? StreamChannel.of(context).channel.state!;
 
-    final altWidget = alternativeWidget ?? const Offstage();
+    final altWidget = alternativeWidget ?? const Empty();
 
     return BetterStreamBuilder<Iterable<User>>(
       initialData: channelState.typingEvents.keys,

--- a/packages/stream_chat_flutter/lib/src/indicators/unread_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/unread_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamUnreadIndicator}
@@ -66,7 +67,7 @@ class StreamUnreadIndicator extends StatelessWidget {
         stream: stream,
         initialData: initialData,
         builder: (context, unreadCount) {
-          if (unreadCount == 0) return const SizedBox.shrink();
+          if (unreadCount == 0) return const Empty();
 
           return Badge(
             textColor: Colors.white,

--- a/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
+++ b/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart' hide ButtonStyle;
 import 'package:stream_chat_flutter/src/message_actions_modal/mam_widgets.dart';
 import 'package:stream_chat_flutter/src/message_actions_modal/mark_unread_message_button.dart';
 import 'package:stream_chat_flutter/src/message_widget/reactions/reactions_align.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template messageActionsModal}
@@ -297,9 +298,9 @@ class _MessageActionsModalState extends State<MessageActionsModal> {
         padding: const EdgeInsets.symmetric(vertical: 11, horizontal: 16),
         child: Row(
           children: [
-            messageAction.leading ?? const Offstage(),
+            messageAction.leading ?? const Empty(),
             const SizedBox(width: 16),
-            messageAction.title ?? const Offstage(),
+            messageAction.title ?? const Empty(),
           ],
         ),
       ),

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_gallery_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_gallery_picker.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
 import 'package:stream_chat_flutter/src/message_input/attachment_picker/stream_attachment_picker.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/scroll_view/photo_gallery/stream_photo_gallery.dart';
 import 'package:stream_chat_flutter/src/scroll_view/photo_gallery/stream_photo_gallery_controller.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
@@ -95,7 +96,7 @@ class _StreamGalleryPickerState extends State<StreamGalleryPicker> {
     return FutureBuilder<PermissionState>(
       future: requestPermission,
       builder: (context, snapshot) {
-        if (!snapshot.hasData) return const SizedBox.shrink();
+        if (!snapshot.hasData) return const Empty();
 
         final theme = StreamChatTheme.of(context);
         final textTheme = theme.textTheme;

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/message_input/attachment_picker/options/options.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// The default maximum size for media attachments.
@@ -461,7 +462,7 @@ class _StreamMobileAttachmentPickerBottomSheetState
             Expanded(
               child: _currentOption.optionViewBuilder
                       ?.call(context, widget.controller) ??
-                  const SizedBox.shrink(),
+                  const Empty(),
             ),
           ],
         );
@@ -629,7 +630,7 @@ class _EndOfFrameCallbackWidgetState extends State<EndOfFrameCallbackWidget> {
     _error = null;
     _stackTrace = null;
 
-    return widget.child ?? const SizedBox.shrink();
+    return widget.child ?? const Empty();
   }
 }
 
@@ -697,7 +698,7 @@ class OptionDrawer extends StatelessWidget {
       height = 40.0;
     }
 
-    final leading = title ?? const SizedBox.shrink();
+    final leading = title ?? const Empty();
 
     Widget trailing;
     if (actions.isNotEmpty) {
@@ -708,7 +709,7 @@ class OptionDrawer extends StatelessWidget {
         children: actions,
       );
     } else {
-      trailing = const SizedBox.shrink();
+      trailing = const Empty();
     }
 
     return Card(

--- a/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/stream_audio_recorder.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/stream_audio_recorder.dart
@@ -9,6 +9,7 @@ import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
 import 'package:stream_chat_flutter/src/message_input/audio_recorder/audio_recorder_state.dart';
 import 'package:stream_chat_flutter/src/message_input/stream_message_input_icon_button.dart';
 import 'package:stream_chat_flutter/src/misc/audio_waveform.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
 
@@ -491,7 +492,7 @@ class _RecordStateStoppedContentState extends State<RecordStateStoppedContent> {
               valueListenable: controller,
               builder: (context, state, _) {
                 final track = state.tracks.firstOrNull;
-                if (track == null) return const SizedBox.shrink();
+                if (track == null) return const Empty();
 
                 return Row(
                   children: [

--- a/packages/stream_chat_flutter/lib/src/message_input/quoted_message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/quoted_message_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/message_input/clear_input_item_button.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 typedef _Builders = Map<String, QuotedMessageAttachmentThumbnailBuilder>;
@@ -255,7 +256,7 @@ class _ParseAttachments extends StatelessWidget {
     );
 
     // Return empty container if no attachment widget is returned.
-    if (attachmentWidget == null) return const SizedBox.shrink();
+    if (attachmentWidget == null) return const Empty();
 
     final colorTheme = StreamChatTheme.of(context).colorTheme;
 

--- a/packages/stream_chat_flutter/lib/src/message_input/quoting_message_top_area.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/quoting_message_top_area.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/message_input/stream_message_input_icon_button.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template quotingMessageTopArea}
@@ -53,7 +54,7 @@ class QuotingMessageTopArea extends StatelessWidget {
         ),
       );
     } else {
-      return const SizedBox.shrink();
+      return const Empty();
     }
   }
 }

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -13,6 +13,7 @@ import 'package:stream_chat_flutter/src/message_input/quoting_message_top_area.d
 import 'package:stream_chat_flutter/src/message_input/simple_safe_area.dart';
 import 'package:stream_chat_flutter/src/message_input/stream_message_input_icon_button.dart';
 import 'package:stream_chat_flutter/src/message_input/tld.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/misc/gradient_box_border.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -879,7 +880,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       secondChild: widget.disableAttachments &&
               !widget.showCommandsButton &&
               !(widget.actionsBuilder != null)
-          ? const Offstage()
+          ? const Empty()
           : Row(
               spacing: widget.spaceBetweenActions,
               mainAxisSize: MainAxisSize.min,
@@ -1322,7 +1323,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
   }
 
   Widget _buildReplyToMessage() {
-    if (!_hasQuotedMessage) return const Offstage();
+    if (!_hasQuotedMessage) return const Empty();
     final quotedMessage = _effectiveController.message.quotedMessage!;
 
     final quotedMessageBuilder = widget.quotedMessageBuilder;
@@ -1355,7 +1356,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
     }).toList(growable: false);
 
     // If there are no attachments, return an empty widget
-    if (nonOGAttachments.isEmpty) return const Offstage();
+    if (nonOGAttachments.isEmpty) return const Empty();
 
     // If the user has provided a custom attachment list builder, use that.
     final attachmentListBuilder = widget.attachmentListBuilder;

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input_attachment_list.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input_attachment_list.dart
@@ -5,6 +5,7 @@ import 'package:stream_chat_flutter/src/attachment/thumbnail/media_attachment_th
 import 'package:stream_chat_flutter/src/attachment/voice_recording_attachment.dart';
 import 'package:stream_chat_flutter/src/audio/audio_playlist_controller.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/src/utils/utils.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
@@ -100,7 +101,7 @@ class StreamMessageInputAttachmentList extends StatelessWidget {
 
     // If there are no attachments, return an empty widget.
     if (files.isEmpty && media.isEmpty && voices.isEmpty) {
-      return const SizedBox.shrink();
+      return const Empty();
     }
 
     return SingleChildScrollView(

--- a/packages/stream_chat_flutter/lib/src/message_list_view/floating_date_divider.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/floating_date_divider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:stream_chat_flutter/src/message_list_view/mlv_utils.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template floatingDateDivider}
@@ -43,7 +44,7 @@ class FloatingDateDivider extends StatelessWidget {
       valueListenable: itemPositionListener,
       builder: (context, positions, child) {
         if (positions.isEmpty || messages.isEmpty) {
-          return const Offstage();
+          return const Empty();
         }
 
         var index = switch (reverse) {
@@ -54,7 +55,7 @@ class FloatingDateDivider extends StatelessWidget {
         if ((index == null) ||
             (!isThreadConversation && index == itemCount - 2) ||
             (isThreadConversation && index == itemCount - 1)) {
-          return const Offstage();
+          return const Empty();
         }
 
         if (index <= 2 || index >= itemCount - 3) {

--- a/packages/stream_chat_flutter/lib/src/message_list_view/loading_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/loading_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template loadingIndicatorMLV}
@@ -48,7 +49,7 @@ class LoadingIndicator extends StatelessWidget {
         ),
       ),
       builder: (context, data) {
-        if (!data) return const Offstage();
+        if (!data) return const Empty();
         return indicatorBuilder?.call(context) ??
             const Center(
               child: Padding(

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -12,6 +12,7 @@ import 'package:stream_chat_flutter/src/message_list_view/mlv_utils.dart';
 import 'package:stream_chat_flutter/src/message_list_view/thread_separator.dart';
 import 'package:stream_chat_flutter/src/message_list_view/unread_messages_separator.dart';
 import 'package:stream_chat_flutter/src/message_widget/ephemeral_message.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Spacing Types (These are properties of a message to help inform the decision
@@ -660,7 +661,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                   separatorBuilder: (context, i) {
                     if (i == itemCount - 2) {
                       if (widget.parentMessage == null) {
-                        return const Offstage();
+                        return const Empty();
                       }
 
                       if (widget.threadSeparatorBuilder != null) {
@@ -679,7 +680,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                         if (messages.isNotEmpty) {
                           return _buildDateDivider(messages.last);
                         }
-                        if (_isThreadConversation) return const Offstage();
+                        if (_isThreadConversation) return const Empty();
                         return const SizedBox(height: 52);
                       }
                       return const SizedBox(height: 8);
@@ -693,7 +694,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                       return const SizedBox(height: 8);
                     }
 
-                    if (i == 1 || i == itemCount - 4) return const Offstage();
+                    if (i == 1 || i == itemCount - 4) return const Empty();
 
                     late final Message message, nextMessage;
                     if (widget.reverse) {
@@ -765,7 +766,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                   itemBuilder: (context, i) {
                     if (i == itemCount - 1) {
                       if (widget.parentMessage == null) {
-                        return const Offstage();
+                        return const Empty();
                       }
                       return buildParentMessage(widget.parentMessage!);
                     }
@@ -773,10 +774,10 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                     if (i == itemCount - 2) {
                       if (widget.reverse) {
                         return widget.headerBuilder?.call(context) ??
-                            const Offstage();
+                            const Empty();
                       } else {
                         return widget.footerBuilder?.call(context) ??
-                            const Offstage();
+                            const Empty();
                       }
                     }
 
@@ -806,10 +807,10 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                     if (i == 0) {
                       if (widget.reverse) {
                         return widget.footerBuilder?.call(context) ??
-                            const Offstage();
+                            const Empty();
                       } else {
                         return widget.headerBuilder?.call(context) ??
-                            const Offstage();
+                            const Empty();
                       }
                     }
 
@@ -864,7 +865,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                 if (!snapshot || value) {
                   return child!;
                 }
-                return const Offstage();
+                return const Empty();
               },
             ),
           ),
@@ -1119,9 +1120,9 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
       stream: streamChannel!.channel.state!.unreadCountStream,
       builder: (_, snapshot) {
         if (snapshot.hasError) {
-          return const Offstage();
+          return const Empty();
         } else if (!snapshot.hasData) {
-          return const Offstage();
+          return const Empty();
         }
         final unreadCount = snapshot.data!;
         if (widget.scrollToBottomBuilder != null) {
@@ -1198,9 +1199,9 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
       stream: streamChannel!.channel.state!.unreadCountStream,
       builder: (_, snapshot) {
         if (snapshot.hasError) {
-          return const Offstage();
+          return const Empty();
         } else if (!snapshot.hasData) {
-          return const Offstage();
+          return const Empty();
         }
         final unreadCount = snapshot.data!;
 
@@ -1217,7 +1218,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
                 e.userId ==
                 streamChannel!.channel.client.state.currentUser!.id);
 
-        if (!showUnread) return const Offstage();
+        if (!showUnread) return const Empty();
 
         final lastReadMessageId =
             streamChannel!.channel.state!.currentUserRead?.lastReadMessageId;

--- a/packages/stream_chat_flutter/lib/src/message_widget/ephemeral_message.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/ephemeral_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/message_widget/giphy_ephemeral_message.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 
 /// {@template streamEphemeralMessage}
@@ -38,6 +39,6 @@ class StreamEphemeralMessage extends StatelessWidget {
     assert(true, 'Ephemeral message not handled, Please add a handler');
 
     // Show nothing if we don't know how to handle the message.
-    return const SizedBox.shrink();
+    return const Empty();
   }
 }

--- a/packages/stream_chat_flutter/lib/src/message_widget/poll_message.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/poll_message.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/poll/interactor/poll_add_comment_dialog.dart';
 import 'package:stream_chat_flutter/src/poll/interactor/poll_suggest_option_dialog.dart';
 import 'package:stream_chat_flutter/src/poll/interactor/stream_poll_interactor.dart';
@@ -59,10 +60,10 @@ class _PollMessageState extends State<PollMessage> {
       valueListenable: _messageNotifier,
       builder: (context, message, child) {
         final poll = message.poll;
-        if (poll == null) return const SizedBox.shrink();
+        if (poll == null) return const Empty();
 
         final currentUser = StreamChat.of(context).currentUser;
-        if (currentUser == null) return const SizedBox.shrink();
+        if (currentUser == null) return const Empty();
 
         final channel = StreamChannel.of(context).channel;
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/text_bubble.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/text_bubble.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template textBubble}
@@ -50,7 +51,7 @@ class TextBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (message.text?.trim().isEmpty ?? true) return const Offstage();
+    if (message.text?.trim().isEmpty ?? true) return const Empty();
     return Padding(
       padding: isOnlyEmoji ? EdgeInsets.zero : textPadding,
       child: textBuilder != null

--- a/packages/stream_chat_flutter/lib/src/misc/connection_status_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/misc/connection_status_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamConnectionStatusBuilder}
@@ -44,7 +45,7 @@ class StreamConnectionStatusBuilder extends StatelessWidget {
         if (errorBuilder != null) {
           return errorBuilder!(context, error);
         }
-        return const Offstage();
+        return const Empty();
       },
       builder: statusBuilder,
     );

--- a/packages/stream_chat_flutter/lib/src/misc/empty_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/misc/empty_widget.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+/// A widget that renders nothing and takes up no space.
+///
+/// This is a type-safe wrapper around [EmptyWidget()] that can be used
+/// when a widget is required but no visible content should be rendered.
+///
+/// Example:
+/// ```dart
+/// Widget buildContent(bool hasContent) {
+///   return hasContent ? ContentWidget() : const Empty();
+/// }
+/// ```
+///
+/// See also:
+///  * [SizedBox.shrink], the underlying widget used by this extension type
+extension type const Empty._(Widget widget) implements Widget {
+  /// Creates a widget that renders nothing and takes up no space.
+  const Empty() : this._(const SizedBox.shrink());
+}

--- a/packages/stream_chat_flutter/lib/src/misc/option_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/misc/option_list_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 
 /// {@template streamOptionListTile}
@@ -81,7 +82,7 @@ class StreamOptionListTile extends StatelessWidget {
                       padding: const EdgeInsets.only(right: 16),
                       child: Align(
                         alignment: Alignment.centerRight,
-                        child: trailing ?? Container(),
+                        child: trailing ?? const Empty(),
                       ),
                     ),
                   ),

--- a/packages/stream_chat_flutter/lib/src/misc/system_message.dart
+++ b/packages/stream_chat_flutter/lib/src/misc/system_message.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// {@template streamSystemMessage}
@@ -23,7 +24,7 @@ class StreamSystemMessage extends StatelessWidget {
     final message = this.message.replaceMentions(linkify: false);
 
     final messageText = message.text;
-    if (messageText == null) return const SizedBox.shrink();
+    if (messageText == null) return const Empty();
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/packages/stream_chat_flutter/lib/src/poll/interactor/poll_options_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/interactor/poll_options_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/avatars/user_avatar.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/poll_interactor_theme.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
@@ -246,7 +247,7 @@ class OptionVoters extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (voters.isEmpty) return const SizedBox.shrink();
+    if (voters.isEmpty) return const Empty();
 
     final theme = StreamChatTheme.of(context);
 

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_comments_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_comments_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/poll/interactor/poll_add_comment_dialog.dart';
 import 'package:stream_chat_flutter/src/scroll_view/poll_vote_scroll_view/stream_poll_vote_list_view.dart';
 import 'package:stream_chat_flutter/src/theme/poll_comments_dialog_theme.dart';
@@ -27,7 +28,7 @@ Future<T?> showStreamPollCommentsDialog<T extends Object?>({
           valueListenable: messageNotifier,
           builder: (context, message, child) {
             final poll = message.poll;
-            if (poll == null) return const SizedBox.shrink();
+            if (poll == null) return const Empty();
 
             final channel = StreamChannel.of(context).channel;
 

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_option_votes_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_option_votes_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/scroll_view/poll_vote_scroll_view/stream_poll_vote_list_view.dart';
 import 'package:stream_chat_flutter/src/theme/poll_option_votes_dialog_theme.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
@@ -26,8 +27,8 @@ Future<T?> showStreamPollOptionVotesDialog<T extends Object?>({
           valueListenable: messageNotifier,
           builder: (context, message, child) {
             final poll = message.poll;
-            if (poll == null) return const SizedBox.shrink();
-            if (option.id == null) return const SizedBox.shrink();
+            if (poll == null) return const Empty();
+            if (option.id == null) return const Empty();
 
             return StreamPollOptionVotesDialog(
               poll: poll,

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_options_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_options_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/poll/interactor/poll_options_list_view.dart';
 import 'package:stream_chat_flutter/src/theme/poll_options_dialog_theme.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
@@ -24,7 +25,7 @@ Future<T?> showStreamPollOptionsDialog<T extends Object?>({
           valueListenable: messageNotifier,
           builder: (context, message, child) {
             final poll = message.poll;
-            if (poll == null) return const SizedBox.shrink();
+            if (poll == null) return const Empty();
 
             final channel = StreamChannel.of(context).channel;
 

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_results_dialog.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_results_dialog.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/poll/stream_poll_option_votes_dialog.dart';
 import 'package:stream_chat_flutter/src/scroll_view/poll_vote_scroll_view/stream_poll_vote_list_tile.dart';
 import 'package:stream_chat_flutter/src/theme/poll_results_dialog_theme.dart';
@@ -35,7 +36,7 @@ Future<T?> showStreamPollResultsDialog<T extends Object?>({
           valueListenable: messageNotifier,
           builder: (context, message, child) {
             final poll = message.poll;
-            if (poll == null) return const SizedBox.shrink();
+            if (poll == null) return const Empty();
 
             void onShowAllVotesPressed(PollOption option) {
               showStreamPollOptionVotesDialog(

--- a/packages/stream_chat_flutter/lib/src/poll/stream_poll_text_field.dart
+++ b/packages/stream_chat_flutter/lib/src/poll/stream_poll_text_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 const _kTransitionDuration = Duration(milliseconds: 167);
@@ -239,7 +240,7 @@ class _PollTextFieldErrorState extends State<PollTextFieldError>
   @override
   Widget build(BuildContext context) {
     final errorText = widget.errorText;
-    if (errorText == null) return const SizedBox.shrink();
+    if (errorText == null) return const Empty();
 
     return Container(
       padding: widget.padding,

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/message_widget/sending_indicator_builder.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// A widget that displays a channel preview.
@@ -197,7 +198,7 @@ class StreamChannelListTile extends StatelessWidget {
                 comparator: const ListEquality().equals,
                 builder: (context, members) {
                   if (members.isEmpty) {
-                    return const Offstage();
+                    return const Empty();
                   }
                   return unreadIndicatorBuilder?.call(context) ??
                       StreamUnreadIndicator.channels(cid: channel.cid);
@@ -224,7 +225,7 @@ class StreamChannelListTile extends StatelessWidget {
 
                   if (lastMessage == null ||
                       (lastMessage.user?.id != currentUser.id)) {
-                    return const Offstage();
+                    return const Empty();
                   }
 
                   final hasNonUrlAttachments = lastMessage.attachments
@@ -391,7 +392,7 @@ class _ChannelLastMessageTextState extends State<ChannelLastMessageText> {
             _lastMessage = lastMessage;
           }
 
-          if (_lastMessage == null) return const Offstage();
+          if (_lastMessage == null) return const Empty();
 
           return StreamMessagePreviewText(
             message: _lastMessage!,

--- a/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_error_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_error_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// A widget that is displayed when a [StreamScrollView] encounters an error
@@ -62,7 +63,7 @@ class StreamScrollViewErrorWidget extends StatelessWidget {
     final titleText = AnimatedDefaultTextStyle(
       style: errorTitleStyle ?? chatThemeData.textTheme.headline,
       duration: kThemeChangeDuration,
-      child: errorTitle ?? const SizedBox(),
+      child: errorTitle ?? const Empty(),
     );
 
     final retryButtonText = AnimatedDefaultTextStyle(

--- a/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_load_more_error.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_load_more_error.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// A tile that is used to display the error indicator when
@@ -68,7 +69,7 @@ class StreamScrollViewLoadMoreError extends StatelessWidget {
     final errorText = AnimatedDefaultTextStyle(
       style: errorStyle ?? theme.textTheme.body.copyWith(color: Colors.white),
       duration: kThemeChangeDuration,
-      child: error ?? const SizedBox(),
+      child: error ?? const Empty(),
     );
 
     final errorIcon = AnimatedSwitcher(

--- a/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_unread_threads_banner.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_unread_threads_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
 
@@ -44,7 +45,7 @@ class StreamUnreadThreadsBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (unreadThreads.isEmpty) {
-      return const SizedBox.shrink();
+      return const Empty();
     }
 
     final theme = StreamChatTheme.of(context);

--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/video/vlc/vlc_manager.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -130,7 +131,7 @@ class StreamChatState extends State<StreamChat> {
                   connectivityStream: widget.connectivityStream,
                   child: Builder(
                     builder: (context) {
-                      return widget.child ?? const Offstage();
+                      return widget.child ?? const Empty();
                     },
                   ),
                 ),


### PR DESCRIPTION
## Description of the pull request

This pull request creates a new `Empty()` widget to standardize the representation of empty widgets. Currently we use different widget such as `Container()`, `Offstage()`, `SizedBox()` and `SizedBox.shrink()` to return a empty widget.