### PR TITLE
fix(llc, core): retain cached channel messages on offline access with unread messages

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Upcoming
 
+🐞 Fixed
+
+- Fixed cached messages are cleared from channels with unread messages when accessed
+  offline. [[#2083]](https://github.com/GetStream/stream-chat-flutter/issues/2083)
+
 🔄 Changed
 
 - Deprecated `SortOption.new` constructor in favor of `SortOption.desc` and `SortOption.asc`.

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -1776,7 +1776,18 @@ class Channel {
       if (this.state == null) {
         _initState(channelState);
       } else {
-        // Otherwise, update the channel state.
+        // Otherwise, we update the existing state with the new channel state.
+        //
+        // But, before updating the state, we check if we are querying around a
+        // message, If we are, we have to truncate the state to avoid potential
+        // gaps in the message sequence.
+        final isQueryingAround = switch (messagesPagination) {
+          PaginationParams(idAround: _?) => true,
+          PaginationParams(createdAtAround: _?) => true,
+          _ => false,
+        };
+
+        if (isQueryingAround) this.state?.truncate();
         this.state?.updateChannelState(channelState);
       }
 

--- a/packages/stream_chat/lib/src/core/api/requests.dart
+++ b/packages/stream_chat/lib/src/core/api/requests.dart
@@ -137,6 +137,11 @@ class PaginationParams extends Equatable {
         greaterThanOrEqual,
         lessThan,
         lessThanOrEqual,
+        createdAtAfterOrEqual,
+        createdAtAfter,
+        createdAtBeforeOrEqual,
+        createdAtBefore,
+        createdAtAround,
       ];
 }
 

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed cached messages are cleared from channels with unread messages when accessed
+  offline. [[#2083]](https://github.com/GetStream/stream-chat-flutter/issues/2083)
+
 ## 9.13.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -358,7 +358,6 @@ class StreamChannelState extends State<StreamChannel> {
   }) async {
     if (channel.state == null) return null;
     channel.state?.isUpToDate = false;
-    channel.state?.truncate();
 
     final pagination = PaginationParams(
       limit: limit,
@@ -461,7 +460,6 @@ class StreamChannelState extends State<StreamChannel> {
   }) async {
     if (channel.state == null) return null;
     channel.state?.isUpToDate = false;
-    channel.state?.truncate();
 
     final pagination = PaginationParams(
       limit: limit,


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-180
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #2083

## Screenshots / Videos

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/cd264350-e934-41b8-9607-bad0300ae04a" /> | <video src="https://github.com/user-attachments/assets/8eef025d-20da-48cd-87d1-91dad00e0d5d" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced message pagination options, allowing filtering by message creation time for more precise message retrieval.

* **Bug Fixes**
  * Resolved an issue where cached messages were incorrectly cleared from channels with unread messages when accessed offline.

* **Documentation**
  * Updated changelogs to reflect the latest bug fix and upcoming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->