### PR TITLE
fix(llc): null check on websocket connection

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Deprecated `message.reactionCounts`, `message.reactionScores` in favor of
   `message.reactionGroups`.
 
+🐞 Fixed
+- `Null check operator used on a null value` in Websocket connect.
+
 ## 9.10.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -210,7 +210,7 @@ class WebSocket with TimerHelper {
   Future<Event> connect(
     User user, {
     bool includeUserDetails = false,
-  }) async {
+  }) {
     if (_connectRequestInProgress) {
       throw const StreamWebSocketError('''
         You've called connect twice,
@@ -222,8 +222,17 @@ class WebSocket with TimerHelper {
 
     _user = user;
     _connectionStatus = ConnectionStatus.connecting;
+
     connectionCompleter = Completer<Event>();
 
+    _setupConnection(includeUserDetails: includeUserDetails);
+
+    return connectionCompleter!.future;
+  }
+
+  Future<void> _setupConnection({
+    required bool includeUserDetails,
+  }) async {
     try {
       final uri = await _buildUri(
         includeUserDetails: includeUserDetails,
@@ -233,8 +242,6 @@ class WebSocket with TimerHelper {
     } catch (e, stk) {
       _onConnectionError(e, stk);
     }
-
-    return connectionCompleter!.future;
   }
 
   int _reconnectAttempt = 0;


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: fixes FLU-142
<!--Optional to add github issue which is solved by this PR-->
Github Issue: fixes #2218

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
We have a null check operator on `connectionCompleter`. This can only be `null` if there is a disconnect while fetching a token. Now we return the connectionCompleter future before we go async, so this should never happen anymore.

We didn't reproduce it, so it's also hard to test.

