### PR TITLE
fix(llc): fix channel membership not updated

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - Added support for message moderation feature.
 
+🐞 Fixed
+
+- [[#1964]](https://github.com/GetStream/stream-chat-flutter/issues/1964) Fixes `Channel.membership`
+  field not updating correctly.
+
 🔄 Changed
 
 - Deprecated `PermissionType` in favor of `ChannelCapability`.

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2153,9 +2153,7 @@ class ChannelClientState {
           final existingMembership = channelState.membership;
 
           // Return if the user is not a existing member of the channel.
-          if (!existingMembers.any((m) => m.userId == user.id)) {
-            return;
-          }
+          if (!existingMembers.any((m) => m.userId == user.id)) return;
 
           Member? maybeUpdateMemberUser(Member? existingMember) {
             if (existingMember == null) return null;

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -554,7 +554,7 @@ class StreamChatClient {
     String? eventType3,
     String? eventType4,
   ]) {
-    if (eventType == null) return eventStream;
+    if (eventType == null || eventType == EventType.any) return eventStream;
     return eventStream.where((event) =>
         event.type == eventType ||
         event.type == eventType2 ||

--- a/packages/stream_chat/lib/src/core/models/channel_state.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_state.dart
@@ -63,16 +63,15 @@ class ChannelState {
     List<User>? watchers,
     List<Read>? read,
     Member? membership,
-  }) {
-    return ChannelState(
-      channel: channel ?? this.channel,
-      messages: messages ?? this.messages,
-      members: members ?? this.members,
-      pinnedMessages: pinnedMessages ?? this.pinnedMessages,
-      watcherCount: watcherCount ?? this.watcherCount,
-      watchers: watchers ?? this.watchers,
-      read: read ?? this.read,
-      membership: membership ?? this.membership,
-    );
-  }
+  }) =>
+      ChannelState(
+        channel: channel ?? this.channel,
+        messages: messages ?? this.messages,
+        members: members ?? this.members,
+        pinnedMessages: pinnedMessages ?? this.pinnedMessages,
+        watcherCount: watcherCount ?? this.watcherCount,
+        watchers: watchers ?? this.watchers,
+        read: read ?? this.read,
+        membership: membership ?? this.membership,
+      );
 }

--- a/packages/stream_chat/lib/src/core/models/channel_state.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_state.dart
@@ -7,6 +7,12 @@ import 'package:stream_chat/src/core/models/user.dart';
 
 part 'channel_state.g.dart';
 
+class _NullConst {
+  const _NullConst();
+}
+
+const _nullConst = _NullConst();
+
 /// The class that contains the information about a channel
 @JsonSerializable()
 class ChannelState {
@@ -62,16 +68,29 @@ class ChannelState {
     int? watcherCount,
     List<User>? watchers,
     List<Read>? read,
-    Member? membership,
-  }) =>
-      ChannelState(
-        channel: channel ?? this.channel,
-        messages: messages ?? this.messages,
-        members: members ?? this.members,
-        pinnedMessages: pinnedMessages ?? this.pinnedMessages,
-        watcherCount: watcherCount ?? this.watcherCount,
-        watchers: watchers ?? this.watchers,
-        read: read ?? this.read,
-        membership: membership ?? this.membership,
-      );
+    Object? membership = _nullConst,
+  }) {
+    assert(() {
+      if (membership is! Member &&
+          membership != null &&
+          membership is! _NullConst) {
+        throw ArgumentError('`membership` can only be set as Member or null');
+      }
+      return true;
+    }(), 'Validate type for membership');
+
+    return ChannelState(
+      channel: channel ?? this.channel,
+      messages: messages ?? this.messages,
+      members: members ?? this.members,
+      pinnedMessages: pinnedMessages ?? this.pinnedMessages,
+      watcherCount: watcherCount ?? this.watcherCount,
+      watchers: watchers ?? this.watchers,
+      read: read ?? this.read,
+      membership: switch (membership) {
+        _nullConst => this.membership,
+        _ => membership as Member?,
+      },
+    );
+  }
 }

--- a/packages/stream_chat/lib/src/core/models/channel_state.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_state.dart
@@ -7,12 +7,6 @@ import 'package:stream_chat/src/core/models/user.dart';
 
 part 'channel_state.g.dart';
 
-class _NullConst {
-  const _NullConst();
-}
-
-const _nullConst = _NullConst();
-
 /// The class that contains the information about a channel
 @JsonSerializable()
 class ChannelState {
@@ -68,17 +62,8 @@ class ChannelState {
     int? watcherCount,
     List<User>? watchers,
     List<Read>? read,
-    Object? membership = _nullConst,
+    Member? membership,
   }) {
-    assert(() {
-      if (membership is! Member &&
-          membership != null &&
-          membership is! _NullConst) {
-        throw ArgumentError('`membership` can only be set as Member or null');
-      }
-      return true;
-    }(), 'Validate type for membership');
-
     return ChannelState(
       channel: channel ?? this.channel,
       messages: messages ?? this.messages,
@@ -87,10 +72,7 @@ class ChannelState {
       watcherCount: watcherCount ?? this.watcherCount,
       watchers: watchers ?? this.watchers,
       read: read ?? this.read,
-      membership: switch (membership) {
-        _nullConst => this.membership,
-        _ => membership as Member?,
-      },
+      membership: membership ?? this.membership,
     );
   }
 }

