### PR TITLE
fix(samples): mark ITSAppUsesNonExemptEncryption to false

### DIFF
--- a/sample_app/ios/Runner/Info.plist
+++ b/sample_app/ios/Runner/Info.plist
@@ -70,5 +70,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description of the pull request

Added the `ITSAppUsesNonExemptEncryption` key with a value of `false`, indicating that the app does not use non-exempt encryption.

This is needed otherwise, AppStore complains about `Missing Compliance status in TestFlight`.