### PR TITLE
fix(ui): fix message input send message key predicate

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed invalid assertions
   applied on message input command and attachment button.
+- [[#2042]](https://github.com/GetStream/stream-chat-flutter/issues/2042) Fixed `StreamMessageInput`
+  send message predicate.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed invalid assertions
   applied on message input command and attachment button.
 - [[#2042]](https://github.com/GetStream/stream-chat-flutter/issues/2042) Fixed `StreamMessageInput`
-  send message predicate.
+  send message predicate to properly handle shift+enter for new lines and improve message text validation.
 
 ✅ Added
 
@@ -17,7 +17,8 @@
 
 - [[#2137]](https://github.com/GetStream/stream-chat-flutter/issues/2137) Fixed message input
   buttons not being able to customized.
-- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message order.
+- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message
+  order.
 
 ## 9.5.0
 
@@ -34,14 +35,16 @@
 🔄 Changed
 
 - Updated the message list view to prevent pinning messages that have restricted visibility.
-- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of `StreamMessageInput.useSystemAttachmentPicker`.
+- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of
+  `StreamMessageInput.useSystemAttachmentPicker`.
 
 ## 9.4.0
 
 🔄 Changed
 
 - Updated minimum Flutter version to 3.27.4 for the SDK.
-- Replaced [image_gallery_saver_plus](https://pub.dev/packages/image_gallery_saver_plus) with [gal](https://pub.dev/packages/gal)
+- Replaced [image_gallery_saver_plus](https://pub.dev/packages/image_gallery_saver_plus)
+  with [gal](https://pub.dev/packages/gal)
 
 ## 9.3.0
 
@@ -56,7 +59,8 @@
 - Deprecated `StreamVoiceRecordingLoading` as it is no longer used.
 - Deprecated `StreamVoiceRecordingPlayer` in favor of `StreamVoiceRecordingAttachment`.
 - Deprecated `StreamVoiceRecordingSlider` in favor of `StreamAudioWaveformSlider`.
-- Deprecated `VoiceRecordingAttachmentBuilder` in favor of `VoiceRecordingAttachmentPlaylistBuilder`.
+- Deprecated `VoiceRecordingAttachmentBuilder` in favor of
+  `VoiceRecordingAttachmentPlaylistBuilder`.
 - Deprecated `StreamVoiceRecordingTheme` in favor of `StreamVoiceRecordingAttachmentTheme`.
 
 ## 9.2.0+1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed invalid assertions
   applied on message input command and attachment button.
 - [[#2042]](https://github.com/GetStream/stream-chat-flutter/issues/2042) Fixed `StreamMessageInput`
-  send message predicate to properly handle shift+enter for new lines and improve message text validation.
+  send message predicate.
 
 ✅ Added
 
@@ -17,8 +17,7 @@
 
 - [[#2137]](https://github.com/GetStream/stream-chat-flutter/issues/2137) Fixed message input
   buttons not being able to customized.
-- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message
-  order.
+- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message order.
 
 ## 9.5.0
 
@@ -35,16 +34,14 @@
 🔄 Changed
 
 - Updated the message list view to prevent pinning messages that have restricted visibility.
-- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of
-  `StreamMessageInput.useSystemAttachmentPicker`.
+- Deprecated `StreamMessageInput.useNativeAttachmentPickerOnMobile` in favor of `StreamMessageInput.useSystemAttachmentPicker`.
 
 ## 9.4.0
 
 🔄 Changed
 
 - Updated minimum Flutter version to 3.27.4 for the SDK.
-- Replaced [image_gallery_saver_plus](https://pub.dev/packages/image_gallery_saver_plus)
-  with [gal](https://pub.dev/packages/gal)
+- Replaced [image_gallery_saver_plus](https://pub.dev/packages/image_gallery_saver_plus) with [gal](https://pub.dev/packages/gal)
 
 ## 9.3.0
 
@@ -59,8 +56,7 @@
 - Deprecated `StreamVoiceRecordingLoading` as it is no longer used.
 - Deprecated `StreamVoiceRecordingPlayer` in favor of `StreamVoiceRecordingAttachment`.
 - Deprecated `StreamVoiceRecordingSlider` in favor of `StreamAudioWaveformSlider`.
-- Deprecated `VoiceRecordingAttachmentBuilder` in favor of
-  `VoiceRecordingAttachmentPlaylistBuilder`.
+- Deprecated `VoiceRecordingAttachmentBuilder` in favor of `VoiceRecordingAttachmentPlaylistBuilder`.
 - Deprecated `StreamVoiceRecordingTheme` in favor of `StreamVoiceRecordingAttachmentTheme`.
 
 ## 9.2.0+1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [[#2118]](https://github.com/GetStream/stream-chat-flutter/issues/2118) Fixed invalid assertions
   applied on message input command and attachment button.
 - [[#2042]](https://github.com/GetStream/stream-chat-flutter/issues/2042) Fixed `StreamMessageInput`
-  send message predicate.
+  send message predicate to properly handle shift+enter for new lines and improve message text validation.
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
@@ -154,4 +155,127 @@ void main() {
       expect(find.text('Slow mode ON'), findsOneWidget);
     },
   );
+
+  group('MessageInput keyboard interactions', () {
+    final client = MockClient();
+    final clientState = MockClientState();
+    final channel = MockChannel();
+    final channelState = MockChannelState();
+
+    setUp(() {
+      registerFallbackValue(Message());
+
+      when(() => client.state).thenReturn(clientState);
+      when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
+      when(() => channel.state).thenReturn(channelState);
+      when(() => channel.client).thenReturn(client);
+      when(channel.getRemainingCooldown).thenReturn(0);
+      when(() => channelState.isUpToDate).thenReturn(true);
+    });
+
+    testWidgets(
+      'should send message when Enter key is pressed on desktop',
+      (tester) async {
+        when(() => channel.sendMessage(any())).thenAnswer(
+          (i) async => SendMessageResponse()
+            ..message = Message(
+              text: 'Hello world',
+            ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StreamChat(
+              client: client,
+              child: StreamChannel(
+                channel: channel,
+                child: const Scaffold(
+                  bottomNavigationBar: StreamMessageInput(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Add some text to the input field
+        final textField = find.byType(StreamMessageInput);
+        await tester.enterText(textField, 'Hello world');
+        await tester.pump();
+
+        // Simulate pressing Enter key
+        await simulateKeyDownEvent(LogicalKeyboardKey.enter, tester: tester);
+
+        await tester.pumpAndSettle();
+
+        // Verify that the message was sent
+        verify(() => channel.sendMessage(any())).called(1);
+      },
+    );
+
+    testWidgets(
+      'should not send message when Shift+Enter key is pressed on desktop',
+      (tester) async {
+        when(() => channel.sendMessage(any())).thenAnswer(
+          (_) async => SendMessageResponse()
+            ..message = Message(
+              text: 'Hello world',
+            ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StreamChat(
+              client: client,
+              child: StreamChannel(
+                channel: channel,
+                child: const Scaffold(
+                  bottomNavigationBar: StreamMessageInput(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Add some text to the input field
+        final textField = find.byType(StreamMessageInput);
+        await tester.enterText(textField, 'Hello world');
+        await tester.pump();
+
+        // Simulate pressing Shift+Enter key
+        await simulateKeyDownEvent(
+          LogicalKeyboardKey.enter,
+          tester: tester,
+          isShiftPressed: true,
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify that the message was not sent.
+        verifyNever(() => channel.sendMessage(any()));
+      },
+    );
+  });
+}
+
+// Helper function to simulate key press events
+Future<void> simulateKeyDownEvent(
+  LogicalKeyboardKey key, {
+  required WidgetTester tester,
+  bool isShiftPressed = false,
+}) async {
+  if (isShiftPressed) {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+  }
+
+  await tester.sendKeyDownEvent(key);
+  await tester.pumpAndSettle();
+  await tester.sendKeyUpEvent(key);
+
+  if (isShiftPressed) {
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+  }
 }


### PR DESCRIPTION
Fixes: #2042 

## Description of the pull request

This pull request includes several updates to the `StreamMessageInput` component in the `stream_chat_flutter` package, focusing on improving message validation and key event handling.

### Key Updates:

**Bug Fixes:**
* Fixed the `StreamMessageInput` send message predicate to ensure proper message sending behavior.

**Code Enhancements:**
* Improved the `_defaultValidator` method to better handle message validation by checking for non-empty text and attachments.
* Refined the `_defaultSendMessageKeyPredicate` method to handle key events more accurately by considering platform-specific behavior and shift key status.
* Updated the `_defaultClearQuotedMessageKeyPredicate` method to clear quoted messages based on the escape key press, with platform-specific handling.
* Simplified the `StreamMessageInputState` class by removing redundant platform-specific handling in the `Focus` widget.