### PR TITLE
feat(llc): add support for OwnUser.blockedUserIds

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - Added support for message moderation feature.
 
+- Improved user blocking functionality by updating client state when blocking/unblocking users:
+  - `client.blockUser` now updates `currentUser.blockedUserIds` list with newly blocked user IDs.
+  - `client.unblockUser` now removes the unblocked user ID from `currentUser.blockedUserIds` list.
+  - `client.queryBlockedUsers` now updates `currentUser.blockedUserIds` with the latest blocked users data.
+
 🐞 Fixed
 
 - [[#1964]](https://github.com/GetStream/stream-chat-flutter/issues/1964) Fixes `Channel.membership`

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/client/channel.dart';
 import 'package:stream_chat/src/client/retry_policy.dart';

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1451,6 +1451,68 @@ class StreamChatClient {
         ...options,
       });
 
+  final _userBlockLock = Lock();
+
+  /// Blocks a user with the provided [userId].
+  Future<UserBlockResponse> blockUser(String userId) async {
+    try {
+      final response = await _userBlockLock.synchronized(
+        () => _chatApi.user.blockUser(userId),
+      );
+
+      final blockedUserId = response.blockedUserId;
+      final currentBlockedUserIds = [...?state.currentUser?.blockedUserIds];
+      if (!currentBlockedUserIds.contains(blockedUserId)) {
+        // Add the new blocked user to the blocked user list.
+        state.blockedUserIds = [...currentBlockedUserIds, blockedUserId];
+      }
+
+      return response;
+    } catch (e, stk) {
+      logger.severe('Error blocking user', e, stk);
+      rethrow;
+    }
+  }
+
+  /// Unblocks a previously blocked user with the provided [userId].
+  Future<EmptyResponse> unblockUser(String userId) async {
+    try {
+      final response = await _userBlockLock.synchronized(
+        () => _chatApi.user.unblockUser(userId),
+      );
+
+      final unblockedUserId = userId;
+      final currentBlockedUserIds = [...?state.currentUser?.blockedUserIds];
+      if (currentBlockedUserIds.contains(unblockedUserId)) {
+        // Remove the unblocked user from the blocked user list.
+        state.blockedUserIds = currentBlockedUserIds..remove(unblockedUserId);
+      }
+
+      return response;
+    } catch (e, stk) {
+      logger.severe('Error unblocking user', e, stk);
+      rethrow;
+    }
+  }
+
+  /// Retrieves a list of all users that the current user has blocked.
+  Future<BlockedUsersResponse> queryBlockedUsers() async {
+    try {
+      final response = await _userBlockLock.synchronized(
+        () => _chatApi.user.queryBlockedUsers(),
+      );
+
+      // Update the blocked user IDs with the latest data.
+      final blockedUserIds = response.blocks.map((it) => it.blockedUserId);
+      state.blockedUserIds = [...blockedUserIds.nonNulls];
+
+      return response;
+    } catch (e, stk) {
+      logger.severe('Error querying blocked users', e, stk);
+      rethrow;
+    }
+  }
+
   /// Mutes a user
   Future<EmptyResponse> muteUser(String userId) =>
       _chatApi.moderation.muteUser(userId);
@@ -1458,18 +1520,6 @@ class StreamChatClient {
   /// Unmutes a user
   Future<EmptyResponse> unmuteUser(String userId) =>
       _chatApi.moderation.unmuteUser(userId);
-
-  /// Blocks a user
-  Future<UserBlockResponse> blockUser(String userId) =>
-      _chatApi.user.blockUser(userId);
-
-  /// Unblocks a user
-  Future<EmptyResponse> unblockUser(String userId) =>
-      _chatApi.user.unblockUser(userId);
-
-  /// Requests users with a given query.
-  Future<BlockedUsersResponse> queryBlockedUsers() =>
-      _chatApi.user.queryBlockedUsers();
 
   /// Flag a message
   Future<EmptyResponse> flagMessage(String messageId) =>
@@ -1995,6 +2045,10 @@ class ClientState {
   /// Removes the channel from the cached list of [channels]
   void removeChannel(String channelCid) {
     channels = channels..remove(channelCid);
+  }
+
+  set blockedUserIds(List<String> blockedUserIds) {
+    currentUser = currentUser?.copyWith(blockedUserIds: blockedUserIds);
   }
 
   /// Used internally for optimistic update of unread count

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -2047,6 +2047,7 @@ class ClientState {
     channels = channels..remove(channelCid);
   }
 
+  @visibleForTesting
   set blockedUserIds(List<String> blockedUserIds) {
     currentUser = currentUser?.copyWith(blockedUserIds: blockedUserIds);
   }

--- a/packages/stream_chat/lib/src/core/models/own_user.dart
+++ b/packages/stream_chat/lib/src/core/models/own_user.dart
@@ -17,6 +17,7 @@ class OwnUser extends User {
     this.unreadChannels = 0,
     this.channelMutes = const [],
     this.unreadThreads = 0,
+    this.blockedUserIds = const [],
     required super.id,
     super.role,
     super.name,
@@ -72,6 +73,7 @@ class OwnUser extends User {
     List<ChannelMute>? channelMutes,
     List<Device>? devices,
     List<Mute>? mutes,
+    List<String>? blockedUserIds,
     int? totalUnreadCount,
     int? unreadChannels,
     int? unreadThreads,
@@ -99,6 +101,7 @@ class OwnUser extends User {
         totalUnreadCount: totalUnreadCount ?? this.totalUnreadCount,
         unreadChannels: unreadChannels ?? this.unreadChannels,
         unreadThreads: unreadThreads ?? this.unreadThreads,
+        blockedUserIds: blockedUserIds ?? this.blockedUserIds,
         language: language ?? this.language,
       );
 
@@ -124,6 +127,7 @@ class OwnUser extends User {
       totalUnreadCount: other.totalUnreadCount,
       unreadChannels: other.unreadChannels,
       unreadThreads: other.unreadThreads,
+      blockedUserIds: other.blockedUserIds,
       updatedAt: other.updatedAt,
       language: other.language,
     );
@@ -153,6 +157,10 @@ class OwnUser extends User {
   @JsonKey(includeIfNull: false)
   final int unreadThreads;
 
+  /// List of user ids that are blocked by the user.
+  @JsonKey(includeIfNull: false)
+  final List<String> blockedUserIds;
+
   /// Known top level fields.
   ///
   /// Useful for [Serializer] methods.
@@ -163,6 +171,7 @@ class OwnUser extends User {
     'unread_channels',
     'channel_mutes',
     'unread_threads',
+    'blocked_user_ids',
     ...User.topLevelFields,
   ];
 }

--- a/packages/stream_chat/lib/src/core/models/own_user.g.dart
+++ b/packages/stream_chat/lib/src/core/models/own_user.g.dart
@@ -22,6 +22,10 @@ OwnUser _$OwnUserFromJson(Map<String, dynamic> json) => OwnUser(
               .toList() ??
           const [],
       unreadThreads: (json['unread_threads'] as num?)?.toInt() ?? 0,
+      blockedUserIds: (json['blocked_user_ids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
       id: json['id'] as String,
       role: json['role'] as String?,
       createdAt: json['created_at'] == null

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -2321,9 +2321,7 @@ void main() {
         'blockUser should not duplicate existing blocked user IDs',
         () async {
           const userId = 'blocked-user-id';
-          client.state.currentUser = client.state.currentUser?.copyWith(
-            blockedUserIds: const [userId],
-          );
+          client.state.blockedUserIds = const [userId];
 
           // Verify the user is already in the blocked list
           expect(client.state.currentUser?.blockedUserIds, contains(userId));
@@ -2348,9 +2346,7 @@ void main() {
       test('unblockUser should remove user from blockedUserIds', () async {
         const blockedUserId = 'blocked-user-id';
         const otherBlockedId = 'other-blocked-id';
-        client.state.currentUser = client.state.currentUser?.copyWith(
-          blockedUserIds: const [blockedUserId, otherBlockedId],
-        );
+        client.state.blockedUserIds = const [blockedUserId, otherBlockedId];
 
         // Verify initial state includes both blocked IDs
         expect(
@@ -2384,9 +2380,7 @@ void main() {
         () async {
           const nonBlockedUserId = 'not-in-list';
           const otherBlockedId = 'other-blocked-id';
-          client.state.currentUser = client.state.currentUser?.copyWith(
-            blockedUserIds: const [otherBlockedId],
-          );
+          client.state.blockedUserIds = const [otherBlockedId];
 
           // Verify initial state
           expect(


### PR DESCRIPTION
Resolves: FLU-86

## Description of the pull request
Improves user blocking functionality by updating client state when blocking/unblocking users:
  - `client.blockUser` now updates `currentUser.blockedUserIds` list with newly blocked user IDs.
  - `client.unblockUser` now removes the unblocked user ID from `currentUser.blockedUserIds` list.
  - `client.queryBlockedUsers` now updates `currentUser.blockedUserIds` with the latest blocked users data.