### PR TITLE
chore(ui): bump just_audio from 0.9.46 to 0.10.2

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -59,7 +59,7 @@ command:
       jiffy: ^6.2.1
       jose: ^0.3.4
       json_annotation: ^4.9.0
-      just_audio: ^0.9.38
+      just_audio: ">=0.9.38 <0.11.0"
       logging: ^1.2.0
       lottie: ^3.1.2
       media_kit: ^1.1.10+1

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Updated `just_audio` dependency to `">=0.9.38 <0.11.0"`.
+
 ## 9.10.0
 
 🔄 Changed

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   image_picker: ^1.1.2
   image_size_getter: ^2.3.0
   jiffy: ^6.2.1
-  just_audio: ^0.9.38
+  just_audio: ">=0.9.38 <0.11.0"
   lottie: ^3.1.2
   media_kit: ^1.1.10+1
   media_kit_video: ^1.2.4


### PR DESCRIPTION
## Description of the pull request

This pull request bumps dependencies for the following packages.

### Dependency Updates:
* Updated `just_audio` to ">=0.9.38 <0.11.0"` in `melos.yaml` and `pubspec.yaml` for stream_chat_flutter.