### PR TITLE
fix(llc, core, ui): fix mark unread issues

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Improved read event handling in the `Channel` class to properly update unread state information.
+
 ## 9.7.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2033,8 +2033,6 @@ class ChannelClientState {
 
     _listenReadEvents();
 
-    _listenUnreadEvents();
-
     _listenChannelTruncated();
 
     _listenChannelUpdated();
@@ -2788,58 +2786,76 @@ class ChannelClientState {
     return updateMessage(message);
   }
 
-  void _listenUnreadEvents() {
-    if (_channelState.channel?.config.readEvents == false) {
-      return;
-    }
-
-    _subscriptions.add(
-        _channel.on(EventType.notificationMarkUnread).listen((Event event) {
-      if (event.user?.id != _channel._client.state.currentUser!.id) return;
-
-      final readList = <Read>[
-        ..._channelState.read?.where((r) => r.user.id != event.user!.id) ??
-            <Read>[],
-        if (event.lastReadAt != null)
-          Read(
-            user: event.user!,
-            lastRead: event.lastReadAt!,
-            unreadMessages: event.unreadMessages ?? 0,
-            lastReadMessageId: event.lastReadMessageId,
-          )
-      ];
-
-      _channelState = _channelState.copyWith(read: readList);
-    }));
-  }
-
   void _listenReadEvents() {
-    if (_channelState.channel?.config.readEvents == false) {
-      return;
-    }
+    if (_channelState.channel?.config.readEvents == false) return;
 
-    _subscriptions.add(
-      _channel.on(EventType.messageRead, EventType.notificationMarkRead).listen(
-        (event) {
-          final readList = List<Read>.from(_channelState.read ?? []);
-          final userReadIndex =
-              read.indexWhere((r) => r.user.id == event.user!.id);
+    _subscriptions
+      ..add(
+        _channel
+            .on(EventType.messageRead, EventType.notificationMarkRead)
+            .listen(
+          (event) {
+            final user = event.user;
+            if (user == null) return;
 
-          if (userReadIndex != -1) {
-            final userRead = readList.removeAt(userReadIndex);
-            if (userRead.user.id == _channel._client.state.currentUser!.id) {
-              unreadCount = 0;
+            final existingRead = [...?channelState.read];
+            // Return if the user does not have a existing read.
+            if (!existingRead.any((r) => r.user.id == user.id)) return;
+
+            Read? maybeUpdateRead(Read? existingRead) {
+              if (existingRead == null) return null;
+              if (existingRead.user.id == user.id) {
+                return existingRead.copyWith(
+                  user: user,
+                  lastRead: event.createdAt,
+                  unreadMessages: event.unreadMessages,
+                  lastReadMessageId: event.lastReadMessageId,
+                );
+              }
+
+              return existingRead;
             }
-            readList.add(Read(
-              user: event.user!,
-              lastRead: event.createdAt,
-              lastReadMessageId: messages.lastOrNull?.id,
-            ));
-            _channelState = _channelState.copyWith(read: readList);
-          }
-        },
-      ),
-    );
+
+            updateChannelState(
+              channelState.copyWith(
+                read: [...existingRead.map(maybeUpdateRead).nonNulls],
+              ),
+            );
+          },
+        ),
+      )
+      ..add(
+        _channel.on(EventType.notificationMarkUnread).listen(
+          (Event event) {
+            final user = event.user;
+            if (user == null) return;
+
+            final existingRead = [...?channelState.read];
+            // Return if the user does not have a existing read.
+            if (!existingRead.any((r) => r.user.id == user.id)) return;
+
+            Read? maybeUpdateRead(Read? existingRead) {
+              if (existingRead == null) return null;
+              if (existingRead.user.id == user.id) {
+                return existingRead.copyWith(
+                  user: user,
+                  lastRead: event.lastReadAt,
+                  unreadMessages: event.unreadMessages,
+                  lastReadMessageId: event.lastReadMessageId,
+                );
+              }
+
+              return existingRead;
+            }
+
+            updateChannelState(
+              channelState.copyWith(
+                read: [...existingRead.map(maybeUpdateRead).nonNulls],
+              ),
+            );
+          },
+        ),
+      );
   }
 
   /// Channel message list.

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2805,7 +2805,7 @@ class ChannelClientState {
             Read? maybeUpdateRead(Read? existingRead) {
               if (existingRead == null) return null;
               if (existingRead.user.id == user.id) {
-                return existingRead.copyWith(
+                return Read(
                   user: user,
                   lastRead: event.createdAt,
                   unreadMessages: event.unreadMessages,
@@ -2837,9 +2837,9 @@ class ChannelClientState {
             Read? maybeUpdateRead(Read? existingRead) {
               if (existingRead == null) return null;
               if (existingRead.user.id == user.id) {
-                return existingRead.copyWith(
+                return Read(
                   user: user,
-                  lastRead: event.lastReadAt,
+                  lastRead: event.lastReadAt!,
                   unreadMessages: event.unreadMessages,
                   lastReadMessageId: event.lastReadMessageId,
                 );

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -35,6 +35,9 @@ class Event {
     this.thread,
     this.unreadThreadMessages,
     this.unreadThreads,
+    this.lastReadAt,
+    this.unreadMessages,
+    this.lastReadMessageId,
     this.extraData = const {},
     this.isLocal = true,
   }) : createdAt = createdAt?.toUtc() ?? DateTime.now().toUtc();
@@ -131,26 +134,17 @@ class Event {
   /// The number of unread threads.
   final int? unreadThreads;
 
-  /// Map of custom channel extraData
-  final Map<String, Object?> extraData;
-
   /// Create date of the last read message (notification.mark_unread)
-  @JsonKey(includeToJson: false, includeFromJson: false)
-  DateTime? get lastReadAt {
-    if (extraData.containsKey('last_read_at')) {
-      return DateTime.parse(extraData['last_read_at']! as String);
-    }
-
-    return null;
-  }
+  final DateTime? lastReadAt;
 
   /// The number of unread messages (notification.mark_unread)
-  @JsonKey(includeToJson: false, includeFromJson: false)
-  int? get unreadMessages => extraData['unread_messages'] as int?;
+  final int? unreadMessages;
 
   /// The id of the last read message (notification.mark_read)
-  @JsonKey(includeToJson: false, includeFromJson: false)
-  String? get lastReadMessageId => extraData['last_read_message_id'] as String?;
+  final String? lastReadMessageId;
+
+  /// Map of custom channel extraData
+  final Map<String, Object?> extraData;
 
   /// Known top level fields.
   /// Useful for [Serializer] methods.
@@ -182,6 +176,9 @@ class Event {
     'thread',
     'unread_thread_messages',
     'unread_threads',
+    'last_read_at',
+    'unread_messages',
+    'last_read_message_id',
   ];
 
   /// Serialize to json
@@ -217,6 +214,9 @@ class Event {
     Thread? thread,
     int? unreadThreadMessages,
     int? unreadThreads,
+    DateTime? lastReadAt,
+    int? unreadMessages,
+    String? lastReadMessageId,
     Map<String, Object?>? extraData,
   }) =>
       Event(
@@ -246,6 +246,9 @@ class Event {
         thread: thread ?? this.thread,
         unreadThreadMessages: unreadThreadMessages ?? this.unreadThreadMessages,
         unreadThreads: unreadThreads ?? this.unreadThreads,
+        lastReadAt: lastReadAt ?? this.lastReadAt,
+        unreadMessages: unreadMessages ?? this.unreadMessages,
+        lastReadMessageId: lastReadMessageId ?? this.lastReadMessageId,
         isLocal: isLocal,
         extraData: extraData ?? this.extraData,
       );

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -56,6 +56,11 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
           : Thread.fromJson(json['thread'] as Map<String, dynamic>),
       unreadThreadMessages: (json['unread_thread_messages'] as num?)?.toInt(),
       unreadThreads: (json['unread_threads'] as num?)?.toInt(),
+      lastReadAt: json['last_read_at'] == null
+          ? null
+          : DateTime.parse(json['last_read_at'] as String),
+      unreadMessages: (json['unread_messages'] as num?)?.toInt(),
+      lastReadMessageId: json['last_read_message_id'] as String?,
       extraData: json['extra_data'] as Map<String, dynamic>? ?? const {},
       isLocal: json['is_local'] as bool? ?? false,
     );
@@ -89,6 +94,9 @@ Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
       'thread': instance.thread?.toJson(),
       'unread_thread_messages': instance.unreadThreadMessages,
       'unread_threads': instance.unreadThreads,
+      'last_read_at': instance.lastReadAt?.toIso8601String(),
+      'unread_messages': instance.unreadMessages,
+      'last_read_message_id': instance.lastReadMessageId,
       'extra_data': instance.extraData,
     };
 

--- a/packages/stream_chat/lib/src/core/models/read.dart
+++ b/packages/stream_chat/lib/src/core/models/read.dart
@@ -12,8 +12,8 @@ class Read extends Equatable {
     required this.lastRead,
     required this.user,
     this.lastReadMessageId,
-    this.unreadMessages = 0,
-  });
+    int? unreadMessages,
+  }) : unreadMessages = unreadMessages ?? 0;
 
   /// Create a new instance from a json
   factory Read.fromJson(Map<String, dynamic> json) => _$ReadFromJson(json);

--- a/packages/stream_chat/test/src/core/models/event_test.dart
+++ b/packages/stream_chat/test/src/core/models/event_test.dart
@@ -19,6 +19,9 @@ void main() {
       expect(event.unreadThreadMessages, 2);
       expect(event.unreadThreads, 3);
       expect(event.channelLastMessageAt, isA<DateTime>());
+      expect(event.lastReadAt, null);
+      expect(event.unreadMessages, null);
+      expect(event.lastReadMessageId, null);
     });
 
     test('should serialize to json correctly', () {
@@ -38,6 +41,9 @@ void main() {
         unreadThreadMessages: 2,
         unreadThreads: 3,
         channelLastMessageAt: DateTime.parse('2019-03-27T17:40:17.155892Z'),
+        lastReadAt: DateTime.parse('2020-02-10T10:00:00.000Z'),
+        unreadMessages: 5,
+        lastReadMessageId: 'last-read-message-id',
       );
 
       expect(
@@ -69,6 +75,9 @@ void main() {
           'unread_thread_messages': 2,
           'unread_threads': 3,
           'channel_last_message_at': '2019-03-27T17:40:17.155892Z',
+          'last_read_at': '2020-02-10T10:00:00.000Z',
+          'unread_messages': 5,
+          'last_read_message_id': 'last-read-message-id',
         },
       );
     });
@@ -86,6 +95,9 @@ void main() {
       expect(newEvent.unreadThreadMessages, 2);
       expect(newEvent.unreadThreads, 3);
       expect(newEvent.channelLastMessageAt, isA<DateTime>());
+      expect(newEvent.lastReadAt, null);
+      expect(newEvent.unreadMessages, null);
+      expect(newEvent.lastReadMessageId, null);
 
       newEvent = event.copyWith(
         type: 'test',
@@ -99,6 +111,9 @@ void main() {
         unreadThreadMessages: 6,
         unreadThreads: 7,
         channelLastMessageAt: DateTime.parse('2020-01-29T03:22:47.636130Z'),
+        lastReadAt: DateTime.parse('2020-02-10T10:00:00.000000Z'),
+        unreadMessages: 5,
+        lastReadMessageId: 'last-read-message-id',
       );
 
       expect(newEvent.channelType, 'testtype');
@@ -115,6 +130,12 @@ void main() {
         newEvent.channelLastMessageAt,
         DateTime.parse('2020-01-29T03:22:47.636130Z'),
       );
+      expect(
+        newEvent.lastReadAt,
+        DateTime.parse('2020-02-10T10:00:00.000000Z'),
+      );
+      expect(newEvent.unreadMessages, 5);
+      expect(newEvent.lastReadMessageId, 'last-read-message-id');
     });
   });
 }

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 🐞 Fixed
 
+- [[#2184]](https://github.com/GetStream/stream-chat-flutter/issues/2184) Fixed messages not being
+  marked as read when scrolled to the bottom.
+- [[#2187]](https://github.com/GetStream/stream-chat-flutter/issues/2187) Fixed `MessageListView`
+  scrolling back up after reaching bottom when unread indicator or scroll to bottom button is
+  tapped.
+- [[#2085]](https://github.com/GetStream/stream-chat-flutter/issues/2085) Fixed handling of read
+  events in the Channel class.
 - [[#2150]](https://github.com/GetStream/stream-chat-flutter/issues/2150) Fixed Push notifications
   for mentions shows user ID instead of Username.
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -88,7 +88,7 @@ class StreamMessageListView extends StatefulWidget {
     this.scrollToBottomBuilder,
     this.showUnreadIndicator = true,
     this.unreadIndicatorBuilder,
-    this.markReadWhenAtTheBottom = false,
+    this.markReadWhenAtTheBottom = true,
     this.messageBuilder,
     this.parentMessageBuilder,
     this.parentMessage,

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -230,11 +230,7 @@ class StreamMessageListView extends StatefulWidget {
   ///   },
   /// ),
   /// ```
-  final Widget Function(
-    int unreadCount,
-    Future<void> Function(String) scrollToUnreadDefaultTapAction,
-    Future<void> Function() dismissIndicatorDefaultTapAction,
-  )? unreadIndicatorBuilder;
+  final UnreadIndicatorBuilder? unreadIndicatorBuilder;
 
   /// If true will mark channel as read when the user scrolls to the bottom of the list
   final bool markReadWhenAtTheBottom;

--- a/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
@@ -29,18 +29,13 @@ int getInitialIndex(
     if (initialMessageIndex != -1) return initialMessageIndex + 2;
   }
 
-  // Otherwise, check if the channel is unread and return the last read
-  // message index.
-  if (channel.state case final state? when state.unreadCount > 0) {
-    final read = state.currentUserRead;
+  // Otherwise, return the first unread message index if available.
+  if (channelState.getFirstUnreadMessage() case final firstUnreadMessage?) {
+    final firstUnreadMessageIndex = messages.indexWhere(
+      (it) => it.id == firstUnreadMessage.id,
+    );
 
-    if (read?.lastReadMessageId case final lastReadMessageId?) {
-      final lastReadMessageIndex = messages.indexWhere(
-        (it) => it.id == lastReadMessageId,
-      );
-
-      if (lastReadMessageIndex != -1) return lastReadMessageIndex + 2;
-    }
+    if (firstUnreadMessageIndex != -1) return firstUnreadMessageIndex + 2;
   }
 
   return 0;

--- a/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
@@ -6,15 +6,33 @@ import 'package:stream_chat_flutter/src/utils/extensions.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 import 'package:svg_icon_widget/svg_icon_widget.dart';
 
+/// Function signature for handling the dismiss action on the unread indicator.
 typedef OnUnreadIndicatorDismissTap = Future<void> Function();
+
+/// Function signature for handling taps on the unread indicator.
+/// [lastReadMessageId] is the ID of the last read message.
 typedef OnUnreadIndicatorTap = Future<void> Function(String lastReadMessageId);
+
+/// Function signature for building a custom unread indicator.
+///
+/// [unreadCount] is the number of unread messages.
+/// [onTap] is called when the indicator is tapped.
+/// [onDismissTap] is called when the dismiss action is triggered.
 typedef UnreadIndicatorBuilder = Widget Function(
   int unreadCount,
   OnUnreadIndicatorTap onTap,
   OnUnreadIndicatorDismissTap onDismissTap,
 );
 
+/// {@template unreadIndicatorButton}
+/// A button that displays the number of unread messages in a channel.
+///
+/// This widget listens to the current user's read state and shows
+/// an indicator when there are unread messages. Users can tap on the
+/// indicator to navigate to the oldest unread message or dismiss it.
+/// {@endtemplate}
 class UnreadIndicatorButton extends StatelessWidget {
+  /// {@macro unreadIndicatorButton}
   const UnreadIndicatorButton({
     super.key,
     required this.onTap,
@@ -22,10 +40,19 @@ class UnreadIndicatorButton extends StatelessWidget {
     this.unreadIndicatorBuilder,
   });
 
+  /// Callback triggered when the indicator is tapped.
+  ///
+  /// This is typically used to navigate to the oldest unread message.
   final OnUnreadIndicatorTap onTap;
 
+  /// Callback triggered when the dismiss button is tapped.
+  ///
+  /// This is typically used to mark all messages as read.
   final OnUnreadIndicatorDismissTap onDismissTap;
 
+  /// Optional builder for customizing the appearance of the unread indicator.
+  ///
+  /// If not provided, a default indicator will be built.
   final UnreadIndicatorBuilder? unreadIndicatorBuilder;
 
   @override

--- a/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/icons/stream_svg_icon.dart';
+import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
+import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
+import 'package:stream_chat_flutter/src/utils/extensions.dart';
+import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
+import 'package:svg_icon_widget/svg_icon_widget.dart';
+
+typedef OnUnreadIndicatorDismissTap = Future<void> Function();
+typedef OnUnreadIndicatorTap = Future<void> Function(String lastReadMessageId);
+typedef UnreadIndicatorBuilder = Widget Function(
+  int unreadCount,
+  OnUnreadIndicatorTap onTap,
+  OnUnreadIndicatorDismissTap onDismissTap,
+);
+
+class UnreadIndicatorButton extends StatelessWidget {
+  const UnreadIndicatorButton({
+    super.key,
+    required this.onTap,
+    required this.onDismissTap,
+    this.unreadIndicatorBuilder,
+  });
+
+  final OnUnreadIndicatorTap onTap;
+
+  final OnUnreadIndicatorDismissTap onDismissTap;
+
+  final UnreadIndicatorBuilder? unreadIndicatorBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final channel = StreamChannel.of(context).channel;
+    if (channel.state == null) return const Empty();
+
+    return BetterStreamBuilder(
+      initialData: channel.state!.currentUserRead,
+      stream: channel.state!.currentUserReadStream,
+      builder: (context, currentUserRead) {
+        final unreadCount = currentUserRead.unreadMessages;
+        if (unreadCount <= 0) return const Empty();
+
+        if (unreadIndicatorBuilder case final builder?) {
+          return builder(unreadCount, onTap, onDismissTap);
+        }
+
+        final theme = StreamChatTheme.of(context);
+        final textTheme = theme.textTheme;
+        final colorTheme = theme.colorTheme;
+
+        return Material(
+          elevation: 4,
+          clipBehavior: Clip.antiAlias,
+          color: colorTheme.textLowEmphasis,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: InkWell(
+            onTap: switch (currentUserRead.lastReadMessageId) {
+              final messageId? => () => onTap(messageId),
+              _ => null,
+            },
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 2, 8, 2),
+              child: Row(
+                children: [
+                  Text(
+                    context.translations.unreadCountIndicatorLabel(
+                      unreadCount: unreadCount,
+                    ),
+                    style: textTheme.body.copyWith(color: Colors.white),
+                  ),
+                  const SizedBox(width: 12),
+                  IconButton(
+                    iconSize: 24,
+                    icon: const SvgIcon(StreamSvgIcons.close),
+                    padding: const EdgeInsets.all(4),
+                    style: IconButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      minimumSize: const Size.square(24),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    onPressed: onDismissTap,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/unread_indicator_button.dart
@@ -11,7 +11,7 @@ typedef OnUnreadIndicatorDismissTap = Future<void> Function();
 
 /// Function signature for handling taps on the unread indicator.
 /// [lastReadMessageId] is the ID of the last read message.
-typedef OnUnreadIndicatorTap = Future<void> Function(String lastReadMessageId);
+typedef OnUnreadIndicatorTap = Future<void> Function(String? lastReadMessageId);
 
 /// Function signature for building a custom unread indicator.
 ///
@@ -83,10 +83,7 @@ class UnreadIndicatorButton extends StatelessWidget {
             borderRadius: BorderRadius.circular(18),
           ),
           child: InkWell(
-            onTap: switch (currentUserRead.lastReadMessageId) {
-              final messageId? => () => onTap(messageId),
-              _ => null,
-            },
+            onTap: () => onTap(currentUserRead.lastReadMessageId),
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 2, 8, 2),
               child: Row(

--- a/packages/stream_chat_flutter/lib/src/utils/extensions.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/extensions.dart
@@ -571,6 +571,7 @@ extension MessageListX on Iterable<Message> {
   ///
   /// The last unread message is the last message in the list that is not
   /// sent by the current user and is sent after the last read message.
+  @Deprecated("Use 'StreamChannel.getFirstUnreadMessage' instead.")
   Message? lastUnreadMessage(Read? userRead) {
     if (isEmpty || userRead == null) return null;
 

--- a/packages/stream_chat_flutter/test/src/message_list_view/message_list_view_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/message_list_view_test.dart
@@ -43,6 +43,9 @@ void main() {
     when(() => channelClientState.membersStream)
         .thenAnswer((_) => const Stream.empty());
     when(() => channelClientState.members).thenReturn([]);
+    when(() => channelClientState.currentUserRead).thenReturn(null);
+    when(() => channelClientState.currentUserReadStream)
+        .thenAnswer((_) => const Stream.empty());
   });
 
   // https://github.com/GetStream/stream-chat-flutter/issues/674
@@ -224,7 +227,7 @@ void main() {
                 channel: channel,
                 child: const StreamMessageListView(
                   key: nonEmptyWidgetKey,
-                  initialScrollIndex: 5,
+                  initialScrollIndex: 7,
                 ),
               ),
             ),

--- a/packages/stream_chat_flutter/test/src/utils/extension_test.dart
+++ b/packages/stream_chat_flutter/test/src/utils/extension_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- Added `StreamChannelState.getFirstUnreadMessage` to get the first unread message in the channel.
+
 ## 9.7.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -501,9 +501,7 @@ class StreamChannelState extends State<StreamChannel> {
     // Otherwise, we should load the channel at the first unread
     // message if available.
     if (channel.state case final state? when state.unreadCount > 0) {
-      final currentUserRead = state.read.firstWhereOrNull(
-        (it) => it.user.id == channel.client.state.currentUser?.id,
-      );
+      final currentUserRead = state.currentUserRead;
 
       // Skip if we don't have read state for the current user.
       if (currentUserRead == null) return;

--- a/sample_app/lib/pages/thread_page.dart
+++ b/sample_app/lib/pages/thread_page.dart
@@ -55,7 +55,6 @@ class _ThreadPageState extends State<ThreadPage> {
               parentMessage: widget.parent,
               initialScrollIndex: widget.initialScrollIndex,
               initialAlignment: widget.initialAlignment,
-              markReadWhenAtTheBottom: true,
               //onMessageSwiped: _reply,
               messageFilter: defaultFilter,
               showScrollToBottom: false,


### PR DESCRIPTION
## Description of the pull request

This PR adds unread message indicators and fixes several read state tracking bugs. Key changes:

- Added `UnreadIndicatorButton` widget to display unread message counts
- Enhanced `Event` model with `unreadMessages` and `lastReadMessageId` fields
- Fixed message list scroll behavior when navigating to unread messages
- Improved read event handling in the Channel class

### Fixed Issues
- #2184 - Messages not marked as read when scrolled to bottom
- #2187 - StreamMessageListView scrolls back up after reaching bottom
- #2085 - Read state not properly updated with messageRead events