### PR TITLE
fix(llc): ensure query cache is cleared when refreshing channel queries

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 🐞 Fixed
 - `Null check operator used on a null value` in Websocket connect.
+- Ensure query cache is cleared when refreshing channel queries.
 
 ## 9.10.0
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -786,7 +786,8 @@ class StreamChatClient {
     await chatPersistenceClient?.updateChannelQueries(
       filter,
       channels.map((c) => c.channel!.cid).toList(),
-      clearQueryCache: paginationParams.offset == 0,
+      // Clear the query cache if we are refreshing.
+      clearQueryCache: (paginationParams.offset ?? 0) == 0,
     );
 
     this.state.addChannels(updateData.key);

--- a/packages/stream_chat_flutter/example/linux/flutter/generated_plugins.cmake
+++ b/packages/stream_chat_flutter/example/linux/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   record_linux
   sqlite3_flutter_libs
   url_launcher_linux
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
# Submit a pull request
Github Issue: #2036 

## Description of the pull request
This PR addresses an issue where the channel list could display stale data upon initial app launch or when refreshed.

Previously, old channel data was not cleared when new data matching the current filter was fetched. This change ensures that the channel list is correctly updated with the latest information from the API, reflecting the active filter hash.