### PR TITLE
fix(core): Fallback to loading channel at last read date when loadChannelAtMessage fails

### DIFF
--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Upcoming
 
+🐞 Fixed
+
+- Fixed an issue with `StreamChannel` where loading channel at `lastReadMessageId` might fail
+  if the channel exceeds the member threshold. This is now handled gracefully by falling back to loading
+  the channel at the `lastRead` date.
+
 🔄 Changed
 
 - Updated `freezed_annotation` dependency to `">=2.4.1 <4.0.0"`.

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -508,7 +508,16 @@ class StreamChannelState extends State<StreamChannel> {
 
       // Load the channel at the last read message if available.
       if (currentUserRead.lastReadMessageId case final lastReadMessageId?) {
-        return loadChannelAtMessage(lastReadMessageId);
+        try {
+          return await loadChannelAtMessage(lastReadMessageId);
+        } catch (e) {
+          // If the loadChannelAtMessage for any reason fails, we fallback to
+          // loading the channel at the last read date.
+          //
+          // One example of this is when the channel becomes too large and
+          // exceeds a certain threshold (I believe it's a 1000 members) it
+          // can't update the readstate anymore for each individual member.
+        }
       }
 
       // Otherwise, load the channel at the last read date.


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Zendesk: [65188](https://getstream.zendesk.com/agent/tickets/65188)

## Description of the pull request

This pull request addresses a bug in the `StreamChannel` component which now ensures that loading a channel at `lastReadMessageId` now gracefully handles situations where the channel exceeds the member threshold by falling back to loading at the `lastRead` date.