### PR TITLE
fix(ui): improve scroll to bottom and floating date divider

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `FloatingDateDivider` not showing the correct date when the latest message was too big and
+  exceeded the viewport main axis size.
+- Fixed `ScrollToBottom` button always showing when the latest message was too big and exceeded the
+  viewport main axis size.
+
 ## 9.12.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/message_list_view/floating_date_divider.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/floating_date_divider.dart
@@ -16,11 +16,13 @@ class FloatingDateDivider extends StatelessWidget {
     required this.reverse,
     required this.messages,
     required this.itemCount,
+    @Deprecated('No longer used, Will be removed in future versions.')
     this.isThreadConversation = false,
     this.dateDividerBuilder,
   });
 
   /// true if this is a thread conversation
+  @Deprecated('No longer used, Will be removed in future versions.')
   final bool isThreadConversation;
 
   // ignore: public_member_api_docs
@@ -47,28 +49,37 @@ class FloatingDateDivider extends StatelessWidget {
           return const Empty();
         }
 
-        var index = switch (reverse) {
+        final index = switch (reverse) {
           true => getBottomElementIndex(positions),
           false => getTopElementIndex(positions),
         };
 
-        if ((index == null) ||
-            (!isThreadConversation && index == itemCount - 2) ||
-            (isThreadConversation && index == itemCount - 1)) {
-          return const Empty();
+        if (index == null) return const Empty();
+
+        // We can only calculate the date divider if the element is a message
+        // widget and not one of the special items.
+
+        // Parent Message
+        if (index == itemCount - 1) return const Empty();
+        // Header Builder
+        if (index == itemCount - 2) return const Empty();
+        // Top Loader Builder
+        if (index == itemCount - 3) return const Empty();
+        // Bottom Loader Builder
+        if (index == 1) return const Empty();
+        // Footer Builder
+        if (index == 0) return const Empty();
+
+        // Offset the index to account for two extra items
+        // (loader and footer) at the bottom of the ListView.
+        final message = messages.elementAtOrNull(index - 2);
+        if (message == null) return const Empty();
+
+        if (dateDividerBuilder case final builder?) {
+          return builder.call(message.createdAt.toLocal());
         }
 
-        if (index <= 2 || index >= itemCount - 3) {
-          if (reverse) {
-            index = itemCount - 4;
-          } else {
-            index = 2;
-          }
-        }
-
-        final message = messages[index - 2];
-        return dateDividerBuilder?.call(message.createdAt.toLocal()) ??
-            StreamDateDivider(dateTime: message.createdAt.toLocal());
+        return StreamDateDivider(dateTime: message.createdAt.toLocal());
       },
     );
   }

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -1452,13 +1452,19 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     final itemPositions = _itemPositionListener.itemPositions.value.toList();
     if (itemPositions.isEmpty) return;
 
-    final isLastItemFullyVisible = isElementAtIndexVisible(
-      itemPositions,
-      fullyVisible: true,
-      // Index of the last item in the list view is 2 as 1 is the progress
-      // indicator and 0 is the footer.
-      index: 2,
+    // Index of the last item in the list view is 2 as 1 is the progress
+    // indicator and 0 is the footer.
+    const lastItemIndex = 2;
+    final lastItemPosition = itemPositions.firstWhereOrNull(
+      (position) => position.index == lastItemIndex,
     );
+
+    var isLastItemFullyVisible = false;
+    if (lastItemPosition != null) {
+      // We consider the last item fully visible if its leading edge (reversed)
+      // is greater than or equal to 0.
+      isLastItemFullyVisible = lastItemPosition.itemLeadingEdge >= 0;
+    }
 
     if (mounted) _showScrollToBottom.value = !isLastItemFullyVisible;
     if (isLastItemFullyVisible) return _handleLastItemFullyVisible();

--- a/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
@@ -43,9 +43,17 @@ int getInitialIndex(
 
 /// Gets the index of the top element in the viewport.
 int? getTopElementIndex(Iterable<ItemPosition> values) {
-  final inView = values.where((position) => position.itemTrailingEdge > 0);
-  if (inView.isEmpty) return null;
+  final inView = values.where((position) {
+    if (position.itemLeadingEdge == position.itemTrailingEdge) {
+      // If the item's leading and trailing edges are the same, it means the
+      // item isn't actually rendering anything in the viewport.
+      return false;
+    }
 
+    return position.itemTrailingEdge > 0;
+  });
+
+  if (inView.isEmpty) return null;
   return inView.reduce((min, position) {
     return position.itemTrailingEdge < min.itemTrailingEdge ? position : min;
   }).index;
@@ -53,9 +61,17 @@ int? getTopElementIndex(Iterable<ItemPosition> values) {
 
 /// Gets the index of the bottom element in the viewport.
 int? getBottomElementIndex(Iterable<ItemPosition> values) {
-  final inView = values.where((position) => position.itemLeadingEdge < 1);
-  if (inView.isEmpty) return null;
+  final inView = values.where((position) {
+    if (position.itemLeadingEdge == position.itemTrailingEdge) {
+      // If the item's leading and trailing edges are the same, it means the
+      // item isn't actually rendering anything in the viewport.
+      return false;
+    }
 
+    return position.itemLeadingEdge < 1;
+  });
+
+  if (inView.isEmpty) return null;
   return inView.reduce((max, position) {
     return position.itemLeadingEdge > max.itemLeadingEdge ? position : max;
   }).index;


### PR DESCRIPTION
## Description of the pull request

This PR addresses two issues:

1.  **Scroll to Bottom:** The logic for determining if the last item is fully visible was flawed, causing the "scroll to bottom" button to appear incorrectly in some cases. This has been fixed by checking if the last item's leading edge is greater than or equal to 0.

2.  **Floating Date Divider:** The floating date divider was not correctly calculating the date for messages in case the message widget exceeds the viewport height. This has been fixed by adjusting the index calculations to account for these items and ensuring that the divider only considers actual message widgets.

Additionally, the `isThreadConversation` property in `FloatingDateDivider` has been deprecated as it's no longer used. The utility functions `getTopElementIndex` and `getBottomElementIndex` have also been updated to ignore items that are not actually rendering anything in the viewport.

## Screenshots / Videos

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/394e7774-547c-4aef-90e1-b1fa7fea5be7" /> | <video src="https://github.com/user-attachments/assets/9e89c6ec-75ff-4f90-9d06-56f8765a5e9a" /> | 
