### PR TITLE
fix(core): handle channel reload failure on dispose

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -471,9 +471,6 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
 
   @override
   void dispose() {
-    if (!_upToDate) {
-      streamChannel!.reloadChannel();
-    }
     debouncedMarkRead?.cancel();
     debouncedMarkThreadRead?.cancel();
     _messageNewListener?.cancel();

--- a/packages/stream_chat_flutter/test/src/mocks.dart
+++ b/packages/stream_chat_flutter/test/src/mocks.dart
@@ -68,6 +68,7 @@ class MockChannelState extends Mock implements ChannelClientState {
     when(() => typingEvents).thenReturn({});
     when(() => typingEventsStream).thenAnswer((_) => Stream.value({}));
     when(() => unreadCount).thenReturn(0);
+    when(() => isUpToDate).thenReturn(true);
     when(() => read).thenReturn([]);
   }
 }

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `MessageListCore.dispose()` crash when channel reload fails due to insufficient permissions.
+- Fixed incorrect parent message comparison in `MessageListCore.didUpdateWidget()`.
+
 ## 9.14.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -238,7 +238,7 @@ class MessageListCoreState extends State<MessageListCore> {
     if (_upToDate) return;
 
     try {
-      return await _streamChannel!.reloadChannel();
+      return await _streamChannel?.reloadChannel();
     } catch (_) {
       // We just ignore the error here, as we can't do anything about it.
       // The reload might fail for various reasons, such as user already

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -210,7 +210,7 @@ class MessageListCoreState extends State<MessageListCore> {
       _setupController();
     }
 
-    if (widget.parentMessage?.id != widget.parentMessage?.id) {
+    if (widget.parentMessage?.id != oldWidget.parentMessage?.id) {
       if (_isThreadConversation) {
         _streamChannel!.getReplies(
           widget.parentMessage!.id,
@@ -233,11 +233,22 @@ class MessageListCoreState extends State<MessageListCore> {
     }
   }
 
+  Future<void> _reloadChannelIfNeeded() async {
+    // If the channel is up to date, we don't need to reload it.
+    if (_upToDate) return;
+
+    try {
+      return await _streamChannel!.reloadChannel();
+    } catch (_) {
+      // We just ignore the error here, as we can't do anything about it.
+      // The reload might fail for various reasons, such as user already
+      // left the channel, or the channel is deleted.
+    }
+  }
+
   @override
   void dispose() {
-    if (!_upToDate) {
-      _streamChannel!.reloadChannel();
-    }
+    _reloadChannelIfNeeded();
     super.dispose();
   }
 }

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -673,6 +673,10 @@ class StreamChannelState extends State<StreamChannel> {
       // Otherwise, load the channel at the last read date.
       return loadChannelAtTimestamp(currentUserRead.lastRead);
     }
+
+    // If nothing above applies, we just load the channel at the latest
+    // messages if we are not already at the latest messages.
+    if (channel.state?.isUpToDate == false) return loadChannelAtMessage(null);
   }
 
   late Future<void> _channelInitFuture;

--- a/packages/stream_chat_flutter_core/test/stream_channel_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_channel_test.dart
@@ -76,6 +76,7 @@ void main() {
       final mockChannel = MockChannel();
       when(() => mockChannel.cid).thenReturn('test:channel');
       when(() => mockChannel.state.unreadCount).thenReturn(0);
+      when(() => mockChannel.state.isUpToDate).thenReturn(true);
 
       // A simple widget that provides StreamChannel
       final testWidget = MaterialApp(
@@ -319,6 +320,7 @@ void main() {
       final mockChannel1 = MockChannel();
       when(() => mockChannel1.cid).thenReturn('test:channel1');
       when(() => mockChannel1.state.unreadCount).thenReturn(0);
+      when(() => mockChannel1.state.isUpToDate).thenReturn(true);
 
       // Build with first channel
       await tester.pumpWidget(
@@ -471,6 +473,7 @@ void main() {
       (tester) async {
         when(() => mockChannel.state.messages).thenReturn([]);
         when(() => mockChannel.state.unreadCount).thenReturn(0);
+        when(() => mockChannel.state.isUpToDate).thenReturn(true);
 
         final streamChannel = await _pumpStreamChannel(tester);
 
@@ -499,6 +502,7 @@ void main() {
         when(() => mockChannel.state.unreadCount).thenReturn(0);
         when(() => mockChannel.state.messages).thenReturn(messages);
         when(() => mockChannel.state.currentUserRead).thenReturn(mockRead);
+        when(() => mockChannel.state.isUpToDate).thenReturn(true);
 
         final streamChannel = await _pumpStreamChannel(tester);
 


### PR DESCRIPTION
# Submit a pull request
Fixes: #2294 

## Description of the pull request
The channel reload on `MessageListCore.dispose` could potentially fail for various reasons, such as the user having already left the channel or the channel being deleted. This change wraps the reload call in a try-catch block to gracefully handle these scenarios, preventing the application from crashing.

Additionally, now `StreamChannel` will initialize the channel from latest messages if there is no `initialMessageId` or `unread` is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel reload logic to prevent unnecessary reloads and handle errors silently, enhancing stability.
  * Fixed parent message comparison to ensure proper widget updates.
  * Enhanced channel initialization to ensure latest messages load when channel state is outdated.
* **Tests**
  * Updated tests to accurately simulate channel state and ensure correct behavior when channels are up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->