### PR TITLE
fix(ui): AttachmentPickerType.poll should respect channel.config.poll

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -11,6 +11,8 @@
   events in the Channel class.
 - [[#2150]](https://github.com/GetStream/stream-chat-flutter/issues/2150) Fixed Push notifications
   for mentions shows user ID instead of Username.
+- [[#2203]](https://github.com/GetStream/stream-chat-flutter/issues/2203) Fixed StreamMessageInput
+  shows Poll option even if polls are disabled in channel config.
 
 ## 9.7.0
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -969,7 +969,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
         if (it != AttachmentPickerType.poll) return false;
         if (_effectiveController.message.parentId != null) return true;
         final channel = StreamChannel.of(context).channel;
-        if (channel.canSendPoll) return false;
+        if (channel.config?.polls == true && channel.canSendPoll) return false;
 
         return true;
       });


### PR DESCRIPTION
Fixes: #2203

## Description of the pull request

Bug fix:

* [`packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart`](diffhunk://#diff-bae4e8bdf40b464850693cbdf2973ec45dedbc41a5e55f1cda0f4bde183b9df3L972-R972): Modified the condition to check if polls are enabled in the channel configuration before showing the poll option in `StreamMessageInput`.