--- a/packages/stream_chat/lib/src/core/models/member.dart
+++ b/packages/stream_chat/lib/src/core/models/member.dart
@@ -16,7 +16,7 @@ class Member extends Equatable {
     this.inviteRejectedAt,
     this.invited = false,
     this.channelRole,
-    this.userId,
+    String? userId,
     this.isModerator = false,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -24,18 +24,14 @@ class Member extends Equatable {
     this.banExpires,
     this.shadowBanned = false,
     this.extraData = const {},
-  })  : createdAt = createdAt ?? DateTime.now(),
+  })  : userId = userId ?? user?.id,
+        createdAt = createdAt ?? DateTime.now(),
         updatedAt = updatedAt ?? DateTime.now();
 
   /// Create a new instance from a json
-  factory Member.fromJson(Map<String, dynamic> json) {
-    final member = _$MemberFromJson(
-      Serializer.moveToExtraDataFromRoot(json, _topLevelFields),
-    );
-    return member.copyWith(
-      userId: member.user?.id,
-    );
-  }
+  factory Member.fromJson(Map<String, dynamic> json) => _$MemberFromJson(
+        Serializer.moveToExtraDataFromRoot(json, _topLevelFields),
+      );
 
   /// Known top level fields.
   ///

--- a/packages/stream_chat/test/src/client/retry_queue_test.dart
+++ b/packages/stream_chat/test/src/client/retry_queue_test.dart
@@ -18,19 +18,6 @@ void main() {
       },
     );
     when(() => channel.client.retryPolicy).thenReturn(retryPolicy);
-
-    when(() => channel.client.on(EventType.connectionRecovered)).thenAnswer(
-      (_) => Stream.value(Event(
-        type: EventType.connectionRecovered,
-        online: false,
-      )),
-    );
-
-    when(() => channel.on(any(), any(), any(), any())).thenAnswer(
-      (_) => Stream.value(
-        Event(type: EventType.any),
-      ),
-    );
   });
 
   setUp(() {

--- a/packages/stream_chat/test/src/fakes.dart
+++ b/packages/stream_chat/test/src/fakes.dart
@@ -93,7 +93,7 @@ class FakeChatApi extends Fake implements StreamChatApi {
 
 class FakeClientState extends Fake implements ClientState {
   @override
-  OwnUser? get currentUser => OwnUser(id: 'test-user-id');
+  OwnUser? get currentUser => OwnUser(id: 'test-user-id', name: 'Test User');
 
   @override
   int totalUnreadCount = 0;

--- a/packages/stream_chat/test/src/mocks.dart
+++ b/packages/stream_chat/test/src/mocks.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:logging/logging.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/client/channel.dart';
 import 'package:stream_chat/src/client/client.dart';
 import 'package:stream_chat/src/core/api/attachment_file_uploader.dart';
@@ -16,7 +17,9 @@ import 'package:stream_chat/src/core/http/connection_id_manager.dart';
 import 'package:stream_chat/src/core/http/stream_http_client.dart';
 import 'package:stream_chat/src/core/http/token_manager.dart';
 import 'package:stream_chat/src/core/models/channel_config.dart';
+import 'package:stream_chat/src/core/models/event.dart';
 import 'package:stream_chat/src/db/chat_persistence_client.dart';
+import 'package:stream_chat/src/event_type.dart';
 import 'package:stream_chat/src/ws/websocket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -92,10 +95,32 @@ class MockPersistenceClient extends Mock implements ChatPersistenceClient {
 class MockStreamChatClient extends Mock implements StreamChatClient {
   @override
   bool get persistenceEnabled => false;
+
+  @override
+  Stream<Event> get eventStream => _eventController.stream;
+  final _eventController = PublishSubject<Event>();
+  void addEvent(Event event) => _eventController.add(event);
+
+  @override
+  Stream<Event> on([
+    String? eventType,
+    String? eventType2,
+    String? eventType3,
+    String? eventType4,
+  ]) {
+    if (eventType == null || eventType == EventType.any) return eventStream;
+    return eventStream.where((event) =>
+        event.type == eventType ||
+        event.type == eventType2 ||
+        event.type == eventType3 ||
+        event.type == eventType4);
+  }
+
+  @override
+  Future<void> dispose() => _eventController.close();
 }
 
-class MockStreamChatClientWithPersistence extends Mock
-    implements StreamChatClient {
+class MockStreamChatClientWithPersistence extends MockStreamChatClient {
   ChatPersistenceClient? _persistenceClient;
 
   @override
@@ -125,6 +150,18 @@ class MockRetryQueueChannel extends Mock implements Channel {
 
   @override
   StreamChatClient get client => _client ??= MockStreamChatClient();
+
+  @override
+  Stream<Event> on([
+    String? eventType,
+    String? eventType2,
+    String? eventType3,
+    String? eventType4,
+  ]) {
+    return client
+        .on(eventType, eventType2, eventType3, eventType4)
+        .where((e) => e.cid == cid);
+  }
 }
 
 class MockWebSocket extends Mock implements WebSocket {}

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel_list_event_handler.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel_list_event_handler.dart
@@ -189,9 +189,7 @@ mixin class StreamChannelListEventHandler {
       final existingMembers = [...channel.state!.members];
 
       // Return if the user is not a existing member of the channel.
-      if (!existingMembers.any((m) => m.userId == user.id)) {
-        return channel;
-      }
+      if (!existingMembers.any((m) => m.userId == user.id)) return channel;
 
       Member? maybeUpdateMemberUser(Member? existingMember) {
         if (existingMember == null) return null;


### PR DESCRIPTION
Resolves: #1964 

## Description of the pull request

This PR fixes an issue where the channel membership is not getting updated when a member update event is received. Additionally, it also improves the test mock classes for better testing for ws events.