### PR TITLE
feat(repo): bump min flutter version to 3.29.3

### DIFF
--- a/.github/workflows/legacy_version_analyze.yml
+++ b/.github/workflows/legacy_version_analyze.yml
@@ -3,7 +3,7 @@ name: legacy_version_analyze
 env:
   # Note: The versions below should be manually updated after a new stable
   # version comes out.
-  flutter_version: "3.27.4"
+  flutter_version: "3.29.3"
 
 on:
   push:

--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -95,9 +95,6 @@ jobs:
           channel: stable
           cache: true
           cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
-      # This step is needed due to https://github.com/actions/runner-images/issues/11279
-      - name: Install SQLite3
-        run: sudo apt-get update && sudo apt-get install -y sqlite3 libsqlite3-dev
       - name: "Install Tools"
         run: |
           flutter pub global activate melos

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,9 +18,9 @@ command:
   bootstrap:
     # Dart and Flutter environment used in the project.
     environment:
-      sdk: ^3.6.2
+      sdk: ^3.7.2
       # We are not using carat '^' syntax here because flutter don't follow semantic versioning.
-      flutter: ">=3.27.4"
+      flutter: ">=3.29.3"
 
     # List of all the dependencies used in the project.
     dependencies:

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Deprecated `message.reactionCounts`, `message.reactionScores` in favor of
   `message.reactionGroups`.
+- Updated minimum Flutter version to `3.29.3` for the SDK.
 
 🐞 Fixed
 - `Null check operator used on a null value` in Websocket connect.

--- a/packages/stream_chat/example/pubspec.yaml
+++ b/packages/stream_chat/example/pubspec.yaml
@@ -17,8 +17,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -18,7 +18,7 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
+  sdk: ^3.7.2
 
 dependencies:
   async: ^2.11.0

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -7,6 +7,7 @@
 🔄 Changed
 
 - Updated `just_audio` dependency to `">=0.9.38 <0.11.0"`.
+- Updated minimum Flutter version to `3.29.3` for the SDK.
 
 ## 9.10.0
 

--- a/packages/stream_chat_flutter/example/pubspec.yaml
+++ b/packages/stream_chat_flutter/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   collection: ^1.17.2

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   cached_network_image: ^3.3.1

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Updated minimum Flutter version to `3.29.3` for the SDK.
+
 ## 9.10.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/example/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_flutter_core/pubspec.yaml
