### PR TITLE
fix(ui): remove replacing mentions with id while sending message

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- [[#2150]](https://github.com/GetStream/stream-chat-flutter/issues/2150) Fixed Push notifications
+  for mentions shows user ID instead of Username.
+
 ## 9.7.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -1476,8 +1476,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
       message = await widget.preMessageSending!(message);
     }
 
-    message = message.replaceMentionsWithId();
-
     // If the channel is not up to date, we should reload it before sending
     // the message.
     if (!channel.state!.isUpToDate) {


### PR DESCRIPTION
Resolves: FLU-94, #2150 

## Description of the pull request

Removed `.replaceMentionsWithId()` call during message sending to ensure push notifications display proper usernames when users are mentioned.