### PR TITLE
feat(ui, core): add maybeOf methods for safe context access

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Upcoming
+
+✅ Added
+
+- Added `StreamChat.maybeOf()` method for safe context access in async operations.
+
+🐞 Fixed
+
+- Fixed `StreamMessageInput` crashes with "Null check operator used on a null value" when async
+  operations continue after widget unmounting.
+
 ## 9.14.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -71,19 +71,67 @@ class StreamChat extends StatefulWidget {
   @override
   StreamChatState createState() => StreamChatState();
 
-  /// Use this method to get the current [StreamChatState] instance
+  /// Finds the [StreamChatState] from the closest [StreamChat] ancestor
+  /// that encloses the given [context].
+  ///
+  /// This will throw a [FlutterError] if no [StreamChat] is found in the
+  /// widget tree above the given context.
+  ///
+  /// Typical usage:
+  ///
+  /// ```dart
+  /// final chatState = StreamChat.of(context);
+  /// ```
+  ///
+  /// If you're calling this in the same `build()` method that creates the
+  /// `StreamChat`, consider using a `Builder` or refactoring into a
+  /// separate widget to obtain a context below the [StreamChat].
+  ///
+  /// If you want to return null instead of throwing, use [maybeOf].
   static StreamChatState of(BuildContext context) {
-    StreamChatState? streamChatState;
+    final result = maybeOf(context);
+    if (result != null) return result;
 
-    streamChatState = context.findAncestorStateOfType<StreamChatState>();
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'StreamChat.of() called with a context that does not contain a '
+        'StreamChat.',
+      ),
+      ErrorDescription(
+        'No StreamChat ancestor could be found starting from the context '
+        'that was passed to StreamChat.of(). This usually happens when the '
+        'context used comes from the widget that creates the StreamChat '
+        'itself.',
+      ),
+      ErrorHint(
+        'To fix this, ensure that you are using a context that is a descendant '
+        'of the StreamChat. You can use a Builder to get a new context that '
+        'is under the StreamChat:\n\n'
+        '  Builder(\n'
+        '    builder: (context) {\n'
+        '      final chatState = StreamChat.of(context);\n'
+        '      ...\n'
+        '    },\n'
+        '  )',
+      ),
+      ErrorHint(
+        'Alternatively, split your build method into smaller widgets so that '
+        'you get a new BuildContext that is below the StreamChat in the '
+        'widget tree.',
+      ),
+      context.describeElement('The context used was'),
+    ]);
+  }
 
-    if (streamChatState == null) {
-      throw Exception(
-        'You must have a StreamChat widget at the top of your widget tree',
-      );
-    }
-
-    return streamChatState;
+  /// Finds the [StreamChatState] from the closest [StreamChat] ancestor
+  /// that encloses the given context.
+  ///
+  /// Returns null if no such ancestor exists.
+  ///
+  /// See also:
+  ///  * [of], which throws if no [StreamChat] is found.
+  static StreamChatState? maybeOf(BuildContext context) {
+    return context.findAncestorStateOfType<StreamChatState>();
   }
 }
 

