### PR TITLE
fix(persistence): improve pagination handling by clamping offset

### DIFF
--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+- Fixed an issue in the `getChannelStates` method where `paginationParams.offset` greater than the
+  available channel count would cause an exception. The method now properly handles this edge case.
+
 ## 9.9.0
 
 - Added support for `User.teamsRole` field.

--- a/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
+++ b/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
@@ -281,13 +281,15 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
       channelStates.sort(channelStateSort.compare);
     }
 
-    final offset = paginationParams?.offset;
-    if (offset != null && offset > 0 && channelStates.isNotEmpty) {
-      channelStates.removeRange(0, offset);
+    // Apply offset
+    if (paginationParams?.offset case final paginationOffset?) {
+      final clampedOffset = paginationOffset.clamp(0, channelStates.length);
+      channelStates.removeRange(0, clampedOffset);
     }
 
-    if (paginationParams?.limit != null) {
-      return channelStates.take(paginationParams!.limit).toList();
+    // Apply limit
+    if (paginationParams?.limit case final paginationLimit?) {
+      return channelStates.take(paginationLimit).toList();
     }
 
     return channelStates;


### PR DESCRIPTION
# Submit a pull request
Github Issue: #2034 

## Description of the pull request
This PR fixes a case in `persistence.getChannelStates` method where the pagination.offset can be greater than the `channelStates.length` which results in an exception. The fix now clamps the offset before applying it to the channelStates.