+++ b/packages/stream_chat_flutter_core/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   collection: ^1.17.2

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Updated minimum Flutter version to `3.29.3` for the SDK.
+
 ## 9.10.0
 
 - Updated `stream_chat_flutter` dependency to [`9.10.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_localizations/example/pubspec.yaml
+++ b/packages/stream_chat_localizations/example/pubspec.yaml
@@ -17,8 +17,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_localizations/pubspec.yaml
+++ b/packages/stream_chat_localizations/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   flutter:

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 - Added support for `Message.reactionGroups` field.
+- Updated minimum Flutter version to `3.29.3` for the SDK.
 
 ## 9.10.0
 

--- a/packages/stream_chat_persistence/example/pubspec.yaml
+++ b/packages/stream_chat_persistence/example/pubspec.yaml
@@ -16,8 +16,8 @@ version: 1.0.0+1
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/stream_chat_persistence/pubspec.yaml
+++ b/packages/stream_chat_persistence/pubspec.yaml
@@ -18,8 +18,8 @@ issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   drift: ^2.22.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "13c1e6c6fd460522ea840abec3f677cc226f5fec7872c04ad7b425517ccf54f7"
+      sha256: "904ae5bb474d32c38fb9482e2d925d5454cda04ddd0e55d2e6826bc72f6ba8c0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.4"
+    version: "7.4.5"
   ansi_styles:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_style
-      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   file:
     dependency: transitive
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mustache_template:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      sha256: "44b4226c0afd4bc3b7c7e67d44c4801abd97103cf0c84609e2654b664ca2798c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.4"
   prompts:
     dependency: transitive
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -426,4 +426,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.6.2 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat_flutter_workspace
 
 environment:
-  sdk: ^3.6.2
+  sdk: ^3.7.2
 
 dev_dependencies:
   code_builder: ^4.10.1

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -16,8 +16,8 @@ version: 2.2.0
 #   2. Add it to the melos.yaml file for future updates.
 
 environment:
-  sdk: ^3.6.2
-  flutter: ">=3.27.4"
+  sdk: ^3.7.2
+  flutter: ">=3.29.3"
 
 dependencies:
   collection: ^1.17.2


### PR DESCRIPTION
## Description of the pull request

This pull request updates the Flutter SDK and Dart SDK versions across multiple files and removes an unnecessary installation step in a GitHub Actions workflow. These changes ensure compatibility with the latest Flutter and Dart versions while simplifying the CI/CD pipeline.

### Flutter and Dart SDK Updates:

* Updated the Flutter version to `3.29.3` and Dart SDK version to `^3.7.2` in various `pubspec.yaml` files across the project, including `stream_chat`, `stream_chat_flutter`, `stream_chat_flutter_core`, `stream_chat_localizations`, `stream_chat_persistence`, and the `sample_app`. This change ensures all packages use the latest stable versions. [[1]](diffhunk://#diff-10a3147dc1670d23bd86175bc11c1042ed66df960cf4dac4ad96da1b21a6e746L20-R21) [[2]](diffhunk://#diff-8ab968cd5852b8b6c169b8b2d49cea09bd3eeaa20535409dde04e8783bd4ff5cL19-R20) [[3]](diffhunk://#diff-a26f7a0faa7001cb2b7b5221fa49ebf24a5d3c342bd9e35e3bd208e0a65c3a15L19-R20) [[4]](diffhunk://#diff-31fefc7637fa878cf5cc180a05bf09940a192ddd00e57eede5b3841e57381fd4L20-R21) [[5]](diffhunk://#diff-0d1f7872bbee88319b3bdea5bafad1d3232376b7aa2236cc015b86f31796b11cL19-R20) [[6]](diffhunk://#diff-944d7c04e9b7ad57f07eef65605c29a1e02c1a4b00d35a3c98a60304090169abL19-R20) [[7]](diffhunk://#diff-8b86258fc5960ab4af70b2ee5965b39ecf7a4acf12095e4855c9a8be96535e69L21-R21) [[8]](diffhunk://#diff-ba3ea9fd951021c430b421b6f048d5f9d6a613365577c29e084fe8e1bf4bc74bL21-R22) [[9]](diffhunk://#diff-9568b2e80ec2ab1e333f7877961b083841f641b5e376711d7180ac133f37257eL21-R22) [[10]](diffhunk://#diff-fafd1d079a5005786b515eee4f937fe3d96e6dd92cc38884351a2b5feea42af0L21-R22) [[11]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4)

* Updated the Flutter version in the `melos.yaml` file to `>=3.29.3` and Dart SDK version to `^3.7.2` for consistency across the project.

* Updated the Flutter version in `.github/workflows/legacy_version_analyze.yml` to `3.29.3` for CI compatibility.

### CI Workflow Simplification:

* Removed the SQLite3 installation step from `.github/workflows/stream_flutter_workflow.yml` as it is no longer required.

### Changelog Updates:

* Added changelog entries for the updated minimum Flutter version (`3.29.3`) in `CHANGELOG.md` files for `stream_chat`, `stream_chat_flutter`, `stream_chat_flutter_core`, `stream_chat_localizations`, and `stream_chat_persistence`. [[1]](diffhunk://#diff-0a4071421926a484a5e4e46567cd96230a5754549ea0a7198146eced8598442dR13) [[2]](diffhunk://#diff-739738ae3e48428d9cb405ab14bc8a9b64c9faa943305d6a15c9d6f7810b6b04R10) [[3]](diffhunk://#diff-c57ce42af59efd304991441bfae07e8a98c09a3c7a2968bef3e47874483887b1R1-R6) [[4]](diffhunk://#diff-7e5a4478875893a4041b2736fe9e5da05d5e6acca9e6c35746f4f832b33a8409R1-R6) [[5]](diffhunk://#diff-093a1648e3d267649406e2a75b4f0d8e27ee52d59fb170a3c0e70ee4d1fd98a4R4)