--- a/packages/stream_chat_flutter/test/src/stream_chat_test.dart
+++ b/packages/stream_chat_flutter/test/src/stream_chat_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import 'mocks.dart';
+
+void main() {
+  group('StreamChat.of()', () {
+    testWidgets(
+      'should return StreamChatState when StreamChat is found in widget tree',
+      (tester) async {
+        final mockClient = MockClient();
+        StreamChatState? chatState;
+
+        final testWidget = StreamChat(
+          client: mockClient,
+          child: Builder(
+            builder: (context) {
+              chatState = StreamChat.of(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(chatState, isNotNull);
+        expect(chatState?.client, equals(mockClient));
+      },
+    );
+
+    testWidgets(
+      'should throw FlutterError when StreamChat is not found in widget tree',
+      (tester) async {
+        Object? caughtError;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              try {
+                StreamChat.of(context);
+              } catch (error) {
+                caughtError = error;
+              }
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(caughtError, isA<FlutterError>());
+      },
+    );
+  });
+
+  group('StreamChat.maybeOf()', () {
+    testWidgets(
+      'should return StreamChatState when StreamChat is found in widget tree',
+      (tester) async {
+        final mockClient = MockClient();
+        StreamChatState? chatState;
+
+        final testWidget = StreamChat(
+          client: mockClient,
+          child: Builder(
+            builder: (context) {
+              chatState = StreamChat.maybeOf(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(chatState, isNotNull);
+        expect(chatState?.client, equals(mockClient));
+      },
+    );
+
+    testWidgets(
+      'should return null when StreamChat is not found in widget tree',
+      (tester) async {
+        StreamChatState? chatState;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              chatState = StreamChat.maybeOf(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(chatState, isNull);
+      },
+    );
+  });
+
+  group('StreamChat widget', () {
+    testWidgets(
+      'should render child widget when valid client is provided',
+      (tester) async {
+        final mockClient = MockClient();
+
+        final testWidget = StreamChat(
+          client: mockClient,
+          child: const Text('Test Child'),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(find.text('Test Child'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should expose client through StreamChatState',
+      (tester) async {
+        final mockClient = MockClient();
+        StreamChatClient? exposedClient;
+
+        final testWidget = StreamChat(
+          client: mockClient,
+          child: Builder(
+            builder: (context) {
+              final chatState = StreamChat.of(context);
+              exposedClient = chatState.client;
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(exposedClient, equals(mockClient));
+      },
+    );
+  });
+}

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+✅ Added
+
+- Added `StreamChatCore.maybeOf()` method for safe context access in async operations.
+- Added `StreamChannel.maybeOf()` method for safe context access in async operations.
+
 ## 9.14.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -94,18 +94,67 @@ class StreamChannel extends StatefulWidget {
     );
   }
 
-  /// Use this method to get the current [StreamChannelState] instance
+  /// Finds the [StreamChannelState] from the closest [StreamChannel] ancestor
+  /// that encloses the given [context].
+  ///
+  /// This will throw a [FlutterError] if no [StreamChannel] is found in the
+  /// widget tree above the given context.
+  ///
+  /// Typical usage:
+  ///
+  /// ```dart
+  /// final channelState = StreamChannel.of(context);
+  /// ```
+  ///
+  /// If you're calling this in the same `build()` method that creates the
+  /// `StreamChannel`, consider using a `Builder` or refactoring into a separate
+  /// widget to obtain a context below the [StreamChannel].
+  ///
+  /// If you want to return null instead of throwing, use [maybeOf].
   static StreamChannelState of(BuildContext context) {
-    StreamChannelState? streamChannelState;
+    final result = maybeOf(context);
+    if (result != null) return result;
 
-    streamChannelState = context.findAncestorStateOfType<StreamChannelState>();
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'StreamChannel.of() called with a context that does not contain a '
+        'StreamChannel.',
+      ),
+      ErrorDescription(
+        'No StreamChannel ancestor could be found starting from the context '
+        'that was passed to StreamChannel.of(). This usually happens when the '
+        'context used comes from the widget that creates the StreamChannel '
+        'itself.',
+      ),
+      ErrorHint(
+        'To fix this, ensure that you are using a context that is a descendant '
+        'of the StreamChannel. You can use a Builder to get a new context that '
+        'is under the StreamChannel:\n\n'
+        '  Builder(\n'
+        '    builder: (context) {\n'
+        '      final channelState = StreamChannel.of(context);\n'
+        '      ...\n'
+        '    },\n'
+        '  )',
+      ),
+      ErrorHint(
+        'Alternatively, split your build method into smaller widgets so that '
+        'you get a new BuildContext that is below the StreamChannel in the '
+        'widget tree.',
+      ),
+      context.describeElement('The context used was'),
+    ]);
+  }
 
-    assert(
-      streamChannelState != null,
-      'You must have a StreamChannel widget at the top of your widget tree',
-    );
-
-    return streamChannelState!;
+  /// Finds the [StreamChannelState] from the closest [StreamChannel] ancestor
+  /// that encloses the given context.
+  ///
+  /// Returns null if no such ancestor exists.
+  ///
+  /// See also:
+  ///  * [of], which throws if no [StreamChannel] is found.
+  static StreamChannelState? maybeOf(BuildContext context) {
+    return context.findAncestorStateOfType<StreamChannelState>();
   }
 
   @override

--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -106,7 +106,7 @@ class StreamChatCore extends StatefulWidget {
       ),
       ErrorHint(
         'To fix this, ensure that you are using a context that is a descendant '
-        'of the StreamChannel. You can use a Builder to get a new context that '
+        'of the StreamChatCore. You can use a Builder to get a new context that '
         'is under the StreamChatCore:\n\n'
         '  Builder(\n'
         '    builder: (context) {\n'

--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -72,18 +72,67 @@ class StreamChatCore extends StatefulWidget {
   @override
   StreamChatCoreState createState() => StreamChatCoreState();
 
-  /// Use this method to get the current [StreamChatCoreState] instance
+  /// Finds the [StreamChatCoreState] from the closest [StreamChatCore] ancestor
+  /// that encloses the given [context].
+  ///
+  /// This will throw a [FlutterError] if no [StreamChatCore] is found in the
+  /// widget tree above the given context.
+  ///
+  /// Typical usage:
+  ///
+  /// ```dart
+  /// final chatCoreState = StreamChatCore.of(context);
+  /// ```
+  ///
+  /// If you're calling this in the same `build()` method that creates the
+  /// `StreamChatCore`, consider using a `Builder` or refactoring into a
+  /// separate widget to obtain a context below the [StreamChatCore].
+  ///
+  /// If you want to return null instead of throwing, use [maybeOf].
   static StreamChatCoreState of(BuildContext context) {
-    StreamChatCoreState? streamChatState;
+    final result = maybeOf(context);
+    if (result != null) return result;
 
-    streamChatState = context.findAncestorStateOfType<StreamChatCoreState>();
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'StreamChatCore.of() called with a context that does not contain a '
+        'StreamChatCore.',
+      ),
+      ErrorDescription(
+        'No StreamChatCore ancestor could be found starting from the context '
+        'that was passed to StreamChatCore.of(). This usually happens when the '
+        'context used comes from the widget that creates the StreamChatCore '
+        'itself.',
+      ),
+      ErrorHint(
+        'To fix this, ensure that you are using a context that is a descendant '
+        'of the StreamChannel. You can use a Builder to get a new context that '
+        'is under the StreamChatCore:\n\n'
+        '  Builder(\n'
+        '    builder: (context) {\n'
+        '      final chatCoreState = StreamChatCore.of(context);\n'
+        '      ...\n'
+        '    },\n'
+        '  )',
+      ),
+      ErrorHint(
+        'Alternatively, split your build method into smaller widgets so that '
+        'you get a new BuildContext that is below the StreamChatCore in the '
+        'widget tree.',
+      ),
+      context.describeElement('The context used was'),
+    ]);
+  }
 
-    assert(
-      streamChatState != null,
-      'You must have a StreamChat widget at the top of your widget tree',
-    );
-
-    return streamChatState!;
+  /// Finds the [StreamChatCoreState] from the closest [StreamChatCore] ancestor
+  /// that encloses the given context.
+  ///
+  /// Returns null if no such ancestor exists.
+  ///
+  /// See also:
+  ///  * [of], which throws if no [StreamChatCore] is found.
+  static StreamChatCoreState? maybeOf(BuildContext context) {
+    return context.findAncestorStateOfType<StreamChatCoreState>();
   }
 }
 

--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -106,8 +106,8 @@ class StreamChatCore extends StatefulWidget {
       ),
       ErrorHint(
         'To fix this, ensure that you are using a context that is a descendant '
-        'of the StreamChatCore. You can use a Builder to get a new context that '
-        'is under the StreamChatCore:\n\n'
+        'of the StreamChatCore. You can use a Builder to get a new context '
+        'that is under the StreamChatCore:\n\n'
         '  Builder(\n'
         '    builder: (context) {\n'
         '      final chatCoreState = StreamChatCore.of(context);\n'

--- a/packages/stream_chat_flutter_core/test/stream_channel_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_channel_test.dart
@@ -8,36 +8,111 @@ import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 import 'mocks.dart';
 
 void main() {
-  testWidgets(
-    'should expose channel state through StreamChannel.of() context method',
-    (tester) async {
-      final mockChannel = MockChannel();
-      StreamChannelState? channelState;
+  group('StreamChannel.of()', () {
+    testWidgets(
+      'should return StreamChannelState when StreamChannel is found in widget tree',
+      (tester) async {
+        final mockChannel = MockChannel();
+        StreamChannelState? channelState;
 
-      // Build a widget that accesses the channel state
-      final testWidget = MaterialApp(
-        home: Scaffold(
-          body: StreamChannel(
-            channel: mockChannel,
-            child: Builder(
-              builder: (context) {
-                // Access the channel state
-                channelState = StreamChannel.of(context);
-                return const Text('Child Widget');
-              },
+        // Build a widget that accesses the channel state
+        final testWidget = MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: mockChannel,
+              child: Builder(
+                builder: (context) {
+                  // Access the channel state
+                  channelState = StreamChannel.of(context);
+                  return const Text('Child Widget');
+                },
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpWidget(testWidget);
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(testWidget);
+        await tester.pumpAndSettle();
 
-      // Verify we can access the channel state
-      expect(channelState, isNotNull);
-      expect(channelState?.channel, equals(mockChannel));
-    },
-  );
+        expect(channelState, isNotNull);
+        expect(channelState?.channel, equals(mockChannel));
+      },
+    );
+
+    testWidgets(
+      'should throw FlutterError when StreamChannel is not found in widget tree',
+      (tester) async {
+        Object? caughtError;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              try {
+                StreamChannel.of(context);
+              } catch (error) {
+                caughtError = error;
+              }
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(caughtError, isA<FlutterError>());
+      },
+    );
+  });
+
+  group('StreamChannel.maybeOf()', () {
+    testWidgets(
+      'should return StreamChannelState when StreamChannel is found in widget tree',
+      (tester) async {
+        final mockChannel = MockChannel();
+        StreamChannelState? channelState;
+
+        final testWidget = MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: mockChannel,
+              child: Builder(
+                builder: (context) {
+                  channelState = StreamChannel.maybeOf(context);
+                  return const Text('Child Widget');
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+        await tester.pumpAndSettle();
+
+        expect(channelState, isNotNull);
+        expect(channelState?.channel, equals(mockChannel));
+      },
+    );
+
+    testWidgets(
+      'should return null when StreamChannel is not found in widget tree',
+      (tester) async {
+        StreamChannelState? channelState;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              channelState = StreamChannel.maybeOf(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(channelState, isNull);
+      },
+    );
+  });
 
   testWidgets(
     'should render child widget when channel has no CID (locally created)',

--- a/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
@@ -13,6 +13,100 @@ class MockOnBackgroundEventReceived extends Mock {
 }
 
 void main() {
+  group('StreamChatCore.of()', () {
+    testWidgets(
+      'should return StreamChatCoreState when StreamChatCore is found in widget tree',
+      (tester) async {
+        final mockClient = MockClient();
+        StreamChatCoreState? chatCoreState;
+
+        final testWidget = StreamChatCore(
+          client: mockClient,
+          child: Builder(
+            builder: (context) {
+              chatCoreState = StreamChatCore.of(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(chatCoreState, isNotNull);
+        expect(chatCoreState?.client, equals(mockClient));
+      },
+    );
+
+    testWidgets(
+      'should throw FlutterError when StreamChatCore is not found in widget tree',
+      (tester) async {
+        Object? caughtError;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              try {
+                StreamChatCore.of(context);
+              } catch (error) {
+                caughtError = error;
+              }
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(caughtError, isA<FlutterError>());
+      },
+    );
+  });
+
+  group('StreamChatCore.maybeOf()', () {
+    testWidgets(
+      'should return StreamChatCoreState when StreamChatCore is found in widget tree',
+      (tester) async {
+        final mockClient = MockClient();
+        StreamChatCoreState? chatCoreState;
+
+        final testWidget = StreamChatCore(
+          client: mockClient,
+          child: Builder(
+            builder: (context) {
+              chatCoreState = StreamChatCore.maybeOf(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(MaterialApp(home: testWidget));
+
+        expect(chatCoreState, isNotNull);
+        expect(chatCoreState?.client, equals(mockClient));
+      },
+    );
+
+    testWidgets(
+      'should return null when StreamChatCore is not found in widget tree',
+      (tester) async {
+        StreamChatCoreState? chatCoreState;
+
+        final testWidget = MaterialApp(
+          home: Builder(
+            builder: (context) {
+              chatCoreState = StreamChatCore.maybeOf(context);
+              return const Text('Child Widget');
+            },
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+
+        expect(chatCoreState, isNull);
+      },
+    );
+  });
+
   testWidgets(
     'should render StreamChatCore if both client and child is provided',
     (tester) async {


### PR DESCRIPTION
<!--Optional to add github issue which is solved by this PR-->
Fixes: #2302 

## Description of the pull request
This commit introduces `maybeOf` methods for `StreamChat`, `StreamChatCore`, and `StreamChannel` to allow for safer access to their respective states from a `BuildContext`. These methods return `null` if the widget is not found in the widget tree, preventing crashes in async operations where the widget might have been unmounted.

The `of` methods have also been updated to throw a more descriptive `FlutterError` when the widget is not found.

Additionally, `StreamMessageInput` has been refactored to use these `maybeOf` methods, fixing potential "Null check operator used on a null value" errors when async operations continue after the widget has been unmounted.# Submit a pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced safe context access methods: `maybeOf()` for `StreamChat`, `StreamChatCore`, and `StreamChannel`, allowing for safer asynchronous operations.
  * Improved error handling with more descriptive error messages when context access fails.

* **Bug Fixes**
  * Fixed crashes in message input caused by null checks during asynchronous operations after widget unmounting.

* **Tests**
  * Added comprehensive tests for the new and updated context access methods to ensure correct behavior and error handling.

* **Documentation**
  * Updated changelogs to reflect new features and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->