### PR TITLE
refactor(llc, ui): introduce 'ChannelCapability' and deprecate 'PermissionType'

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Upcoming
+
+✅ Added
+
+- Added new helper extensions on `Channel` to provide a convenient way to check if the current user
+  has specific capabilities in a channel.
+
+  ```dart
+  final canSendMessage = channel.canSendMessage;
+  final canSendReaction = channel.canSendReaction;
+  ```
+
+🔄 Changed
+
+- Deprecated `PermissionType` in favor of `ChannelCapability`.
+
 ## 9.6.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -270,7 +270,7 @@ class Channel {
     final userLastMessageAt = currentUserLastMessageAt;
     if (userLastMessageAt == null) return 0;
 
-    if (ownCapabilities.contains(PermissionType.skipSlowMode)) return 0;
+    if (canSkipSlowMode) return 0;
 
     final currentTime = DateTime.timestamp();
     final elapsedTime = currentTime.difference(userLastMessageAt).inSeconds;
@@ -2899,9 +2899,7 @@ class ChannelClientState {
     if (_channel.isMuted) return false;
 
     // Don't count if the channel doesn't allow read events.
-    if (!_channel.ownCapabilities.contains(PermissionType.readEvents)) {
-      return false;
-    }
+    if (!_channel.canReceiveReadEvents) return false;
 
     // Don't count thread replies which are not shown in the channel as unread.
     if (message.parentId != null && message.showInChannel == false) {
@@ -3213,5 +3211,189 @@ extension on Iterable<Message> {
     }
 
     return messageMap.values;
+  }
+}
+
+/// Extension methods for checking channel capabilities on a Channel instance.
+///
+/// These methods provide a convenient way to check if the current user has
+/// specific capabilities in a channel.
+extension ChannelCapabilityExtension on Channel {
+  /// True, if the current user can send a message to this channel.
+  bool get canSendMessage {
+    return ownCapabilities.contains(ChannelCapability.sendMessage);
+  }
+
+  /// True, if the current user can send a reply to this channel.
+  bool get canSendReply {
+    return ownCapabilities.contains(ChannelCapability.sendReply);
+  }
+
+  /// True, if the current user can send a message with restricted visibility.
+  bool get canSendRestrictedVisibilityMessage {
+    return ownCapabilities.contains(
+      ChannelCapability.sendRestrictedVisibilityMessage,
+    );
+  }
+
+  /// True, if the current user can send reactions.
+  bool get canSendReaction {
+    return ownCapabilities.contains(ChannelCapability.sendReaction);
+  }
+
+  /// True, if the current user can attach links to messages.
+  bool get canSendLinks {
+    return ownCapabilities.contains(ChannelCapability.sendLinks);
+  }
+
+  /// True, if the current user can attach files to messages.
+  bool get canCreateAttachment {
+    return ownCapabilities.contains(ChannelCapability.createAttachment);
+  }
+
+  /// True, if the current user can freeze or unfreeze channel.
+  bool get canFreezeChannel {
+    return ownCapabilities.contains(ChannelCapability.freezeChannel);
+  }
+
+  /// True, if the current user can enable or disable slow mode.
+  bool get canSetChannelCooldown {
+    return ownCapabilities.contains(ChannelCapability.setChannelCooldown);
+  }
+
+  /// True, if the current user can leave channel (remove own membership).
+  bool get canLeaveChannel {
+    return ownCapabilities.contains(ChannelCapability.leaveChannel);
+  }
+
+  /// True, if the current user can join channel (add own membership).
+  bool get canJoinChannel {
+    return ownCapabilities.contains(ChannelCapability.joinChannel);
+  }
+
+  /// True, if the current user can pin a message.
+  bool get canPinMessage {
+    return ownCapabilities.contains(ChannelCapability.pinMessage);
+  }
+
+  /// True, if the current user can delete any message from the channel.
+  bool get canDeleteAnyMessage {
+    return ownCapabilities.contains(ChannelCapability.deleteAnyMessage);
+  }
+
+  /// True, if the current user can delete own messages from the channel.
+  bool get canDeleteOwnMessage {
+    return ownCapabilities.contains(ChannelCapability.deleteOwnMessage);
+  }
+
+  /// True, if the current user can update any message in the channel.
+  bool get canUpdateAnyMessage {
+    return ownCapabilities.contains(ChannelCapability.updateAnyMessage);
+  }
+
+  /// True, if the current user can update own messages in the channel.
+  bool get canUpdateOwnMessage {
+    return ownCapabilities.contains(ChannelCapability.updateOwnMessage);
+  }
+
+  /// True, if the current user can use message search.
+  bool get canSearchMessages {
+    return ownCapabilities.contains(ChannelCapability.searchMessages);
+  }
+
+  /// True, if the current user can send typing events.
+  bool get canSendTypingEvents {
+    return ownCapabilities.contains(ChannelCapability.sendTypingEvents);
+  }
+
+  /// True, if the current user can upload message attachments.
+  bool get canUploadFile {
+    return ownCapabilities.contains(ChannelCapability.uploadFile);
+  }
+
+  /// True, if the current user can delete channel.
+  bool get canDeleteChannel {
+    return ownCapabilities.contains(ChannelCapability.deleteChannel);
+  }
+
+  /// True, if the current user can update channel data.
+  bool get canUpdateChannel {
+    return ownCapabilities.contains(ChannelCapability.updateChannel);
+  }
+
+  /// True, if the current user can update channel members.
+  bool get canUpdateChannelMembers {
+    return ownCapabilities.contains(ChannelCapability.updateChannelMembers);
+  }
+
+  /// True, if the current user can update thread data.
+  bool get canUpdateThread {
+    return ownCapabilities.contains(ChannelCapability.updateThread);
+  }
+
+  /// True, if the current user can quote a message.
+  bool get canQuoteMessage {
+    return ownCapabilities.contains(ChannelCapability.quoteMessage);
+  }
+
+  /// True, if the current user can ban channel members.
+  bool get canBanChannelMembers {
+    return ownCapabilities.contains(ChannelCapability.banChannelMembers);
+  }
+
+  /// True, if the current user can flag a message.
+  bool get canFlagMessage {
+    return ownCapabilities.contains(ChannelCapability.flagMessage);
+  }
+
+  /// True, if the current user can mute a channel.
+  bool get canMuteChannel {
+    return ownCapabilities.contains(ChannelCapability.muteChannel);
+  }
+
+  /// True, if the current user can send custom events.
+  bool get canSendCustomEvents {
+    return ownCapabilities.contains(ChannelCapability.sendCustomEvents);
+  }
+
+  /// True, if the current user has read events capability.
+  bool get canReceiveReadEvents {
+    return ownCapabilities.contains(ChannelCapability.readEvents);
+  }
+
+  /// True, if the current user has connect events capability.
+  bool get canReceiveConnectEvents {
+    return ownCapabilities.contains(ChannelCapability.connectEvents);
+  }
+
+  /// True, if the current user can send and receive typing events.
+  bool get canUseTypingEvents {
+    return ownCapabilities.contains(ChannelCapability.typingEvents);
+  }
+
+  /// True, if channel slow mode is active.
+  bool get isInSlowMode {
+    return ownCapabilities.contains(ChannelCapability.slowMode);
+  }
+
+  /// True, if the current user is allowed to post messages as usual even if the
+  /// channel is in slow mode.
+  bool get canSkipSlowMode {
+    return ownCapabilities.contains(ChannelCapability.skipSlowMode);
+  }
+
+  /// True, if the current user can create a poll.
+  bool get canSendPoll {
+    return ownCapabilities.contains(ChannelCapability.sendPoll);
+  }
+
+  /// True, if the current user can vote in a poll.
+  bool get canCastPollVote {
+    return ownCapabilities.contains(ChannelCapability.castPollVote);
+  }
+
+  /// True, if the current user can query poll votes.
+  bool get canQueryPollVotes {
+    return ownCapabilities.contains(ChannelCapability.queryPollVotes);
   }
 }

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -413,11 +413,11 @@ class Channel {
   }
 
   /// List of user permissions on this channel
