### PR TITLE
refactor(llc): use SortOption.desc/asc instead of new constructor

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- Deprecated `SortOption.new` constructor in favor of `SortOption.desc` and `SortOption.asc`.
+
 ## 9.13.0
 
 - Bug fixes and improvements

--- a/packages/stream_chat/lib/src/core/api/sort_order.dart
+++ b/packages/stream_chat/lib/src/core/api/sort_order.dart
@@ -41,6 +41,7 @@ class SortOption<T extends ComparableFieldProvider> {
   /// ```dart
   /// final sorting = SortOption("last_message_at") // Default: descending order
   /// ```
+  @Deprecated('Use SortOption.desc or SortOption.asc instead')
   const SortOption(
     this.field, {
     this.direction = SortOption.DESC,

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -1273,7 +1273,7 @@ void main() {
 
       test('should work fine with `query`', () async {
         const query = 'test-search-query';
-        const sort = [SortOption('test-sort-field')];
+        const sort = [SortOption.asc('test-sort-field')];
         const pagination = PaginationParams();
 
         final results = List.generate(3, (index) => GetMessageResponse());
@@ -1306,7 +1306,7 @@ void main() {
 
       test('should work fine with `messageFilters`', () async {
         final messageFilters = Filter.query('key', 'text');
-        const sort = [SortOption('test-sort-field')];
+        const sort = [SortOption.desc('test-sort-field')];
         const pagination = PaginationParams();
 
         final results = List.generate(3, (index) => GetMessageResponse());

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -2243,7 +2243,7 @@ void main() {
 
     test('`.queryPolls`', () async {
       final filter = Filter.in_('id', const ['test-poll-id']);
-      final sort = [const SortOption<Poll>('created_at')];
+      final sort = [const SortOption<Poll>.desc('created_at')];
       const pagination = PaginationParams(limit: 20);
 
       final polls = List.generate(
@@ -2285,7 +2285,7 @@ void main() {
     test('`.queryPollVotes`', () async {
       const pollId = 'test-poll-id';
       final filter = Filter.in_('id', const ['test-vote-id']);
-      final sort = [const SortOption<PollVote>('created_at')];
+      final sort = [const SortOption<PollVote>.desc('created_at')];
       const pagination = PaginationParams(limit: 20);
 
       final votes = List.generate(

--- a/packages/stream_chat/test/src/core/api/channel_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/channel_api_test.dart
@@ -122,7 +122,7 @@ void main() {
     const channelType = 'test-channel-type';
 
     final filter = Filter.in_('cid', const ['test-cid']);
-    const sort = [SortOption<ChannelState>('test-field')];
+    const sort = [SortOption<ChannelState>.desc('test-field')];
     const memberLimit = 33;
     const messageLimit = 33;
 

--- a/packages/stream_chat/test/src/core/api/general_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/general_api_test.dart
@@ -86,7 +86,7 @@ void main() {
       'should throw if `pagination.offset` and `sort` both are provided',
       () async {
         final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
-        const sort = [SortOption('test-field')];
+        const sort = [SortOption.desc('test-field')];
         const pagination = PaginationParams(offset: 10);
         try {
           await generalApi.searchMessages(
@@ -103,7 +103,7 @@ void main() {
     test('should run successfully with `query`', () async {
       final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
       const query = 'test-query';
-      const sort = [SortOption('test-field')];
+      const sort = [SortOption.desc('test-field')];
       const pagination = PaginationParams();
 
       const path = '/search';
@@ -142,7 +142,7 @@ void main() {
 
     test('should run successfully with `messageFilter`', () async {
       final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
-      const sort = [SortOption('test-field')];
+      const sort = [SortOption.desc('test-field')];
       final messageFilter = Filter.query('key', 'text');
       const pagination = PaginationParams();
 
@@ -187,7 +187,7 @@ void main() {
       const channelId = 'test-channel-id';
       final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
       const pagination = PaginationParams();
-      const sort = [SortOption<Member>('test-field')];
+      const sort = [SortOption<Member>.desc('test-field')];
 
       const path = '/members';
 
@@ -234,7 +234,7 @@ void main() {
       const channelType = 'test-channel-type';
       final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
       const pagination = PaginationParams();
-      const sort = [SortOption<Member>('test-field')];
+      const sort = [SortOption<Member>.desc('test-field')];
 
       const path = '/members';
 

--- a/packages/stream_chat/test/src/core/api/polls_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/polls_api_test.dart
@@ -331,7 +331,7 @@ void main() {
   test('queryPolls', () async {
     const path = '/polls/query';
     final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
-    const sort = [SortOption<Poll>('test-field')];
+    const sort = [SortOption<Poll>.desc('test-field')];
     const pagination = PaginationParams(limit: 20);
 
     final payload = jsonEncode({
@@ -381,7 +381,7 @@ void main() {
   test('queryPollVotes', () async {
     const pollId = 'test-poll-id';
     final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
-    const sort = [SortOption<PollVote>('test-field')];
+    const sort = [SortOption<PollVote>.desc('test-field')];
     const pagination = PaginationParams(limit: 20);
 
     const path = '/polls/$pollId/votes';

--- a/packages/stream_chat/test/src/core/api/reminders_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/reminders_api_test.dart
@@ -68,7 +68,7 @@ void main() {
     test('should query reminders with filter, sort, and pagination', () async {
       const path = '/reminders/query';
       final filter = Filter.equal('userId', 'test-user-id');
-      const sort = [SortOption<MessageReminder>('remindAt')];
+      const sort = [SortOption<MessageReminder>.desc('remindAt')];
       const pagination = PaginationParams(limit: 10, offset: 5);
 
       final expectedPayload = jsonEncode({

--- a/packages/stream_chat/test/src/core/api/sort_order_test.dart
+++ b/packages/stream_chat/test/src/core/api/sort_order_test.dart
@@ -53,12 +53,6 @@ void main() {
       expect(j, {'field': 'name', 'direction': -1});
     });
 
-    test('should create a SortOption with default DESC direction', () {
-      const option = SortOption<TestModel>('name');
-      expect(option.field, 'name');
-      expect(option.direction, SortOption.DESC);
-    });
-
     test('should create a SortOption with ASC direction', () {
       const option = SortOption<TestModel>.asc('age');
       expect(option.field, 'age');

--- a/packages/stream_chat/test/src/core/api/user_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/user_api_test.dart
@@ -25,7 +25,7 @@ void main() {
   test('queryUsers', () async {
     const presence = true;
     final filter = Filter.in_('cid', const ['test-cid-1', 'test-cid-2']);
-    const sort = [SortOption<User>('test-field')];
+    const sort = [SortOption<User>.desc('test-field')];
     const pagination = PaginationParams();
 
     const path = '/users';

--- a/packages/stream_chat_flutter/example/lib/main.dart
+++ b/packages/stream_chat_flutter/example/lib/main.dart
@@ -189,7 +189,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/example/lib/split_view.dart
+++ b/packages/stream_chat_flutter/example/lib/split_view.dart
@@ -107,7 +107,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_2.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_2.dart
@@ -88,7 +88,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
   );
 
   @override

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_3.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_3.dart
@@ -84,7 +84,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_4.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_4.dart
@@ -70,7 +70,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_5.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_5.dart
@@ -74,7 +74,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
@@ -117,7 +117,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
       'members',
       [StreamChat.of(context).currentUser!.id],
     ),
-    channelStateSort: const [SortOption('last_message_at')],
+    channelStateSort: const [SortOption.desc('last_message_at')],
     limit: 20,
   );
 

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_mention_autocomplete_options.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_mention_autocomplete_options.dart
@@ -160,7 +160,7 @@ class _StreamMentionAutocompleteOptionsState
               Filter.autoComplete('id', query),
               Filter.autoComplete('name', query),
             ]),
-      sort: [const SortOption('id', direction: SortOption.ASC)],
+      sort: [const SortOption.asc('id')],
     );
     return response.users;
   }

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel_list_controller.dart
@@ -11,7 +11,7 @@ const defaultChannelPagedLimit = 10;
 
 /// The default sort used for the channel list.
 const defaultChannelListSort = [
-  SortOption<ChannelState>(ChannelSortKey.lastUpdated),
+  SortOption<ChannelState>.desc(ChannelSortKey.lastUpdated),
 ];
 
 const _kDefaultBackendPaginationLimit = 30;

--- a/packages/stream_chat_flutter_core/lib/src/stream_member_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_member_list_controller.dart
@@ -10,10 +10,7 @@ const defaultMemberPagedLimit = 10;
 
 /// The default sort used for the member list.
 const defaultMemberListSort = [
-  SortOption<Member>(
-    MemberSortKey.createdAt,
-    direction: SortOption.ASC,
-  ),
+  SortOption<Member>.asc(MemberSortKey.createdAt),
 ];
 
 const _kDefaultBackendPaginationLimit = 30;

--- a/packages/stream_chat_flutter_core/lib/src/stream_poll_vote_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_poll_vote_list_controller.dart
@@ -10,10 +10,7 @@ const defaultPollVotePagedLimit = 10;
 
 /// The default sort used for the poll vote list.
 const defaultPollVoteListSort = [
-  SortOption<PollVote>(
-    PollVoteSortKey.createdAt,
-    direction: SortOption.ASC,
-  ),
+  SortOption<PollVote>.asc(PollVoteSortKey.createdAt),
 ];
 
 const _kDefaultBackendPaginationLimit = 30;

--- a/packages/stream_chat_flutter_core/lib/src/stream_user_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_user_list_controller.dart
@@ -10,7 +10,7 @@ const defaultUserPagedLimit = 10;
 
 /// The default sort used for the user list.
 const defaultUserListSort = [
-  SortOption<User>(UserSortKey.createdAt),
+  SortOption<User>.desc(UserSortKey.createdAt),
 ];
 
 const _kDefaultBackendPaginationLimit = 30;

--- a/sample_app/lib/pages/new_group_chat_screen.dart
+++ b/sample_app/lib/pages/new_group_chat_screen.dart
@@ -29,12 +29,7 @@ class _NewGroupChatScreenState extends State<NewGroupChatScreen> {
 
   late final userListController = StreamUserListController(
     client: StreamChat.of(context).client,
-    sort: [
-      const SortOption(
-        'name',
-        direction: 1,
-      ),
-    ],
+    sort: [const SortOption.asc('name')],
     limit: 25,
     filter: Filter.and([
       Filter.notEqual('id', StreamChat.of(context).currentUser!.id),

--- a/sample_app/lib/pages/user_mentions_page.dart
+++ b/sample_app/lib/pages/user_mentions_page.dart
@@ -20,12 +20,7 @@ class _UserMentionsPageState extends State<UserMentionsPage> {
       key: 'mentioned_users.id',
       value: StreamChat.of(context).currentUser!.id,
     ),
-    sort: [
-      const SortOption(
-        'created_at',
-        direction: SortOption.ASC,
-      ),
-    ],
+    sort: [const SortOption.asc('created_at')],
     limit: 20,
   );
   @override

--- a/sample_app/lib/widgets/channel_list.dart
+++ b/sample_app/lib/widgets/channel_list.dart
@@ -28,8 +28,8 @@ class _ChannelList extends State<ChannelList> {
     limit: 5,
     searchQuery: '',
     sort: [
-      const SortOption(ChannelSortKey.pinnedAt),
-      const SortOption(ChannelSortKey.createdAt, direction: SortOption.ASC),
+      const SortOption.desc(ChannelSortKey.pinnedAt),
+      const SortOption.asc(ChannelSortKey.createdAt),
     ],
   );
 
@@ -57,11 +57,11 @@ class _ChannelList extends State<ChannelList> {
     client: StreamChat.of(context).client,
     filter: Filter.in_('members', [StreamChat.of(context).currentUser!.id]),
     channelStateSort: [
-      const SortOption(
+      const SortOption.desc(
         ChannelSortKey.pinnedAt,
         nullOrdering: NullOrdering.nullsLast,
       ),
-      const SortOption(ChannelSortKey.lastMessageAt),
+      const SortOption.desc(ChannelSortKey.lastMessageAt),
     ],
     limit: 30,
   );


### PR DESCRIPTION
## Description of the pull request
The `SortOption.new` constructor is now deprecated in favor of the more explicit `SortOption.desc` and `SortOption.asc` named constructors. This change improves code readability by making the sorting direction immediately clear.

This commit updates all usages of `SortOption.new` across the codebase to use the new named constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Upcoming" section to the changelog highlighting the deprecation of the `SortOption.new` constructor in favor of `SortOption.desc` and `SortOption.asc`.

* **Refactor**
  * Updated sorting syntax throughout the app and examples to use explicit `asc` and `desc` constructors for improved clarity.
  * Changed default sorting for channel and user lists to descending order by most recent activity or creation date.

* **Bug Fixes**
  * Adjusted sorting in test cases and UI to ensure channels and messages are prioritized by most recent updates.

* **Style**
  * Streamlined code by replacing verbose sort option declarations with concise static constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->