### PR TITLE
fix(ui): fix MessageInput to use with non-initialized channel

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+🐞 Fixed
+
+- Fixed `StreamMessageInput` throwing exception when a non-initialized `Channel` is used.
+
 🔄 Changed
 
 - Updated `just_audio` dependency to `">=0.9.38 <0.11.0"`.

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -636,20 +636,21 @@ class StreamMessageInputState extends State<StreamMessageInput>
     }
 
     final channel = StreamChannel.of(context).channel;
-    final messageInput = BetterStreamBuilder(
-      stream: channel.ownCapabilitiesStream.map(canSendOrUpdateMessage),
-      initialData: canSendOrUpdateMessage(channel.ownCapabilities),
-      builder: (context, enabled) {
-        // Allow the user to send messages if the user has the permission to
-        // send messages or if the user is editing a message.
-        if (enabled) {
-          return _buildAutocompleteMessageInput(context);
-        }
+    final messageInput = switch (_buildAutocompleteMessageInput(context)) {
+      final messageInput when channel.state != null => BetterStreamBuilder(
+          stream: channel.ownCapabilitiesStream.map(canSendOrUpdateMessage),
+          initialData: canSendOrUpdateMessage(channel.ownCapabilities),
+          builder: (context, enabled) {
+            // Allow the user to send messages if the user has the permission to
+            // send messages or if the user is editing a message.
+            if (enabled) return messageInput;
 
-        // Otherwise, show the no permission message.
-        return _buildNoPermissionMessage(context);
-      },
-    );
+            // Otherwise, show the no permission message.
+            return _buildNoPermissionMessage(context);
+          },
+        ),
+      final messageInput => messageInput,
+    };
 
     final shadow = widget.shadow ?? _messageInputTheme.shadow;
     final elevation = widget.elevation ?? _messageInputTheme.elevation;


### PR DESCRIPTION
## Description of the pull request

**Fixed `StreamMessageInput` exception**: Updated the `StreamMessageInput` widget to handle cases where the `Channel` is not initialized. This change introduces a conditional logic using a `switch` statement to ensure the widget behaves correctly even when `channel.state` is `null`. (`packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart`)