-  List<String> get ownCapabilities =>
+  List<ChannelCapability> get ownCapabilities =>
       state?._channelState.channel?.ownCapabilities ?? [];
 
   /// List of user permissions on this channel
-  Stream<List<String>> get ownCapabilitiesStream {
+  Stream<List<ChannelCapability>> get ownCapabilitiesStream {
     _checkInitialized();
     return state!.channelStateStream
         .map((cs) => cs.channel?.ownCapabilities ?? [])
@@ -3218,7 +3218,7 @@ extension on Iterable<Message> {
 ///
 /// These methods provide a convenient way to check if the current user has
 /// specific capabilities in a channel.
-extension ChannelCapabilityExtension on Channel {
+extension ChannelCapabilityCheck on Channel {
   /// True, if the current user can send a message to this channel.
   bool get canSendMessage {
     return ownCapabilities.contains(ChannelCapability.sendMessage);

--- a/packages/stream_chat/lib/src/core/models/channel_model.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.dart
@@ -68,15 +68,8 @@ class ChannelModel {
   @JsonKey(includeToJson: false)
   final String cid;
 
-  static List<ChannelCapability>? _ownCapabilitiesFromJson(
-    List<String>? ownCapabilities,
-  ) {
-    if (ownCapabilities == null) return null;
-    return [...ownCapabilities.map(ChannelCapability.new)];
-  }
-
   /// List of various capabilities that a user can have in a channel.
-  @JsonKey(includeToJson: false, fromJson: _ownCapabilitiesFromJson)
+  @JsonKey(includeToJson: false)
   final List<ChannelCapability>? ownCapabilities;
 
   /// The channel configuration data

--- a/packages/stream_chat/lib/src/core/models/channel_model.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.dart
@@ -14,7 +14,7 @@ class ChannelModel {
     String? id,
     String? type,
     String? cid,
-    this.ownCapabilities,
+    List<String>? ownCapabilities,
     ChannelConfig? config,
     this.createdBy,
     this.frozen = false,
@@ -40,6 +40,7 @@ class ChannelModel {
         config = config ?? ChannelConfig(),
         createdAt = createdAt ?? DateTime.now(),
         updatedAt = updatedAt ?? DateTime.now(),
+        ownCapabilities = ownCapabilities?.map(ChannelCapability.new).toList(),
 
         // For backwards compatibility, set 'disabled', 'hidden'
         // and 'truncated_at' in [extraData].
@@ -67,9 +68,16 @@ class ChannelModel {
   @JsonKey(includeToJson: false)
   final String cid;
 
-  /// List of user permissions on this channel
-  @JsonKey(includeToJson: false)
-  final List<String>? ownCapabilities;
+  static List<ChannelCapability>? _ownCapabilitiesFromJson(
+    List<String>? ownCapabilities,
+  ) {
+    if (ownCapabilities == null) return null;
+    return [...ownCapabilities.map(ChannelCapability.new)];
+  }
+
+  /// List of various capabilities that a user can have in a channel.
+  @JsonKey(includeToJson: false, fromJson: _ownCapabilitiesFromJson)
+  final List<ChannelCapability>? ownCapabilities;
 
   /// The channel configuration data
   @JsonKey(includeToJson: false)
@@ -237,4 +245,119 @@ class ChannelModel {
       truncatedAt: other.truncatedAt,
     );
   }
+}
+
+/// {@template channelCapability}
+/// Represents various capabilities that a user can have in a channel.
+/// {@endtemplate}
+extension type const ChannelCapability(String capability) implements String {
+  /// Ability to send a message.
+  static const sendMessage = ChannelCapability('send-message');
+
+  /// Ability to reply to a message.
+  static const sendReply = ChannelCapability('send-reply');
+
+  /// Ability to send a message with restricted visibility.
+  static const sendRestrictedVisibilityMessage = ChannelCapability(
+    'send-restricted-visibility-message',
+  );
+
+  /// Ability to send reactions.
+  static const sendReaction = ChannelCapability('send-reaction');
+
+  /// Ability to attach links to messages.
+  static const sendLinks = ChannelCapability('send-links');
+
+  /// Ability to attach files to messages.
+  static const createAttachment = ChannelCapability('create-attachment');
+
+  /// Ability to freeze or unfreeze channel.
+  static const freezeChannel = ChannelCapability('freeze-channel');
+
+  /// Ability to enable or disable slow mode.
+  static const setChannelCooldown = ChannelCapability('set-channel-cooldown');
+
+  /// Ability to leave channel (remove own membership).
+  static const leaveChannel = ChannelCapability('leave-channel');
+
+  /// Ability to join channel (add own membership).
+  static const joinChannel = ChannelCapability('join-channel');
+
+  /// Ability to pin a message.
+  static const pinMessage = ChannelCapability('pin-message');
+
+  /// Ability to delete any message from the channel.
+  static const deleteAnyMessage = ChannelCapability('delete-any-message');
+
+  /// Ability to delete own messages from the channel.
+  static const deleteOwnMessage = ChannelCapability('delete-own-message');
+
+  /// Ability to update any message in the channel.
+  static const updateAnyMessage = ChannelCapability('update-any-message');
+
+  /// Ability to update own messages in the channel.
+  static const updateOwnMessage = ChannelCapability('update-own-message');
+
+  /// Ability to use message search.
+  static const searchMessages = ChannelCapability('search-messages');
+
+  /// Ability to send typing events.
+  static const sendTypingEvents = ChannelCapability('send-typing-events');
+
+  /// Ability to upload message attachments.
+  static const uploadFile = ChannelCapability('upload-file');
+
+  /// Ability to delete channel.
+  static const deleteChannel = ChannelCapability('delete-channel');
+
+  /// Ability to update channel data.
+  static const updateChannel = ChannelCapability('update-channel');
+
+  /// Ability to update channel members.
+  static const updateChannelMembers = ChannelCapability(
+    'update-channel-members',
+  );
+
+  /// Ability to update thread data.
+  static const updateThread = ChannelCapability('update-thread');
+
+  /// Ability to quote a message.
+  static const quoteMessage = ChannelCapability('quote-message');
+
+  /// Ability to ban channel members.
+  static const banChannelMembers = ChannelCapability('ban-channel-members');
+
+  /// Ability to flag a message.
+  static const flagMessage = ChannelCapability('flag-message');
+
+  /// Ability to mute a channel.
+  static const muteChannel = ChannelCapability('mute-channel');
+
+  /// Ability to send custom events.
+  static const sendCustomEvents = ChannelCapability('send-custom-events');
+
+  /// Ability to receive read events.
+  static const readEvents = ChannelCapability('read-events');
+
+  /// Ability to receive connect events.
+  static const connectEvents = ChannelCapability('connect-events');
+
+  /// Ability to send and receive typing events.
+  static const typingEvents = ChannelCapability('typing-events');
+
+  /// Indicates that channel slow mode is active.
+  static const slowMode = ChannelCapability('slow-mode');
+
+  /// Indicates that the user is allowed to post messages as usual even if the
+  /// channel is in slow mode.
+  static const skipSlowMode = ChannelCapability('skip-slow-mode');
+
+  /// Ability to update a poll.
+  static const sendPoll = ChannelCapability('send-poll');
+
+  /// Ability to update a poll.
+  static const castPollVote = ChannelCapability('cast-poll-vote');
+
+  /// Ability to query poll votes.
+  static const queryPollVotes = ChannelCapability('query-poll-votes');
 }

--- a/packages/stream_chat/lib/src/core/models/channel_model.g.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.g.dart
@@ -10,8 +10,9 @@ ChannelModel _$ChannelModelFromJson(Map<String, dynamic> json) => ChannelModel(
       id: json['id'] as String?,
       type: json['type'] as String?,
       cid: json['cid'] as String?,
-      ownCapabilities: ChannelModel._ownCapabilitiesFromJson(
-          json['own_capabilities'] as List<String>?),
+      ownCapabilities: (json['own_capabilities'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       config: json['config'] == null
           ? null
           : ChannelConfig.fromJson(json['config'] as Map<String, dynamic>),

--- a/packages/stream_chat/lib/src/core/models/channel_model.g.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.g.dart
@@ -10,9 +10,8 @@ ChannelModel _$ChannelModelFromJson(Map<String, dynamic> json) => ChannelModel(
       id: json['id'] as String?,
       type: json['type'] as String?,
       cid: json['cid'] as String?,
-      ownCapabilities: (json['own_capabilities'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
+      ownCapabilities: ChannelModel._ownCapabilitiesFromJson(
+          json['own_capabilities'] as List<String>?),
       config: json['config'] == null
           ? null
           : ChannelConfig.fromJson(json['config'] as Map<String, dynamic>),

--- a/packages/stream_chat/lib/src/permission_type.dart
+++ b/packages/stream_chat/lib/src/permission_type.dart
@@ -1,4 +1,5 @@
 /// Describes capabilities of a user vis-a-vis a channel
+@Deprecated("Use 'ChannelCapability' instead")
 class PermissionType {
   /// Capability required to send a message in the channel
   /// Channel is not frozen (or user has UseFrozenChannel permission)

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -16,7 +16,7 @@ void main() {
     String channelId,
     String channelType, {
     DateTime? lastMessageAt,
-    List<String>? ownCapabilities,
+    List<ChannelCapability>? ownCapabilities,
     bool mockChannelConfig = false,
   }) {
     ChannelConfig? config;
@@ -3100,7 +3100,7 @@ void main() {
     );
   });
 
-  group('ChannelCapabilityExtension', () {
+  group('ChannelCapabilityCheck', () {
     const channelId = 'test-channel-id';
     const channelType = 'test-channel-type';
     late final client = MockStreamChatClient();

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -16,6 +16,7 @@ void main() {
     String channelId,
     String channelType, {
     DateTime? lastMessageAt,
+    List<String>? ownCapabilities,
     bool mockChannelConfig = false,
   }) {
     ChannelConfig? config;
@@ -28,6 +29,7 @@ void main() {
       id: channelId,
       type: channelType,
       config: config,
+      ownCapabilities: ownCapabilities,
       lastMessageAt: lastMessageAt,
     );
     final state = ChannelState(channel: channel);
@@ -3096,5 +3098,289 @@ void main() {
         );
       },
     );
+  });
+
+  group('ChannelCapabilityExtension', () {
+    const channelId = 'test-channel-id';
+    const channelType = 'test-channel-type';
+    late final client = MockStreamChatClient();
+
+    setUpAll(() {
+      // detached loggers
+      when(() => client.detachedLogger(any())).thenAnswer((invocation) {
+        final name = invocation.positionalArguments.first;
+        return _createLogger(name);
+      });
+
+      final retryPolicy = RetryPolicy(
+        shouldRetry: (_, __, ___) => false,
+        delayFactor: Duration.zero,
+      );
+      when(() => client.retryPolicy).thenReturn(retryPolicy);
+
+      final event = Event(type: 'event.local');
+      when(() => client.on(any(), any(), any(), any()))
+          .thenAnswer((_) => Stream.value(event));
+
+      // fake clientState
+      final clientState = FakeClientState();
+      when(() => client.state).thenReturn(clientState);
+
+      // client logger
+      when(() => client.logger).thenReturn(_createLogger('mock-client-logger'));
+    });
+
+    /// Parameterized test for channel capability extension properties
+    void testCapability(
+      String capabilityName,
+      ChannelCapability capability,
+      bool Function(Channel) getterMethod,
+    ) {
+      test('can$capabilityName returns false when capability is absent', () {
+        final channelState = _generateChannelState(channelId, channelType);
+        final channel = Channel.fromState(client, channelState);
+        expect(getterMethod(channel), false);
+      });
+
+      test('can$capabilityName returns true when capability is present', () {
+        final channelState = _generateChannelState(
+          channelId,
+          channelType,
+          ownCapabilities: [capability],
+        );
+        final channel = Channel.fromState(client, channelState);
+        expect(getterMethod(channel), true);
+      });
+    }
+
+    // Test all channel capabilities using the parameterized function
+    testCapability(
+      'SendMessage',
+      ChannelCapability.sendMessage,
+      (channel) => channel.canSendMessage,
+    );
+
+    testCapability(
+      'SendReply',
+      ChannelCapability.sendReply,
+      (channel) => channel.canSendReply,
+    );
+
+    testCapability(
+      'SendRestrictedVisibilityMessage',
+      ChannelCapability.sendRestrictedVisibilityMessage,
+      (channel) => channel.canSendRestrictedVisibilityMessage,
+    );
+
+    testCapability(
+      'SendReaction',
+      ChannelCapability.sendReaction,
+      (channel) => channel.canSendReaction,
+    );
+
+    testCapability(
+      'SendLinks',
+      ChannelCapability.sendLinks,
+      (channel) => channel.canSendLinks,
+    );
+
+    testCapability(
+      'CreateAttachment',
+      ChannelCapability.createAttachment,
+      (channel) => channel.canCreateAttachment,
+    );
+
+    testCapability(
+      'FreezeChannel',
+      ChannelCapability.freezeChannel,
+      (channel) => channel.canFreezeChannel,
+    );
+
+    testCapability(
+      'SetChannelCooldown',
+      ChannelCapability.setChannelCooldown,
+      (channel) => channel.canSetChannelCooldown,
+    );
+
+    testCapability(
+      'LeaveChannel',
+      ChannelCapability.leaveChannel,
+      (channel) => channel.canLeaveChannel,
+    );
+
+    testCapability(
+      'JoinChannel',
+      ChannelCapability.joinChannel,
+      (channel) => channel.canJoinChannel,
+    );
+
+    testCapability(
+      'PinMessage',
+      ChannelCapability.pinMessage,
+      (channel) => channel.canPinMessage,
+    );
+
+    testCapability(
+      'DeleteAnyMessage',
+      ChannelCapability.deleteAnyMessage,
+      (channel) => channel.canDeleteAnyMessage,
+    );
+
+    testCapability(
+      'DeleteOwnMessage',
+      ChannelCapability.deleteOwnMessage,
+      (channel) => channel.canDeleteOwnMessage,
+    );
+
+    testCapability(
+      'UpdateAnyMessage',
+      ChannelCapability.updateAnyMessage,
+      (channel) => channel.canUpdateAnyMessage,
+    );
+
+    testCapability(
+      'UpdateOwnMessage',
+      ChannelCapability.updateOwnMessage,
+      (channel) => channel.canUpdateOwnMessage,
+    );
+
+    testCapability(
+      'SearchMessages',
+      ChannelCapability.searchMessages,
+      (channel) => channel.canSearchMessages,
+    );
+
+    testCapability(
+      'SendTypingEvents',
+      ChannelCapability.sendTypingEvents,
+      (channel) => channel.canSendTypingEvents,
+    );
+
+    testCapability(
+      'UploadFile',
+      ChannelCapability.uploadFile,
+      (channel) => channel.canUploadFile,
+    );
+
+    testCapability(
+      'DeleteChannel',
+      ChannelCapability.deleteChannel,
+      (channel) => channel.canDeleteChannel,
+    );
+
+    testCapability(
+      'UpdateChannel',
+      ChannelCapability.updateChannel,
+      (channel) => channel.canUpdateChannel,
+    );
+
+    testCapability(
+      'UpdateChannelMembers',
+      ChannelCapability.updateChannelMembers,
+      (channel) => channel.canUpdateChannelMembers,
+    );
+
+    testCapability(
+      'UpdateThread',
+      ChannelCapability.updateThread,
+      (channel) => channel.canUpdateThread,
+    );
+
+    testCapability(
+      'QuoteMessage',
+      ChannelCapability.quoteMessage,
+      (channel) => channel.canQuoteMessage,
+    );
+
+    testCapability(
+      'BanChannelMembers',
+      ChannelCapability.banChannelMembers,
+      (channel) => channel.canBanChannelMembers,
+    );
+
+    testCapability(
+      'FlagMessage',
+      ChannelCapability.flagMessage,
+      (channel) => channel.canFlagMessage,
+    );
+
+    testCapability(
+      'MuteChannel',
+      ChannelCapability.muteChannel,
+      (channel) => channel.canMuteChannel,
+    );
+
+    testCapability(
+      'SendCustomEvents',
+      ChannelCapability.sendCustomEvents,
+      (channel) => channel.canSendCustomEvents,
+    );
+
+    testCapability(
+      'ReceiveReadEvents',
+      ChannelCapability.readEvents,
+      (channel) => channel.canReceiveReadEvents,
+    );
+
+    testCapability(
+      'ReceiveConnectEvents',
+      ChannelCapability.connectEvents,
+      (channel) => channel.canReceiveConnectEvents,
+    );
+
+    testCapability(
+      'UseTypingEvents',
+      ChannelCapability.typingEvents,
+      (channel) => channel.canUseTypingEvents,
+    );
+
+    testCapability(
+      'InSlowMode',
+      ChannelCapability.slowMode,
+      (channel) => channel.isInSlowMode,
+    );
+
+    testCapability(
+      'SkipSlowMode',
+      ChannelCapability.skipSlowMode,
+      (channel) => channel.canSkipSlowMode,
+    );
+
+    testCapability(
+      'SendPoll',
+      ChannelCapability.sendPoll,
+      (channel) => channel.canSendPoll,
+    );
+
+    testCapability(
+      'CastPollVote',
+      ChannelCapability.castPollVote,
+      (channel) => channel.canCastPollVote,
+    );
+
+    testCapability(
+      'QueryPollVotes',
+      ChannelCapability.queryPollVotes,
+      (channel) => channel.canQueryPollVotes,
+    );
+
+    test('returns correct values with multiple capabilities', () {
+      final channelState = _generateChannelState(
+        channelId,
+        channelType,
+        ownCapabilities: [
+          ChannelCapability.sendMessage,
+          ChannelCapability.sendReply,
+          ChannelCapability.deleteOwnMessage,
+        ],
+      );
+
+      final channel = Channel.fromState(client, channelState);
+      expect(channel.canSendMessage, true);
+      expect(channel.canSendReply, true);
+      expect(channel.canDeleteOwnMessage, true);
+      expect(channel.canDeleteAnyMessage, false);
+      expect(channel.canUpdateChannel, false);
+    });
   });
 }

--- a/packages/stream_chat_flutter/lib/src/bottom_sheets/stream_channel_info_bottom_sheet.dart
+++ b/packages/stream_chat_flutter/lib/src/bottom_sheets/stream_channel_info_bottom_sheet.dart
@@ -144,7 +144,7 @@ class StreamChannelInfoBottomSheet extends StatelessWidget {
             ),
             onTap: onLeaveChannelTap,
           ),
-        if (channel.ownCapabilities.contains(PermissionType.deleteChannel))
+        if (channel.canDeleteChannel)
           StreamOptionListTile(
             leading: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
+++ b/packages/stream_chat_flutter/lib/src/message_actions_modal/message_actions_modal.dart
@@ -108,14 +108,12 @@ class _MessageActionsModalState extends State<MessageActionsModal> {
     final user = StreamChat.of(context).currentUser;
     final orientation = mediaQueryData.orientation;
 
-    final _userPermissions = StreamChannel.of(context).channel.ownCapabilities;
-    final hasReactionPermission =
-        _userPermissions.contains(PermissionType.sendReaction);
-
     final fontSize = widget.messageTheme.messageTextStyle?.fontSize;
     final streamChatThemeData = StreamChatTheme.of(context);
 
     final channel = StreamChannel.of(context).channel;
+
+    final canSendReaction = channel.canSendReaction;
 
     final child = Center(
       child: SingleChildScrollView(
@@ -126,7 +124,7 @@ class _MessageActionsModalState extends State<MessageActionsModal> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
-                if (widget.showReactionPicker && hasReactionPermission)
+                if (widget.showReactionPicker && canSendReaction)
                   LayoutBuilder(
                     builder: (context, constraints) {
                       return Align(

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -599,8 +599,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
   @override
   Widget build(BuildContext context) {
     final channel = StreamChannel.of(context).channel;
-    if (channel.state != null &&
-        !channel.ownCapabilities.contains(PermissionType.sendMessage)) {
+    if (channel.state != null && !channel.canSendMessage) {
       return SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(
@@ -891,8 +890,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
   List<Widget> _actionsList() {
     final channel = StreamChannel.of(context).channel;
     final defaultActions = <Widget>[
-      if (!widget.disableAttachments &&
-          channel.ownCapabilities.contains(PermissionType.uploadFile))
+      if (!widget.disableAttachments && channel.canUploadFile)
         _buildAttachmentButton(context),
       if (widget.showCommandsButton &&
           !_isEditing &&
@@ -969,9 +967,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
         if (it != AttachmentPickerType.poll) return false;
         if (_effectiveController.message.parentId != null) return true;
         final channel = StreamChannel.of(context).channel;
-        if (channel.ownCapabilities.contains(PermissionType.sendPoll)) {
-          return false;
-        }
+        if (channel.canSendPoll) return false;
 
         return true;
       });
@@ -1202,8 +1198,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
       value = value.trim();
 
       final channel = StreamChannel.of(context).channel;
-      if (value.isNotEmpty &&
-          channel.ownCapabilities.contains(PermissionType.sendTypingEvents)) {
+      if (value.isNotEmpty && channel.canSendTypingEvents) {
         // Notify the server that the user started typing.
         channel.keyStroke(_effectiveController.message.parentId).onError(
           (error, stackTrace) {
@@ -1270,10 +1265,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
     // Reset the og attachment if the text doesn't contain any url
     if (matchedUrls.isEmpty ||
-        !StreamChannel.of(context)
-            .channel
-            .ownCapabilities
-            .contains(PermissionType.sendLinks)) {
+        !StreamChannel.of(context).channel.canSendLinks) {
       _effectiveController.clearOGAttachment();
       return;
     }
@@ -1460,7 +1452,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
     final channel = streamChannel.channel;
     var message = _effectiveController.value;
 
-    if (!channel.ownCapabilities.contains(PermissionType.sendLinks) &&
+    if (!channel.canSendLinks &&
         _urlRegex.allMatches(message.text ?? '').any((element) =>
             element.group(0)?.split('.').last.isValidTLD() == true)) {
       showInfoBottomSheet(

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -345,7 +345,6 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
   int? _messageListLength;
   StreamChannelState? streamChannel;
   late StreamChatThemeData _streamTheme;
-  late List<String> _userPermissions;
   late int unreadCount;
 
   double get _initialAlignment {
@@ -399,7 +398,6 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     super.didChangeDependencies();
     final newStreamChannel = StreamChannel.of(context);
     _streamTheme = StreamChatTheme.of(context);
-    _userPermissions = newStreamChannel.channel.ownCapabilities;
 
     if (newStreamChannel != streamChannel) {
       streamChannel = newStreamChannel;
@@ -1095,7 +1093,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
         FocusScope.of(context).unfocus();
       },
       showPinButton: currentUserMember != null &&
-          _userPermissions.contains(PermissionType.pinMessage) &&
+          streamChannel?.channel.canPinMessage == true &&
           // Pinning a restricted visibility message is not allowed, simply
           // because pinning a message is meant to bring attention to that
           // message, that is not possible with a message that is only visible
@@ -1380,10 +1378,8 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
       },
       showEditMessage: isMyMessage,
       showDeleteMessage: isMyMessage,
-      showThreadReplyMessage: !isThreadMessage &&
-          streamChannel?.channel.ownCapabilities
-                  .contains(PermissionType.sendReply) ==
-              true,
+      showThreadReplyMessage:
+          !isThreadMessage && streamChannel?.channel.canSendReply == true,
       showFlagButton: !isMyMessage,
       borderSide: borderSide,
       onThreadTap: _onThreadTap,
@@ -1458,7 +1454,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
         FocusScope.of(context).unfocus();
       },
       showPinButton: currentUserMember != null &&
-          _userPermissions.contains(PermissionType.pinMessage) &&
+          streamChannel?.channel.canPinMessage == true &&
           // Pinning a restricted visibility message is not allowed, simply
           // because pinning a message is meant to bring attention to that
           // message, that is not possible with a message that is only visible

--- a/packages/stream_chat_flutter/lib/src/message_widget/reactions/message_reactions_modal.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/reactions/message_reactions_modal.dart
@@ -41,11 +41,9 @@ class StreamMessageReactionsModal extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final user = StreamChat.of(context).currentUser;
-    final _userPermissions = StreamChannel.of(context).channel.ownCapabilities;
+    final channel = StreamChannel.of(context).channel;
     final orientation = MediaQuery.of(context).orientation;
-
-    final hasReactionPermission =
-        _userPermissions.contains(PermissionType.sendReaction);
+    final canSendReaction = channel.canSendReaction;
     final fontSize = messageTheme.messageTextStyle?.fontSize;
 
     final child = Center(
@@ -57,7 +55,7 @@ class StreamMessageReactionsModal extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
-                if (showReactionPicker && hasReactionPermission)
+                if (showReactionPicker && canSendReaction)
                   LayoutBuilder(
                     builder: (context, constraints) {
                       return Align(

--- a/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_actions_modal/message_actions_modal_test.dart
@@ -71,7 +71,10 @@ void main() {
       final client = MockClient();
       final clientState = MockClientState();
       final channel = MockChannel(
-        ownCapabilities: ['send-message', 'send-reaction'],
+        ownCapabilities: [
+          ChannelCapability.sendMessage,
+          ChannelCapability.sendReaction,
+        ],
       );
 
       when(() => client.state).thenReturn(clientState);

--- a/packages/stream_chat_flutter/test/src/mocks.dart
+++ b/packages/stream_chat_flutter/test/src/mocks.dart
@@ -22,7 +22,7 @@ class MockChannel extends Mock implements Channel {
   });
 
   @override
-  final List<String> ownCapabilities;
+  final List<ChannelCapability> ownCapabilities;
 
   @override
   Future<bool> get initialized async => true;

--- a/packages/stream_chat_flutter/test/src/mocks.dart
+++ b/packages/stream_chat_flutter/test/src/mocks.dart
@@ -16,8 +16,8 @@ class MockClientState extends Mock implements ClientState {}
 class MockChannel extends Mock implements Channel {
   MockChannel({
     this.ownCapabilities = const [
-      PermissionType.sendMessage,
-      PermissionType.uploadFile,
+      ChannelCapability.sendMessage,
+      ChannelCapability.uploadFile,
     ],
   });
 

--- a/sample_app/lib/widgets/channel_list.dart
+++ b/sample_app/lib/widgets/channel_list.dart
@@ -174,8 +174,7 @@ class _ChannelList extends State<ChannelList> {
                         final chatTheme = StreamChatTheme.of(context);
                         final backgroundColor = chatTheme.colorTheme.inputBg;
                         final channel = channels[index];
-                        final canDeleteChannel = channel.ownCapabilities
-                            .contains(PermissionType.deleteChannel);
+                        final canDeleteChannel = channel.canDeleteChannel;
                         return Slidable(
                           groupTag: 'channels-actions',
                           endActionPane: ActionPane(


### PR DESCRIPTION
## Description of the pull request

This pull request introduces significant improvements to the `stream_chat` package by refactoring user capabilities into a more structured format. The changes include replacing the `PermissionType` with a new `ChannelCapability` extension type and adding convenience methods to check user capabilities.