### PR TITLE
refactor(ui): refactor message preview text to support polls

### DIFF
--- a/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
@@ -62,18 +62,19 @@ class StreamMessagePreviewText extends StatelessWidget {
     );
   }
 
-  /// Returns the preview text based on the message context
   String _getPreviewText(
     BuildContext context,
     Message message,
     User currentUser,
   ) {
+    final translations = context.translations;
+
     if (message.isDeleted) {
-      return context.translations.messageDeletedLabel;
+      return translations.messageDeletedLabel;
     }
 
     if (message.isSystem) {
-      return message.text ?? 'Empty System Message';
+      return message.text ?? translations.systemMessageLabel;
     }
 
     if (message.poll case final poll?) {
@@ -81,7 +82,7 @@ class StreamMessagePreviewText extends StatelessWidget {
     }
 
     final previewText = _previewMessageContextText(context, message);
-    if (previewText == null) return 'No messages';
+    if (previewText == null) return translations.emptyMessagePreviewText;
 
     // TODO: Handle Author name, Requires channel member count (breaking)
 
@@ -93,23 +94,29 @@ class StreamMessagePreviewText extends StatelessWidget {
     Poll poll,
     User currentUser,
   ) {
+    final translations = context.translations;
+
     // If the poll already contains some votes, we will preview the latest voter
     // and the poll name
     if (poll.latestVotes.firstOrNull?.user case final latestVoter?) {
       if (latestVoter.id == currentUser.id) {
-        return '📊 You voted: "${poll.name}"';
+        final youVoted = translations.pollYouVotedText;
+        return '📊 $youVoted: "${poll.name}"';
       }
 
-      return '📊 ${latestVoter.name} voted: "${poll.name}"';
+      final someoneVoted = translations.pollSomeoneVotedText(latestVoter.name);
+      return '📊 $someoneVoted: "${poll.name}"';
     }
 
     // Otherwise, we will show the creator of the poll and the poll name
     if (poll.createdBy case final creator?) {
       if (creator.id == currentUser.id) {
-        return '📊 You created: "${poll.name}"';
+        final youCreated = translations.pollYouCreatedText;
+        return '📊 $youCreated: "${poll.name}"';
       }
 
-      return '📊 ${creator.name} created: "${poll.name}"';
+      final someoneCreated = translations.pollSomeoneCreatedText(creator.name);
+      return '📊 $someoneCreated: "${poll.name}"';
     }
 
     // Otherwise, we will show the poll name if it exists.
@@ -121,11 +128,12 @@ class StreamMessagePreviewText extends StatelessWidget {
     return '📊';
   }
 
-  /// Gets the message content text, considering translations, attachments, and poll
   String? _previewMessageContextText(
     BuildContext context,
     Message message,
   ) {
+    final translations = context.translations;
+
     final messageText = switch (message.text) {
       final messageText? when messageText.isNotEmpty => messageText,
       _ => null,
@@ -145,12 +153,12 @@ class StreamMessagePreviewText extends StatelessWidget {
       };
 
       final attachmentTitle = switch (attachment.type) {
-        AttachmentType.audio => messageText ?? 'Audio',
+        AttachmentType.audio => messageText ?? translations.audioAttachmentText,
         AttachmentType.file => attachment.title ?? messageText,
-        AttachmentType.image => messageText ?? 'Image',
-        AttachmentType.video => messageText ?? 'Video',
+        AttachmentType.image => messageText ?? translations.imageAttachmentText,
+        AttachmentType.video => messageText ?? translations.videoAttachmentText,
         AttachmentType.giphy => messageText,
-        AttachmentType.voiceRecording => messageText ?? 'Voice recording',
+        AttachmentType.voiceRecording => translations.voiceRecordingText,
         _ => null,
       };
 

--- a/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
@@ -20,114 +20,169 @@ class StreamMessagePreviewText extends StatelessWidget {
   /// The style to use for the text.
   final TextStyle? textStyle;
 
-  /// The default preview predicate which determines if the message should be
-  /// shown in the preview or not.
-  static bool defaultPredicate(Message message) {
-    if (message.isShadowed) return false;
-    if (message.isDeleted) return false;
-    if (message.isError) return false;
-    if (message.isEphemeral) return false;
-
-    return true;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final messageText = message
-        .translate(language ?? 'en')
-        .replaceMentions(linkify: false)
-        .text;
-    final messageAttachments = message.attachments;
-    final messageMentionedUsers = message.mentionedUsers;
+    final currentUser = StreamChat.of(context).currentUser!;
+    final translatedMessage = message.translate(language ?? 'en');
+    final previewMessage = translatedMessage.replaceMentions(linkify: false);
 
+    final previewText = _getPreviewText(context, previewMessage, currentUser);
+
+    final mentionedUsers = message.mentionedUsers;
     final mentionedUsersRegex = RegExp(
-      messageMentionedUsers.map((it) => '@${it.name}').join('|'),
-      caseSensitive: false,
+      mentionedUsers.map((it) => '@${it.name}').join('|'),
     );
 
-    final messageTextParts = switch (message.isDeleted) {
-      // Show the deleted message label if the message is deleted.
-      true => [context.translations.messageDeletedLabel],
-      // Otherwise, combine the message text with the attachments and poll.
-      false => [
-          ...messageAttachments.map(
-            (it) => switch (it.type) {
-              AttachmentType.image => '📷',
-              AttachmentType.video => '🎬',
-              AttachmentType.giphy => '[GIF]',
-              AttachmentType.audio => '🎧',
-              AttachmentType.voiceRecording => '🎤',
-              _ => it == message.attachments.last
-                  ? (it.title ?? 'File')
-                  : '${it.title ?? 'File'},',
-            },
-          ),
-          if (message.poll?.name case final pollName?) '📊 $pollName',
-          if (messageText != null && messageText.isNotEmpty)
-            if (messageMentionedUsers.isNotEmpty)
-              ...mentionedUsersRegex.allMatchesWithSep(messageText)
-            else
-              messageText.trim(),
-        ]
-    };
+    final previewTextSpan = TextSpan(
+      children: [
+        ...previewText.splitByRegExp(mentionedUsersRegex).map(
+          (text) {
+            // Bold the text if it is a mention user.
+            if (mentionedUsers.any((it) => '@${it.name}' == text)) {
+              return TextSpan(
+                text: text,
+                style: textStyle?.copyWith(fontWeight: FontWeight.bold),
+              );
+            }
 
-    final fontStyle = switch (message.isSystem || message.isDeleted) {
-      true => FontStyle.italic,
-      false => FontStyle.normal,
-    };
-
-    final regularTextStyle = textStyle?.copyWith(fontStyle: fontStyle);
-
-    final mentionsTextStyle = textStyle?.copyWith(
-      fontStyle: fontStyle,
-      fontWeight: FontWeight.bold,
+            return TextSpan(
+              text: text,
+              style: textStyle,
+            );
+          },
+        )
+      ],
     );
-
-    final spans = [
-      ...messageTextParts.map((part) {
-        if (messageMentionedUsers.any((it) => '@${it.name}' == part)) {
-          return TextSpan(
-            text: part,
-            style: mentionsTextStyle,
-          );
-        }
-
-        if (messageAttachments.any((it) => it.title == part)) {
-          return TextSpan(
-            text: part,
-            style: regularTextStyle?.copyWith(
-              fontStyle: FontStyle.italic,
-            ),
-          );
-        }
-
-        return TextSpan(
-          text: part,
-          style: regularTextStyle,
-        );
-      })
-    ].insertBetween(const TextSpan(text: ' '));
 
     return Text.rich(
-      TextSpan(children: spans),
       maxLines: 1,
+      previewTextSpan,
       overflow: TextOverflow.ellipsis,
       textAlign: TextAlign.start,
     );
   }
+
+  /// Returns the preview text based on the message context
+  String _getPreviewText(
+    BuildContext context,
+    Message message,
+    User currentUser,
+  ) {
+    if (message.isDeleted) {
+      return context.translations.messageDeletedLabel;
+    }
+
+    if (message.isSystem) {
+      return message.text ?? 'Empty System Message';
+    }
+
+    if (message.poll case final poll?) {
+      return _pollPreviewText(context, poll, currentUser);
+    }
+
+    final previewText = _previewMessageContextText(context, message);
+    if (previewText == null) return 'No messages';
+
+    // TODO: Handle Author name, Requires channel member count (breaking)
+
+    return previewText;
+  }
+
+  String _pollPreviewText(
+    BuildContext context,
+    Poll poll,
+    User currentUser,
+  ) {
+    // If the poll already contains some votes, we will preview the latest voter
+    // and the poll name
+    if (poll.latestVotes.firstOrNull?.user case final latestVoter?) {
+      if (latestVoter.id == currentUser.id) {
+        return '📊 You voted: "${poll.name}"';
+      }
+
+      return '📊 ${latestVoter.name} voted: "${poll.name}"';
+    }
+
+    // Otherwise, we will show the creator of the poll and the poll name
+    if (poll.createdBy case final creator?) {
+      if (creator.id == currentUser.id) {
+        return '📊 You created: "${poll.name}"';
+      }
+
+      return '📊 ${creator.name} created: "${poll.name}"';
+    }
+
+    // Otherwise, we will show the poll name if it exists.
+    if (poll.name.trim() case final pollName when pollName.isNotEmpty) {
+      return '📊 $pollName';
+    }
+
+    // If nothing else, we will show the default poll emoji.
+    return '📊';
+  }
+
+  /// Gets the message content text, considering translations, attachments, and poll
+  String? _previewMessageContextText(
+    BuildContext context,
+    Message message,
+  ) {
+    final messageText = switch (message.text) {
+      final messageText? when messageText.isNotEmpty => messageText,
+      _ => null,
+    };
+
+    // If the message contains some attachments, we will show the first one
+    // and the text if it exists.
+    if (message.attachments.firstOrNull case final attachment?) {
+      final attachmentIcon = switch (attachment.type) {
+        AttachmentType.audio => '🎧',
+        AttachmentType.file => '📄',
+        AttachmentType.image => '📷',
+        AttachmentType.video => '📹',
+        AttachmentType.giphy => '[GIF]',
+        AttachmentType.voiceRecording => '🎤',
+        _ => null,
+      };
+
+      final attachmentTitle = switch (attachment.type) {
+        AttachmentType.audio => messageText ?? 'Audio',
+        AttachmentType.file => attachment.title ?? messageText,
+        AttachmentType.image => messageText ?? 'Image',
+        AttachmentType.video => messageText ?? 'Video',
+        AttachmentType.giphy => messageText,
+        AttachmentType.voiceRecording => messageText ?? 'Voice recording',
+        _ => null,
+      };
+
+      if (attachmentIcon != null || attachmentTitle != null) {
+        return [attachmentIcon, attachmentTitle].nonNulls.join(' ');
+      }
+    }
+
+    return messageText;
+  }
 }
 
-extension _RegExpX on RegExp {
-  List<String> allMatchesWithSep(String input, [int start = 0]) {
+extension on String {
+  List<String> splitByRegExp(RegExp regex) {
+    // If the pattern is empty, return the whole string
+    if (regex.pattern.isEmpty) return [this];
+
     final result = <String>[];
-    for (final match in allMatches(input, start)) {
-      result.add(input.substring(start, match.start));
-      // ignore: cascade_invocations
-      result.add(match[0]!);
-      // ignore: parameter_assignments
+    var start = 0;
+
+    for (final match in regex.allMatches(this)) {
+      if (match.start > start) {
+        result.add(substring(start, match.start));
+      }
+      result.add(match.group(0)!);
       start = match.end;
     }
-    result.add(input.substring(start));
+
+    if (start < length) {
+      result.add(substring(start));
+    }
+
     return result;
   }
 }

--- a/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
+++ b/packages/stream_chat_flutter/lib/src/channel/stream_message_preview_text.dart
@@ -7,12 +7,16 @@ class StreamMessagePreviewText extends StatelessWidget {
   const StreamMessagePreviewText({
     super.key,
     required this.message,
+    this.channel,
     this.language,
     this.textStyle,
   });
 
   /// The message to display.
   final Message message;
+
+  /// The channel to which the message belongs.
+  final ChannelModel? channel;
 
   /// The language to use for translations.
   final String? language;
@@ -23,7 +27,8 @@ class StreamMessagePreviewText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final currentUser = StreamChat.of(context).currentUser!;
-    final translatedMessage = message.translate(language ?? 'en');
+    final translationLanguage = language ?? currentUser.language ?? 'en';
+    final translatedMessage = message.translate(translationLanguage);
     final previewMessage = translatedMessage.replaceMentions(linkify: false);
 
     final previewText = _getPreviewText(context, previewMessage, currentUser);
@@ -84,7 +89,15 @@ class StreamMessagePreviewText extends StatelessWidget {
     final previewText = _previewMessageContextText(context, message);
     if (previewText == null) return translations.emptyMessagePreviewText;
 
-    // TODO: Handle Author name, Requires channel member count (breaking)
+    if (channel case final channel?) {
+      if (message.user?.id == currentUser.id) {
+        return '${translations.youText}: $previewText';
+      }
+
+      if (channel.memberCount > 2) {
+        return '${message.user?.name}: $previewText';
+      }
+    }
 
     return previewText;
   }
@@ -147,7 +160,7 @@ class StreamMessagePreviewText extends StatelessWidget {
         AttachmentType.file => '📄',
         AttachmentType.image => '📷',
         AttachmentType.video => '📹',
-        AttachmentType.giphy => '[GIF]',
+        AttachmentType.giphy => '/giphy',
         AttachmentType.voiceRecording => '🎤',
         _ => null,
       };

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -69,6 +69,9 @@ abstract class Translations {
   /// The label for message deleted
   String get messageDeletedLabel;
 
+  /// The label for system message
+  String get systemMessageLabel;
+
   /// The label for showing the message is edited
   String get editedMessageLabel;
 
@@ -505,6 +508,33 @@ abstract class Translations {
 
   /// The content text of the moderated message warning dialog
   String get moderationReviewModalDescription;
+
+  /// The text for empty message previews
+  String get emptyMessagePreviewText;
+
+  /// The text for voice recording in channel list preview
+  String get voiceRecordingText;
+
+  /// The text for audio attachment in channel list preview
+  String get audioAttachmentText;
+
+  /// The text for image attachment in channel list preview
+  String get imageAttachmentText;
+
+  /// The text for video attachment in channel list preview
+  String get videoAttachmentText;
+
+  /// The text for poll when current user voted
+  String get pollYouVotedText;
+
+  /// The text for poll when someone voted
+  String pollSomeoneVotedText(String username);
+
+  /// The text for poll when current user created
+  String get pollYouCreatedText;
+
+  /// The text for poll when someone created
+  String pollSomeoneCreatedText(String username);
 }
 
 /// Default implementation of Translation strings for the stream chat widgets
@@ -592,6 +622,9 @@ class DefaultTranslations implements Translations {
 
   @override
   String get messageDeletedLabel => 'Message deleted';
+
+  @override
+  String get systemMessageLabel => 'System Message';
 
   @override
   String get editedMessageLabel => 'Edited';
@@ -1138,4 +1171,31 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
   @override
   String get moderationReviewModalDescription =>
       '''Consider how your comment might make others feel and be sure to follow our Community Guidelines.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Voice Recording';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Image';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'You voted';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username voted';
+
+  @override
+  String get pollYouCreatedText => 'You created';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username created';
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -4,6 +4,7 @@ import 'package:stream_chat_flutter/src/message_widget/sending_indicator_builder
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/misc/timestamp.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+import 'package:collection/collection.dart' show IterableComparableExtension;
 
 /// A widget that displays a channel preview.
 ///
@@ -341,6 +342,7 @@ class ChannelLastMessageText extends StatefulWidget {
     super.key,
     required this.channel,
     this.textStyle,
+    this.lastMessagePredicate = _defaultLastMessagePredicate,
   }) : assert(
           channel.state != null,
           'Channel ${channel.id} is not initialized',
@@ -352,33 +354,60 @@ class ChannelLastMessageText extends StatefulWidget {
   /// The style of the text displayed
   final TextStyle? textStyle;
 
+  /// The predicate to determine if the message should be considered for the
+  /// last message.
+  ///
+  /// This predicate is used to filter out messages that should not be
+  /// considered for the last message.
+  final bool Function(Message) lastMessagePredicate;
+
+  // The default predicate to determine if the message should be
+  // considered for the last message.
+  static bool _defaultLastMessagePredicate(Message message) {
+    if (message.isShadowed) return false;
+    if (message.isDeleted) return false;
+    if (message.isError) return false;
+    if (message.isEphemeral) return false;
+
+    return true;
+  }
+
   @override
   State<ChannelLastMessageText> createState() => _ChannelLastMessageTextState();
 }
 
 class _ChannelLastMessageTextState extends State<ChannelLastMessageText> {
-  Message? _lastMessage;
+  Message? _currentLastMessage;
 
   @override
-  Widget build(BuildContext context) => BetterStreamBuilder<List<Message>>(
-        stream: widget.channel.state!.messagesStream,
-        initialData: widget.channel.state!.messages,
-        builder: (context, messages) {
-          final lastMessage = messages.lastWhereOrNull(
-            StreamMessagePreviewText.defaultPredicate,
-          );
+  Widget build(BuildContext context) {
+    return BetterStreamBuilder<List<Message>>(
+      stream: widget.channel.state!.messagesStream,
+      initialData: widget.channel.state!.messages,
+      builder: (context, messages) {
+        final message = messages.lastWhereOrNull(widget.lastMessagePredicate);
+        final latestLastMessage = [message, _currentLastMessage].latest;
 
-          if (widget.channel.state?.isUpToDate == true) {
-            _lastMessage = lastMessage;
-          }
+        if (latestLastMessage == null) return const Empty();
 
-          if (_lastMessage == null) return const Empty();
+        return StreamMessagePreviewText(
+          message: latestLastMessage,
+          textStyle: widget.textStyle,
+          language: widget.channel.client.state.currentUser?.language,
+        );
+      },
+    );
+  }
+}
 
-          return StreamMessagePreviewText(
-            message: _lastMessage!,
-            textStyle: widget.textStyle,
-            language: widget.channel.client.state.currentUser?.language,
-          );
-        },
-      );
+extension on Iterable<Message?> {
+  Message? get latest {
+    return reduce((a, b) {
+      if (a == null) return b;
+      if (b == null) return a;
+
+      if (a.createdAt.isAfter(b.createdAt)) return a;
+      return b;
+    });
+  }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -4,7 +4,6 @@ import 'package:stream_chat_flutter/src/message_widget/sending_indicator_builder
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/misc/timestamp.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
-import 'package:collection/collection.dart' show IterableComparableExtension;
 
 /// A widget that displays a channel preview.
 ///
@@ -388,7 +387,14 @@ class _ChannelLastMessageTextState extends State<ChannelLastMessageText> {
         final message = messages.lastWhereOrNull(widget.lastMessagePredicate);
         final latestLastMessage = [message, _currentLastMessage].latest;
 
-        if (latestLastMessage == null) return const Empty();
+        if (latestLastMessage == null) {
+          return Text(
+            maxLines: 1,
+            context.translations.emptyMessagesText,
+            style: widget.textStyle,
+            overflow: TextOverflow.ellipsis,
+          );
+        }
 
         return StreamMessagePreviewText(
           message: latestLastMessage,

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -399,7 +399,7 @@ class _ChannelLastMessageTextState extends State<ChannelLastMessageText> {
         return StreamMessagePreviewText(
           message: latestLastMessage,
           textStyle: widget.textStyle,
-          language: widget.channel.client.state.currentUser?.language,
+          channel: widget.channel.state?.channelState.channel,
         );
       },
     );

--- a/packages/stream_chat_flutter/test/src/channel/stream_message_preview_text_test.dart
+++ b/packages/stream_chat_flutter/test/src/channel/stream_message_preview_text_test.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late MockClient client;
+  late MockClientState clientState;
+  late OwnUser currentUser;
+
+  setUp(() {
+    client = MockClient();
+    clientState = MockClientState();
+    currentUser = OwnUser(id: 'test-user-id', name: 'Test User');
+
+    when(() => client.state).thenReturn(clientState);
+    when(() => clientState.currentUser).thenReturn(currentUser);
+  });
+
+  // Helper to pump the message preview widget
+  Future<void> pumpMessagePreview(
+    WidgetTester tester,
+    Message message, {
+    String? language,
+    TextStyle? textStyle,
+  }) async {
+    final client = MockClient();
+    final clientState = MockClientState();
+    final currentUser = OwnUser(id: 'test-user-id', name: 'Test User');
+
+    when(() => client.state).thenReturn(clientState);
+    when(() => clientState.currentUser).thenReturn(currentUser);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StreamChat(
+            client: client,
+            streamChatThemeData: StreamChatThemeData.light(),
+            child: Center(
+              child: StreamMessagePreviewText(
+                message: message,
+                language: language,
+                textStyle: textStyle,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  group('StreamMessagePreviewText', () {
+    testWidgets('renders regular text message', (tester) async {
+      final message = Message(
+        text: 'Hello, world!',
+        user: User(id: 'other-user-id', name: 'Other User'),
+      );
+
+      await pumpMessagePreview(tester, message);
+
+      expect(find.text('Hello, world!'), findsOneWidget);
+    });
+
+    testWidgets('renders deleted message', (tester) async {
+      final message = Message(
+        text: 'Original message',
+        type: MessageType.deleted,
+        user: User(id: 'other-user-id', name: 'Other User'),
+        deletedAt: DateTime.now(),
+      );
+
+      await pumpMessagePreview(tester, message);
+
+      expect(find.text('Message deleted'), findsOneWidget);
+    });
+
+    testWidgets('renders system message', (tester) async {
+      final message = Message(
+        text: 'User joined the channel',
+        type: MessageType.system,
+      );
+
+      await pumpMessagePreview(tester, message);
+
+      expect(find.text('User joined the channel'), findsOneWidget);
+    });
+
+    testWidgets('renders empty system message', (tester) async {
+      final message = Message(
+        text: null,
+        type: MessageType.system,
+      );
+
+      await pumpMessagePreview(tester, message);
+
+      expect(find.text('Empty System Message'), findsOneWidget);
+    });
+
+    testWidgets('renders empty message with no attachments', (tester) async {
+      final message = Message(
+        text: '',
+        user: User(id: 'other-user-id', name: 'Other User'),
+      );
+
+      await pumpMessagePreview(tester, message);
+
+      expect(find.text('No messages'), findsOneWidget);
+    });
+
+    testWidgets('renders message with mentioned users in bold', (tester) async {
+      final mentionedUser = User(id: 'mentioned-id', name: 'Mentioned User');
+      final message = Message(
+        text: 'Hello @Mentioned User, how are you?',
+        user: User(id: 'other-user-id', name: 'Other User'),
+        mentionedUsers: [mentionedUser],
+      );
+
+      await pumpMessagePreview(tester, message, textStyle: const TextStyle());
+
+      expect(find.text('Hello @Mentioned User, how are you?'), findsOneWidget);
+
+      // Find the rich text and verify that it contains a valid TextSpan
+      final textWidget = tester.widget<Text>(find.byType(Text).last);
+      expect(textWidget.textSpan, isNotNull);
+    });
+
+    group('Attachments', () {
+      testWidgets('renders image attachment', (tester) async {
+        final message = Message(
+          text: '',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.image,
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📷 Image'), findsOneWidget);
+      });
+
+      testWidgets('renders image attachment with text', (tester) async {
+        final message = Message(
+          text: 'Check this out',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.image,
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📷 Check this out'), findsOneWidget);
+      });
+
+      testWidgets('renders video attachment', (tester) async {
+        final message = Message(
+          text: '',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.video,
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📹 Video'), findsOneWidget);
+      });
+
+      testWidgets('renders file attachment', (tester) async {
+        final message = Message(
+          text: '',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.file,
+              title: 'document.pdf',
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📄 document.pdf'), findsOneWidget);
+      });
+
+      testWidgets('renders audio attachment', (tester) async {
+        final message = Message(
+          text: '',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.audio,
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('🎧 Audio'), findsOneWidget);
+      });
+
+      testWidgets('renders voice recording attachment', (tester) async {
+        final message = Message(
+          text: '',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: AttachmentType.voiceRecording,
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('🎤 Voice recording'), findsOneWidget);
+      });
+
+      testWidgets('renders unknown attachment type with text', (tester) async {
+        final message = Message(
+          text: 'Some text',
+          user: User(id: 'other-user-id', name: 'Other User'),
+          attachments: [
+            Attachment(
+              type: 'unknown',
+            ),
+          ],
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('Some text'), findsOneWidget);
+      });
+    });
+
+    group('Poll Tests', () {
+      testWidgets('renders poll with latest voter (current user)',
+          (tester) async {
+        final voterPoll = Poll(
+          name: 'Favorite Color?',
+          options: const [
+            PollOption(id: 'option-1', text: 'Red'),
+            PollOption(id: 'option-2', text: 'Blue'),
+          ],
+          latestVotesByOption: {
+            'option-1': [
+              PollVote(
+                user: currentUser,
+                optionId: 'option-1',
+              ),
+            ],
+          },
+        );
+
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Poll Creator'),
+          poll: voterPoll,
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊 You voted: "Favorite Color?"'), findsOneWidget);
+      });
+
+      testWidgets('renders poll with latest voter (another user)',
+          (tester) async {
+        final voter = User(id: 'voter-id', name: 'Voter');
+        final voterPoll = Poll(
+          name: 'Favorite Color?',
+          options: const [
+            PollOption(id: 'option-1', text: 'Red'),
+            PollOption(id: 'option-2', text: 'Blue'),
+          ],
+          latestVotesByOption: {
+            'option-1': [
+              PollVote(
+                user: voter,
+                optionId: 'option-1',
+              ),
+            ],
+          },
+        );
+
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Poll Creator'),
+          poll: voterPoll,
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊 Voter voted: "Favorite Color?"'), findsOneWidget);
+      });
+
+      testWidgets('renders poll with creator (current user)', (tester) async {
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Message Sender'),
+          poll: Poll(
+            name: 'Favorite Color?',
+            options: const [
+              PollOption(id: 'option-1', text: 'Red'),
+              PollOption(id: 'option-2', text: 'Blue'),
+            ],
+            createdBy: currentUser,
+          ),
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊 You created: "Favorite Color?"'), findsOneWidget);
+      });
+
+      testWidgets('renders poll with creator (another user)', (tester) async {
+        final creator = User(id: 'creator-id', name: 'Alex');
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Message Sender'),
+          poll: Poll(
+            name: 'Favorite Color?',
+            options: const [
+              PollOption(id: 'option-1', text: 'Red'),
+              PollOption(id: 'option-2', text: 'Blue'),
+            ],
+            createdBy: creator,
+          ),
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊 Alex created: "Favorite Color?"'), findsOneWidget);
+      });
+
+      testWidgets('renders poll with only name', (tester) async {
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Message Sender'),
+          poll: Poll(
+            name: 'Favorite Color?',
+            options: const [
+              PollOption(id: 'option-1', text: 'Red'),
+              PollOption(id: 'option-2', text: 'Blue'),
+            ],
+          ),
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊 Favorite Color?'), findsOneWidget);
+      });
+
+      testWidgets('renders poll with empty name', (tester) async {
+        final message = Message(
+          user: User(id: 'other-user-id', name: 'Message Sender'),
+          poll: Poll(
+            name: '   ',
+            options: const [
+              PollOption(id: 'option-1', text: 'Red'),
+              PollOption(id: 'option-2', text: 'Blue'),
+            ],
+          ),
+        );
+
+        await pumpMessagePreview(tester, message);
+
+        expect(find.text('📊'), findsOneWidget);
+      });
+    });
+
+    testWidgets('supports different language for translation', (tester) async {
+      final message = Message(
+        text: 'Hello, world!',
+        user: User(id: 'other-user-id', name: 'Other User'),
+        i18n: const {
+          'fr_text': 'Bonjour, monde!',
+        },
+      );
+
+      await pumpMessagePreview(tester, message, language: 'fr');
+
+      expect(find.text('Bonjour, monde!'), findsOneWidget);
+    });
+  });
+}

--- a/packages/stream_chat_flutter/test/src/channel/stream_message_preview_text_test.dart
+++ b/packages/stream_chat_flutter/test/src/channel/stream_message_preview_text_test.dart
@@ -90,14 +90,11 @@ void main() {
     });
 
     testWidgets('renders empty system message', (tester) async {
-      final message = Message(
-        text: null,
-        type: MessageType.system,
-      );
+      final message = Message(type: MessageType.system);
 
       await pumpMessagePreview(tester, message);
 
-      expect(find.text('Empty System Message'), findsOneWidget);
+      expect(find.text('System Message'), findsOneWidget);
     });
 
     testWidgets('renders empty message with no attachments', (tester) async {
@@ -108,7 +105,7 @@ void main() {
 
       await pumpMessagePreview(tester, message);
 
-      expect(find.text('No messages'), findsOneWidget);
+      expect(find.text(''), findsOneWidget);
     });
 
     testWidgets('renders message with mentioned users in bold', (tester) async {
@@ -223,7 +220,7 @@ void main() {
 
         await pumpMessagePreview(tester, message);
 
-        expect(find.text('🎤 Voice recording'), findsOneWidget);
+        expect(find.text('🎤 Voice Recording'), findsOneWidget);
       });
 
       testWidgets('renders unknown attachment type with text', (tester) async {

--- a/packages/stream_chat_flutter/test/src/localization/default_translations_test.dart
+++ b/packages/stream_chat_flutter/test/src/localization/default_translations_test.dart
@@ -173,5 +173,15 @@ void main() {
     expect(translations.unreadMessagesSeparatorText(), isNotNull);
     expect(translations.markUnreadError, isNotNull);
     expect(translations.markAsUnreadLabel, isNotNull);
+    expect(translations.emptyMessagePreviewText, isNotNull);
+    expect(translations.voiceRecordingText, isNotNull);
+    expect(translations.audioAttachmentText, isNotNull);
+    expect(translations.imageAttachmentText, isNotNull);
+    expect(translations.videoAttachmentText, isNotNull);
+    expect(translations.pollYouVotedText, isNotNull);
+    expect(translations.pollSomeoneVotedText('TestUser'), isNotNull);
+    expect(translations.pollYouCreatedText, isNotNull);
+    expect(translations.pollSomeoneCreatedText('TestUser'), isNotNull);
+    expect(translations.systemMessageLabel, isNotNull);
   });
 }

--- a/packages/stream_chat_flutter/test/src/scroll_view/thread_scroll_view/stream_thread_list_tile_test.dart
+++ b/packages/stream_chat_flutter/test/src/scroll_view/thread_scroll_view/stream_thread_list_tile_test.dart
@@ -1,6 +1,9 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:flutter/material.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../../mocks.dart';
 
 void main() {
   final user1 = User(id: 'uid1', name: 'User 1');
@@ -75,18 +78,27 @@ Widget _wrapWithMaterialApp(
   Widget widget, {
   Brightness? brightness,
 }) {
+  final client = MockClient();
+  final clientState = MockClientState();
+  final currentUser = OwnUser(id: 'current-user-id', name: 'Current User');
+
+  when(() => client.state).thenReturn(clientState);
+  when(() => clientState.currentUser).thenReturn(currentUser);
+
   return MaterialApp(
-    home: StreamChatConfiguration(
-      data: StreamChatConfigurationData(),
-      child: StreamChatTheme(
-        data: StreamChatThemeData(brightness: brightness),
-        child: Builder(builder: (context) {
+    home: StreamChat(
+      client: client,
+      streamChatConfigData: StreamChatConfigurationData(),
+      connectivityStream: Stream.value([ConnectivityResult.wifi]),
+      streamChatThemeData: StreamChatThemeData(brightness: brightness),
+      child: Builder(
+        builder: (context) {
           final theme = StreamChatTheme.of(context);
           return Scaffold(
             backgroundColor: theme.colorTheme.appBg,
             body: Center(child: widget),
           );
-        }),
+        },
       ),
     ),
   );

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -4,6 +4,16 @@
 - Added translations for new `moderatedMessageBlockedText` text.
 - Added translations for new `moderationReviewModalTitle` text.
 - Added translations for new `moderationReviewModalDescription` text.
+- Added translations for new `emptyMessagePreviewText` text.
+- Added translations for new `voiceRecordingText` text.
+- Added translations for new `audioAttachmentText` text.
+- Added translations for new `imageAttachmentText` text.
+- Added translations for new `videoAttachmentText` text.
+- Added translations for new `pollYouVotedText` text.
+- Added translations for new `pollSomeoneVotedText` text.
+- Added translations for new `pollYouCreatedText` text.
+- Added translations for new `pollSomeoneCreatedText` text.
+- Added translations for new `systemMessageLabel` label.
 
 ## 9.6.0
 

--- a/packages/stream_chat_localizations/example/lib/add_new_lang.dart
+++ b/packages/stream_chat_localizations/example/lib/add_new_lang.dart
@@ -109,6 +109,9 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Message deleted';
 
   @override
+  String get systemMessageLabel => 'System message';
+
+  @override
   String get editedMessageLabel => 'Edited';
 
   @override
@@ -652,6 +655,33 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   @override
   String get moderationReviewModalDescription =>
       '''Consider how your comment might make others feel and be sure to follow our Community Guidelines.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Voice Recording';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Image';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'You voted';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username voted';
+
+  @override
+  String get pollYouCreatedText => 'You created';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username created';
 }
 
 void main() async {

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
@@ -83,7 +83,10 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
   String get messageDeletedText => 'Aquest missatge ha estat esborrat';
 
   @override
-  String get messageDeletedLabel => 'Missatge esborrat';
+  String get messageDeletedLabel => 'Missatge eliminat';
+
+  @override
+  String get systemMessageLabel => 'Missatge del sistema';
 
   @override
   String get editedMessageLabel => 'Editat';
@@ -633,5 +636,32 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      """Considera com el teu comentari podria fer sentir als altres i assegura't de seguir les nostres Directrius de la Comunitat.""";
+      '''Considera com el teu comentari pot fer sentir als altres i assegura't de seguir les nostres Directrius de la Comunitat.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Enregistrament de veu';
+
+  @override
+  String get audioAttachmentText => 'Àudio';
+
+  @override
+  String get imageAttachmentText => 'Imatge';
+
+  @override
+  String get videoAttachmentText => 'Vídeo';
+
+  @override
+  String get pollYouVotedText => 'Has votat';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username ha votat';
+
+  @override
+  String get pollYouCreatedText => 'Has creat';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username ha creat';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -81,6 +81,9 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Nachricht gelöscht';
 
   @override
+  String get systemMessageLabel => 'Systemnachricht';
+
+  @override
   String get editedMessageLabel => 'Bearbeitet';
 
   @override
@@ -626,5 +629,32 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      '''Bedenke, wie dein Kommentar auf andere wirken könnte, und halte dich an unsere Community-Richtlinien.''';
+      '''Bedenke, wie dein Kommentar andere beeinflussen könnte, und achte darauf, unsere Community-Richtlinien einzuhalten.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Sprachaufnahme';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Bild';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'Du hast abgestimmt';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username hat abgestimmt';
+
+  @override
+  String get pollYouCreatedText => 'Du hast erstellt';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username hat erstellt';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -85,6 +85,9 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Message deleted';
 
   @override
+  String get systemMessageLabel => 'System Message';
+
+  @override
   String get editedMessageLabel => 'Edited';
 
   @override
@@ -629,4 +632,31 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   @override
   String get moderationReviewModalDescription =>
       '''Consider how your comment might make others feel and be sure to follow our Community Guidelines.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Voice Recording';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Image';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'You voted';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username voted';
+
+  @override
+  String get pollYouCreatedText => 'You created';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username created';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
@@ -84,7 +84,10 @@ class StreamChatLocalizationsEs extends GlobalStreamChatLocalizations {
   String get messageDeletedText => 'Este mensaje ha sido borrado.';
 
   @override
-  String get messageDeletedLabel => 'Mensaje borrado';
+  String get messageDeletedLabel => 'Mensaje eliminado';
+
+  @override
+  String get systemMessageLabel => 'Mensaje del sistema';
 
   @override
   String get editedMessageLabel => 'Editado';
@@ -635,5 +638,32 @@ No es posible añadir más de $limit archivos adjuntos
 
   @override
   String get moderationReviewModalDescription =>
-      '''Considera cómo tu comentario podría hacer sentir a los demás y asegúrate de seguir nuestras Normas de la Comunidad.''';
+      '''Considera cómo tu comentario podría hacer sentir a los demás y asegúrate de seguir nuestras Directrices de la Comunidad.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Grabación de voz';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Imagen';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'Has votado';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username ha votado';
+
+  @override
+  String get pollYouCreatedText => 'Has creado';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username ha creado';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -86,7 +86,10 @@ class StreamChatLocalizationsFr extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Message supprimé';
 
   @override
-  String get editedMessageLabel => 'Édité';
+  String get systemMessageLabel => 'Message système';
+
+  @override
+  String get editedMessageLabel => 'Modifié';
 
   @override
   String get messageReactionsLabel => 'Réactions aux messages';
@@ -639,4 +642,31 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
   @override
   String get moderationReviewModalDescription =>
       '''Réfléchissez à la façon dont votre commentaire pourrait affecter les autres et assurez-vous de respecter nos directives communautaires.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Enregistrement vocal';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Image';
+
+  @override
+  String get videoAttachmentText => 'Vidéo';
+
+  @override
+  String get pollYouVotedText => 'Vous avez voté';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username a voté';
+
+  @override
+  String get pollYouCreatedText => 'Vous avez créé';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username a créé';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -81,7 +81,10 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   String get messageDeletedText => 'यह संदेश हटा दिया गया है।';
 
   @override
-  String get messageDeletedLabel => 'संदेश हटाये';
+  String get messageDeletedLabel => 'संदेश हटा दिया गया';
+
+  @override
+  String get systemMessageLabel => 'सिस्टम संदेश';
 
   @override
   String get editedMessageLabel => 'संपादित';
@@ -629,5 +632,32 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      '''विचार करें कि आपकी टिप्पणी से दूसरों को कैसा महसूस हो सकता है और सुनिश्चित करें कि आप हमारे सामुदायिक दिशानिर्देशों का पालन करें।''';
+      '''इस बात पर विचार करें कि आपकी टिप्पणी से दूसरों को कैसा महसूस हो सकता है और सुनिश्चित करें कि आप हमारे समुदाय दिशानिर्देशों का पालन करें।''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'ध्वनि रिकॉर्डिंग';
+
+  @override
+  String get audioAttachmentText => 'ऑडियो';
+
+  @override
+  String get imageAttachmentText => 'फोटो';
+
+  @override
+  String get videoAttachmentText => 'वीडियो';
+
+  @override
+  String get pollYouVotedText => 'आपने वोट दिया';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username ने वोट दिया';
+
+  @override
+  String get pollYouCreatedText => 'आपने बनाया';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username ने बनाया';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -88,7 +88,10 @@ class StreamChatLocalizationsIt extends GlobalStreamChatLocalizations {
   String get messageDeletedText => 'Questo messaggio è stato eliminato';
 
   @override
-  String get messageDeletedLabel => 'Messaggio cancellato';
+  String get messageDeletedLabel => 'Messaggio eliminato';
+
+  @override
+  String get systemMessageLabel => 'Messaggio di sistema';
 
   @override
   String get editedMessageLabel => 'Modificato';
@@ -638,5 +641,32 @@ Attenzione: il limite massimo di $limit file è stato superato.
 
   @override
   String get moderationReviewModalDescription =>
-      '''Considera come il tuo commento potrebbe far sentire gli altri e assicurati di seguire le nostre Linee guida della Comunità.''';
+      '''Considera come il tuo commento potrebbe far sentire gli altri e assicurati di seguire le nostre Linee guida della community.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Registrazione vocale';
+
+  @override
+  String get audioAttachmentText => 'Audio';
+
+  @override
+  String get imageAttachmentText => 'Immagine';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'Hai votato';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username ha votato';
+
+  @override
+  String get pollYouCreatedText => 'Hai creato';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username ha creato';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
@@ -84,6 +84,9 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'メッセージ削除';
 
   @override
+  String get systemMessageLabel => 'システムメッセージ';
+
+  @override
   String get editedMessageLabel => '編集済み';
 
   @override
@@ -608,5 +611,32 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      'あなたのコメントが他の人にどのような影響を与えるかを考え、コミュニティガイドラインに従ってください。';
+      '''あなたのコメントが他の人にどのような影響を与えるかを考え、コミュニティガイドラインに従ってください。''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => '音声録音';
+
+  @override
+  String get audioAttachmentText => 'オーディオ';
+
+  @override
+  String get imageAttachmentText => '画像';
+
+  @override
+  String get videoAttachmentText => '動画';
+
+  @override
+  String get pollYouVotedText => '投票しました';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$usernameが投票しました';
+
+  @override
+  String get pollYouCreatedText => '作成しました';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$usernameが作成しました';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
@@ -84,6 +84,9 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => '메시지가 삭제되었습니다';
 
   @override
+  String get systemMessageLabel => '시스템 메시지';
+
+  @override
   String get editedMessageLabel => '편집됨';
 
   @override
@@ -609,5 +612,32 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      '귀하의 댓글이 다른 사람들에게 어떤 느낌을 줄 수 있는지 고려하고 커뮤니티 가이드라인을 준수하십시오.';
+      '''귀하의 댓글이 다른 사람들에게 어떤 영향을 미칠 수 있는지 고려하고 커뮤니티 가이드라인을 준수하세요.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => '음성 녹음';
+
+  @override
+  String get audioAttachmentText => '오디오';
+
+  @override
+  String get imageAttachmentText => '이미지';
+
+  @override
+  String get videoAttachmentText => '비디오';
+
+  @override
+  String get pollYouVotedText => '투표했습니다';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username님이 투표했습니다';
+
+  @override
+  String get pollYouCreatedText => '생성했습니다';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username님이 생성했습니다';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
@@ -85,6 +85,9 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Melding slettet';
 
   @override
+  String get systemMessageLabel => 'Systemmelding';
+
+  @override
   String get editedMessageLabel => 'Redigert';
 
   @override
@@ -619,5 +622,32 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
 
   @override
   String get moderationReviewModalDescription =>
-      '''Tenk på hvordan kommentaren din kan få andre til å føle seg, og sørg for å følge retningslinjene for fellesskapet vårt.''';
+      '''Tenk på hvordan kommentaren din kan få andre til å føle seg og sørg for å følge retningslinjene for fellesskapet.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Taleopptak';
+
+  @override
+  String get audioAttachmentText => 'Lyd';
+
+  @override
+  String get imageAttachmentText => 'Bilde';
+
+  @override
+  String get videoAttachmentText => 'Video';
+
+  @override
+  String get pollYouVotedText => 'Du stemte';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username stemte';
+
+  @override
+  String get pollYouCreatedText => 'Du opprettet';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username opprettet';
 }

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -82,7 +82,10 @@ class StreamChatLocalizationsPt extends GlobalStreamChatLocalizations {
   String get messageDeletedLabel => 'Mensagem excluída';
 
   @override
-  String get editedMessageLabel => 'Editado';
+  String get systemMessageLabel => 'Mensagem do sistema';
+
+  @override
+  String get editedMessageLabel => 'Editada';
 
   @override
   String get messageReactionsLabel => 'Reações às mensagens';
@@ -633,4 +636,31 @@ Não é possível adicionar mais de $limit arquivos de uma vez
   @override
   String get moderationReviewModalDescription =>
       '''Considere como seu comentário pode fazer os outros se sentirem e certifique-se de seguir nossas Diretrizes da Comunidade.''';
+
+  @override
+  String get emptyMessagePreviewText => '';
+
+  @override
+  String get voiceRecordingText => 'Gravação de voz';
+
+  @override
+  String get audioAttachmentText => 'Áudio';
+
+  @override
+  String get imageAttachmentText => 'Imagem';
+
+  @override
+  String get videoAttachmentText => 'Vídeo';
+
+  @override
+  String get pollYouVotedText => 'Você votou';
+
+  @override
+  String pollSomeoneVotedText(String username) => '$username votou';
+
+  @override
+  String get pollYouCreatedText => 'Você criou';
+
+  @override
+  String pollSomeoneCreatedText(String username) => '$username criou';
 }

--- a/packages/stream_chat_localizations/test/translations_test.dart
+++ b/packages/stream_chat_localizations/test/translations_test.dart
@@ -52,6 +52,7 @@ void main() {
       expect(localizations.resultCountText(3), isNotNull);
       expect(localizations.messageDeletedText, isNotNull);
       expect(localizations.messageDeletedLabel, isNotNull);
+      expect(localizations.systemMessageLabel, isNotNull);
       expect(localizations.messageReactionsLabel, isNotNull);
       expect(localizations.emptyChatMessagesText, isNotNull);
       expect(localizations.threadSeparatorText(3), isNotNull);
@@ -295,6 +296,16 @@ void main() {
       expect(localizations.moderatedMessageBlockedText, isNotNull);
       expect(localizations.moderationReviewModalTitle, isNotNull);
       expect(localizations.moderationReviewModalDescription, isNotNull);
+      expect(localizations.emptyMessagePreviewText, isNotNull);
+      expect(localizations.voiceRecordingText, isNotNull);
+      expect(localizations.audioAttachmentText, isNotNull);
+      expect(localizations.imageAttachmentText, isNotNull);
+      expect(localizations.videoAttachmentText, isNotNull);
+      expect(localizations.pollYouVotedText, isNotNull);
+      expect(localizations.pollSomeoneVotedText('TestUser'), isNotNull);
+      expect(localizations.pollYouCreatedText, isNotNull);
+      expect(localizations.pollSomeoneCreatedText('TestUser'), isNotNull);
+      expect(localizations.systemMessageLabel, isNotNull);
     });
   }
 


### PR DESCRIPTION
Resolves: FLU-89

## Description of the pull request

This pull request includes significant changes to the `stream_chat_flutter` package to improve message preview functionality and localization support. The most important changes include refactoring the `StreamMessagePreviewText` class, adding new translation strings, and updating the `ChannelLastMessageText` class.

### Improvements to message preview functionality:
* [`stream_message_preview_text.dart`](diffhunk://#diff-90b9c414677a57502bf85d06926543f0fd1b2b4f88eed488f9855ecdb801fd3cL23-R193): Refactored the `StreamMessagePreviewText` class to improve message preview logic, including handling of mentions, attachments, and polls. Added helper methods `_getPreviewText`, `_pollPreviewText`, and `_previewMessageContextText` to streamline the preview text generation.

### Localization support:
* [`translations.dart`](diffhunk://#diff-e0110e720902554bdae3830f34bb081de51be35668aac961a78bd01ed4fb0cc7R72-R74): Added new translation strings for system messages, empty message previews, voice recordings, and various attachment types. Implemented these new strings in the `DefaultTranslations` class. [[1]](diffhunk://#diff-e0110e720902554bdae3830f34bb081de51be35668aac961a78bd01ed4fb0cc7R72-R74) [[2]](diffhunk://#diff-e0110e720902554bdae3830f34bb081de51be35668aac961a78bd01ed4fb0cc7R511-R537) [[3]](diffhunk://#diff-e0110e720902554bdae3830f34bb081de51be35668aac961a78bd01ed4fb0cc7R626-R628) [[4]](diffhunk://#diff-e0110e720902554bdae3830f34bb081de51be35668aac961a78bd01ed4fb0cc7R1174-R1200)

### Improvements to last message handling:
* [`stream_channel_list_tile.dart`](diffhunk://#diff-95e1e17f8fc5f32bfbf43af58dd382e00e399fbdb76b1e3163a6350ed3aff55aR344): Updated the `ChannelLastMessageText` class to use a customizable predicate for determining the last message. Added a default predicate `_defaultLastMessagePredicate` and an extension method `latest` to handle message selection logic. [[1]](diffhunk://#diff-95e1e17f8fc5f32bfbf43af58dd382e00e399fbdb76b1e3163a6350ed3aff55aR344) [[2]](diffhunk://#diff-95e1e17f8fc5f32bfbf43af58dd382e00e399fbdb76b1e3163a6350ed3aff55aR356-R419)

| Before | After |
|--------|--------|
| <img width="359" alt="Screenshot 2025-04-01 at 12 28 05" src="https://github.com/user-attachments/assets/934d031c-9be0-46b1-a5c3-cccaae8dee3d" /> | <img width="347" alt="Screenshot 2025-04-01 at 14 11 53" src="https://github.com/user-attachments/assets/02b1f1de-8d94-493f-b4fb-a11cd3f4f2d5" /> | 
