### PR TITLE
fix(ui): constrain StreamMessageInput height when no constraint is given

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `StreamMessageInput` tries to expand to full height when used in a unconstrained environment.
+
 ## 9.13.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -663,7 +663,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
         ),
         child: SimpleSafeArea(
           enabled: widget.enableSafeArea ?? _messageInputTheme.enableSafeArea,
-          child: Center(child: messageInput),
+          child: Center(heightFactor: 1, child: messageInput),
         ),
       ),
     );


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-200

## Description of the pull request
When `StreamMessageInput` is used in an unconstrained environment, it tries to expand to fill all available vertical space. This change wraps the internal message input in a `Center` widget with `heightFactor: 1` to constrain its height.

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| <img width="400" alt="simulator_screenshot_86BFD8AB-CBAE-461F-A51B-2195E13E0616" src="https://github.com/user-attachments/assets/8c8f7da2-4ec0-4dc7-94ee-9b4bf1096dab" /> | <img width="400" alt="simulator_screenshot_EFB9578E-9D5D-43C6-AE1A-2FDBB5B17FD0" src="https://github.com/user-attachments/assets/51475ae7-0db7-4e97-aad4-a0ec75aedcc3" /> |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the message input widget would incorrectly expand to full height in unconstrained environments, ensuring more consistent layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->