### PR TITLE
fix(llc): adjust WebSocket disconnect order to prevent race conditions

### DIFF
--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -475,20 +475,17 @@ class WebSocket with TimerHelper {
   /// Disconnects the WS and releases eventual resources
   void disconnect() {
     if (connectionStatus == ConnectionStatus.disconnected) return;
-
-    _resetRequestFlags(resetAttempts: true);
-
     _connectionStatus = ConnectionStatus.disconnected;
 
     _logger?.info('Disconnecting web-socket connection');
 
+    _manuallyClosed = true;
+    _resetRequestFlags(resetAttempts: true);
+    _stopMonitoringEvents();
+
     // resetting user
     _user = null;
     connectionCompleter = null;
-
-    _stopMonitoringEvents();
-
-    _manuallyClosed = true;
 
     _closeWebSocketChannel();
   }

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -263,6 +263,12 @@ class WebSocket with TimerHelper {
     setTimer(
       Duration(milliseconds: delay),
       () async {
+        // If the user is null, it means either the connection was never
+        // established or it was disconnected manually.
+        //
+        // In either case, we should not attempt to reconnect.
+        if (_user == null) return;
+
         final uri = await _buildUri(
           refreshToken: refreshToken,
           includeUserDetails: false,


### PR DESCRIPTION
# Submit a pull request
Fixes: #2303 

## Description of the pull request
This commit addresses a race condition that could occur during the WebSocket disconnection process.

The issue stemmed from the order of operations:
1. User was reset (`_user = null`).
2. Event monitoring was stopped.

This order could lead to a situation where an reconnection was processed after the user was already null, causing a crash.

The fix reverses this order:
1. Event monitoring is stopped (`_stopMonitoringEvents()`).
2. User is reset.

This ensures that no reconnect attempts are made after the user object has been cleared, preventing the race condition.