### PR TITLE
feat(persistence): add support for location persistence

### DIFF
--- a/packages/stream_chat/lib/src/db/chat_persistence_client.dart
+++ b/packages/stream_chat/lib/src/db/chat_persistence_client.dart
@@ -7,6 +7,7 @@ import 'package:stream_chat/src/core/models/channel_state.dart';
 import 'package:stream_chat/src/core/models/draft.dart';
 import 'package:stream_chat/src/core/models/event.dart';
 import 'package:stream_chat/src/core/models/filter.dart';
+import 'package:stream_chat/src/core/models/location.dart';
 import 'package:stream_chat/src/core/models/member.dart';
 import 'package:stream_chat/src/core/models/message.dart';
 import 'package:stream_chat/src/core/models/poll.dart';
@@ -82,6 +83,12 @@ abstract class ChatPersistenceClient {
   /// Get stored [Draft] message by providing channel [cid] and a optional
   /// [parentId] for thread messages.
   Future<Draft?> getDraftMessageByCid(String cid, {String? parentId});
+
+  /// Get stored [Location]s by providing channel [cid]
+  Future<List<Location>> getLocationsByCid(String cid);
+
+  /// Get stored [Location] by providing [messageId]
+  Future<Location?> getLocationByMessageId(String messageId);
 
   /// Get [ChannelState] data by providing channel [cid]
   Future<ChannelState> getChannelStateByCid(
@@ -168,6 +175,12 @@ abstract class ChatPersistenceClient {
   /// [DraftMessages.parentId].
   Future<void> deleteDraftMessageByCid(String cid, {String? parentId});
 
+  /// Removes locations by channel [cid]
+  Future<void> deleteLocationsByCid(String cid);
+
+  /// Removes locations by message [messageIds]
+  Future<void> deleteLocationsByMessageIds(List<String> messageIds);
+
   /// Updates the message data of a particular channel [cid] with
   /// the new [messages] data
   Future<void> updateMessages(String cid, List<Message> messages) =>
@@ -228,6 +241,9 @@ abstract class ChatPersistenceClient {
   /// Updates the draft messages data with the new [draftMessages] data
   Future<void> updateDraftMessages(List<Draft> draftMessages);
 
+  /// Updates the locations data with the new [locations] data
+  Future<void> updateLocations(List<Location> locations);
+
   /// Deletes all the reactions by [messageIds]
   Future<void> deleteReactionsByMessageId(List<String> messageIds);
 
@@ -287,6 +303,8 @@ abstract class ChatPersistenceClient {
     final pollVotes = <PollVote>[];
     final pollVotesToDelete = <String>[];
 
+    final locations = <Location>[];
+
     for (final state in channelStates) {
       final channel = state.channel;
       // Continue if channel is not available.
@@ -336,6 +354,11 @@ abstract class ChatPersistenceClient {
         ...?pinnedMessages?.map((it) => it.draft),
       ].nonNulls);
 
+      locations.addAll([
+        ...?messages?.map((it) => it.sharedLocation),
+        ...?pinnedMessages?.map((it) => it.sharedLocation),
+      ].nonNulls);
+
       users.addAll([
         channel.createdBy,
         ...?messages?.map((it) => it.user),
@@ -379,6 +402,7 @@ abstract class ChatPersistenceClient {
       updatePinnedMessageReactions(pinnedReactions),
       updatePollVotes(pollVotes),
       updateDraftMessages(drafts),
+      updateLocations(locations),
     ]);
   }
 

--- a/packages/stream_chat/test/src/db/chat_persistence_client_test.dart
+++ b/packages/stream_chat/test/src/db/chat_persistence_client_test.dart
@@ -6,6 +6,7 @@ import 'package:stream_chat/src/core/models/draft.dart';
 import 'package:stream_chat/src/core/models/draft_message.dart';
 import 'package:stream_chat/src/core/models/event.dart';
 import 'package:stream_chat/src/core/models/filter.dart';
+import 'package:stream_chat/src/core/models/location.dart';
 import 'package:stream_chat/src/core/models/member.dart';
 import 'package:stream_chat/src/core/models/message.dart';
 import 'package:stream_chat/src/core/models/poll.dart';
@@ -173,6 +174,22 @@ class TestPersistenceClient extends ChatPersistenceClient {
 
   @override
   Future<void> updateDraftMessages(List<Draft> draftMessages) => Future.value();
+
+  @override
+  Future<List<Location>> getLocationsByCid(String cid) async => [];
+
+  @override
+  Future<Location?> getLocationByMessageId(String messageId) async => null;
+
+  @override
+  Future<void> updateLocations(List<Location> locations) => Future.value();
+
+  @override
+  Future<void> deleteLocationsByCid(String cid) => Future.value();
+
+  @override
+  Future<void> deleteLocationsByMessageIds(List<String> messageIds) =>
+      Future.value();
 }
 
 void main() {

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming Beta
+
+- Added support for `Location` entity in the database.
+
 ## 10.0.0-beta.3
 
 - Included the changes from version [`9.14.0`](https://pub.dev/packages/stream_chat_persistence/changelog).

--- a/packages/stream_chat_persistence/lib/src/dao/dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/dao.dart
@@ -2,6 +2,7 @@ export 'channel_dao.dart';
 export 'channel_query_dao.dart';
 export 'connection_event_dao.dart';
 export 'draft_message_dao.dart';
+export 'location_dao.dart';
 export 'member_dao.dart';
 export 'message_dao.dart';
 export 'pinned_message_dao.dart';

--- a/packages/stream_chat_persistence/lib/src/dao/draft_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/draft_message_dao.dart
@@ -18,18 +18,27 @@ class DraftMessageDao extends DatabaseAccessor<DriftChatDatabase>
   final DriftChatDatabase _db;
 
   Future<Draft> _draftFromEntity(DraftMessageEntity entity) async {
-    // We do not want to fetch the draft message of the parent and quoted
-    // message because it will create a circular dependency and will
+    // We do not want to fetch the draft and shared location of the parent and
+    // quoted message because it will create a circular dependency and will
     // result in infinite loop.
     const fetchDraft = false;
+    const fetchSharedLocation = false;
 
     final parentMessage = await switch (entity.parentId) {
-      final id? => _db.messageDao.getMessageById(id, fetchDraft: fetchDraft),
+      final id? => _db.messageDao.getMessageById(
+          id,
+          fetchDraft: fetchDraft,
+          fetchSharedLocation: fetchSharedLocation,
+        ),
       _ => null,
     };
 
     final quotedMessage = await switch (entity.quotedMessageId) {
-      final id? => _db.messageDao.getMessageById(id, fetchDraft: fetchDraft),
+      final id? => _db.messageDao.getMessageById(
+          id,
+          fetchDraft: fetchDraft,
+          fetchSharedLocation: fetchSharedLocation,
+        ),
       _ => null,
     };
 

--- a/packages/stream_chat_persistence/lib/src/dao/location_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/location_dao.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: join_return_with_assignment
+
+import 'package:drift/drift.dart';
+import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_persistence/src/db/drift_chat_database.dart';
+import 'package:stream_chat_persistence/src/entity/locations.dart';
+import 'package:stream_chat_persistence/src/mapper/mapper.dart';
+
+part 'location_dao.g.dart';
+
+/// The Data Access Object for operations in [Locations] table.
+@DriftAccessor(tables: [Locations])
+class LocationDao extends DatabaseAccessor<DriftChatDatabase>
+    with _$LocationDaoMixin {
+  /// Creates a new location dao instance
+  LocationDao(this._db) : super(_db);
+
+  final DriftChatDatabase _db;
+
+  Future<Location> _locationFromEntity(LocationEntity entity) async {
+    // We do not want to fetch the location of the parent and quoted
+    // message because it will create a circular dependency and will
+    // result in infinite loop.
+    const fetchDraft = false;
+    const fetchSharedLocation = false;
+
+    final channel = await switch (entity.channelCid) {
+      final cid? => db.channelDao.getChannelByCid(cid),
+      _ => null,
+    };
+
+    final message = await switch (entity.messageId) {
+      final id? => _db.messageDao.getMessageById(
+          id,
+          fetchDraft: fetchDraft,
+          fetchSharedLocation: fetchSharedLocation,
+        ),
+      _ => null,
+    };
+
+    return entity.toLocation(
+      channel: channel,
+      message: message,
+    );
+  }
+
+  /// Get all locations for a channel
+  Future<List<Location>> getLocationsByCid(String cid) async {
+    final query = select(locations)..where((tbl) => tbl.channelCid.equals(cid));
+
+    final result = await query.map(_locationFromEntity).get();
+    return Future.wait(result);
+  }
+
+  /// Get location by message ID
+  Future<Location?> getLocationByMessageId(String messageId) async {
+    final query = select(locations) //
+      ..where((tbl) => tbl.messageId.equals(messageId));
+
+    final result = await query.getSingleOrNull();
+    if (result == null) return null;
+
+    return _locationFromEntity(result);
+  }
+
+  /// Update multiple locations
+  Future<void> updateLocations(List<Location> locationList) {
+    return batch(
+      (it) => it.insertAllOnConflictUpdate(
+        locations,
+        locationList.map((it) => it.toEntity()),
+      ),
+    );
+  }
+
+  /// Delete locations by channel ID
+  Future<void> deleteLocationsByCid(String cid) =>
+      (delete(locations)..where((tbl) => tbl.channelCid.equals(cid))).go();
+
+  /// Delete locations by message IDs
+  Future<void> deleteLocationsByMessageIds(List<String> messageIds) =>
+      (delete(locations)..where((tbl) => tbl.messageId.isIn(messageIds))).go();
+}

--- a/packages/stream_chat_persistence/lib/src/dao/location_dao.g.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/location_dao.g.dart
@@ -1,0 +1,10 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'location_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$LocationDaoMixin on DatabaseAccessor<DriftChatDatabase> {
+  $ChannelsTable get channels => attachedDatabase.channels;
+  $MessagesTable get messages => attachedDatabase.messages;
+  $LocationsTable get locations => attachedDatabase.locations;
+}

--- a/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
@@ -35,27 +35,43 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
   Future<void> deleteMessageByCids(List<String> cids) async =>
       (delete(pinnedMessages)..where((tbl) => tbl.channelCid.isIn(cids))).go();
 
-  Future<Message> _messageFromJoinRow(TypedResult rows) async {
-    final userEntity = rows.readTableOrNull(users);
+  Future<Message> _messageFromJoinRow(
+    TypedResult rows, {
+    bool fetchDraft = false,
+    bool fetchSharedLocation = false,
+  }) async {
+    final userEntity = rows.readTableOrNull(_users);
     final pinnedByEntity = rows.readTableOrNull(_pinnedByUsers);
     final msgEntity = rows.readTable(pinnedMessages);
-    final latestReactions =
-        await _db.pinnedMessageReactionDao.getReactions(msgEntity.id);
-    final ownReactions =
-        await _db.pinnedMessageReactionDao.getReactionsByUserId(
+    final latestReactions = await _db.reactionDao.getReactions(msgEntity.id);
+    final ownReactions = await _db.reactionDao.getReactionsByUserId(
       msgEntity.id,
       _db.userId,
     );
-    Message? quotedMessage;
-    final quotedMessageId = msgEntity.quotedMessageId;
-    if (quotedMessageId != null) {
-      quotedMessage = await getMessageById(quotedMessageId);
-    }
-    Poll? poll;
-    final pollId = msgEntity.pollId;
-    if (pollId != null) {
-      poll = await _db.pollDao.getPollById(pollId);
-    }
+
+    final quotedMessage = await switch (msgEntity.quotedMessageId) {
+      final id? => getMessageById(id),
+      _ => null,
+    };
+
+    final poll = await switch (msgEntity.pollId) {
+      final id? => _db.pollDao.getPollById(id),
+      _ => null,
+    };
+
+    final draft = await switch (fetchDraft) {
+      true => _db.draftMessageDao.getDraftMessageByCid(
+          msgEntity.channelCid,
+          parentId: msgEntity.parentId,
+        ),
+      _ => null,
+    };
+
+    final sharedLocation = await switch (fetchSharedLocation) {
+      true => _db.locationDao.getLocationByMessageId(msgEntity.id),
+      _ => null,
+    };
+
     return msgEntity.toMessage(
       user: userEntity?.toUser(),
       pinnedBy: pinnedByEntity?.toUser(),
@@ -63,21 +79,35 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
       ownReactions: ownReactions,
       quotedMessage: quotedMessage,
       poll: poll,
+      draft: draft,
+      sharedLocation: sharedLocation,
     );
   }
 
   /// Returns a single message by matching the [PinnedMessages.id] with [id]
-  Future<Message?> getMessageById(String id) async =>
-      await (select(pinnedMessages).join([
-        leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
-        leftOuterJoin(
-          _pinnedByUsers,
-          pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
-        ),
-      ])
-            ..where(pinnedMessages.id.equals(id)))
-          .map(_messageFromJoinRow)
-          .getSingleOrNull();
+  Future<Message?> getMessageById(
+    String id, {
+    bool fetchDraft = true,
+    bool fetchSharedLocation = true,
+  }) async {
+    final query = select(pinnedMessages).join([
+      leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
+      leftOuterJoin(
+        _pinnedByUsers,
+        pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
+      ),
+    ])
+      ..where(pinnedMessages.id.equals(id));
+
+    final result = await query.getSingleOrNull();
+    if (result == null) return null;
+
+    return _messageFromJoinRow(
+      result,
+      fetchDraft: fetchDraft,
+      fetchSharedLocation: fetchSharedLocation,
+    );
+  }
 
   /// Returns all the messages of a particular thread by matching
   /// [PinnedMessages.channelCid] with [cid]
@@ -142,21 +172,34 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
   /// [PinnedMessages.channelCid] with [parentId]
   Future<List<Message>> getMessagesByCid(
     String cid, {
+    bool fetchDraft = true,
+    bool fetchSharedLocation = true,
     PaginationParams? messagePagination,
   }) async {
-    final msgList = await Future.wait(await (select(pinnedMessages).join([
+    final query = select(pinnedMessages).join([
       leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
       leftOuterJoin(
         _pinnedByUsers,
         pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
       ),
     ])
-          ..where(pinnedMessages.channelCid.equals(cid))
-          ..where(pinnedMessages.parentId.isNull() |
-              pinnedMessages.showInChannel.equals(true))
-          ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]))
-        .map(_messageFromJoinRow)
-        .get());
+      ..where(pinnedMessages.channelCid.equals(cid))
+      ..where(pinnedMessages.parentId.isNull() |
+          pinnedMessages.showInChannel.equals(true))
+      ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]);
+
+    final result = await query.get();
+    if (result.isEmpty) return [];
+
+    final msgList = await Future.wait(
+      result.map(
+        (row) => _messageFromJoinRow(
+          row,
+          fetchDraft: fetchDraft,
+          fetchSharedLocation: fetchSharedLocation,
+        ),
+      ),
+    );
 
     if (msgList.isNotEmpty) {
       if (messagePagination?.lessThan != null) {

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -13,6 +13,7 @@ part 'drift_chat_database.g.dart';
   tables: [
     Channels,
     DraftMessages,
+    Locations,
     Messages,
     PinnedMessages,
     Polls,
@@ -30,6 +31,7 @@ part 'drift_chat_database.g.dart';
     ChannelDao,
     MessageDao,
     DraftMessageDao,
+    LocationDao,
     PinnedMessageDao,
     PinnedMessageReactionDao,
     MemberDao,
@@ -55,7 +57,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 21;
+  int get schemaVersion => 22;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -2808,6 +2808,484 @@ class DraftMessagesCompanion extends UpdateCompanion<DraftMessageEntity> {
   }
 }
 
+class $LocationsTable extends Locations
+    with TableInfo<$LocationsTable, LocationEntity> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $LocationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _channelCidMeta =
+      const VerificationMeta('channelCid');
+  @override
+  late final GeneratedColumn<String> channelCid = GeneratedColumn<String>(
+      'channel_cid', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES channels (cid) ON DELETE CASCADE'));
+  static const VerificationMeta _messageIdMeta =
+      const VerificationMeta('messageId');
+  @override
+  late final GeneratedColumn<String> messageId = GeneratedColumn<String>(
+      'message_id', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES messages (id) ON DELETE CASCADE'));
+  static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
+  @override
+  late final GeneratedColumn<String> userId = GeneratedColumn<String>(
+      'user_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _latitudeMeta =
+      const VerificationMeta('latitude');
+  @override
+  late final GeneratedColumn<double> latitude = GeneratedColumn<double>(
+      'latitude', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _longitudeMeta =
+      const VerificationMeta('longitude');
+  @override
+  late final GeneratedColumn<double> longitude = GeneratedColumn<double>(
+      'longitude', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _createdByDeviceIdMeta =
+      const VerificationMeta('createdByDeviceId');
+  @override
+  late final GeneratedColumn<String> createdByDeviceId =
+      GeneratedColumn<String>('created_by_device_id', aliasedName, false,
+          type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _endAtMeta = const VerificationMeta('endAt');
+  @override
+  late final GeneratedColumn<DateTime> endAt = GeneratedColumn<DateTime>(
+      'end_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  @override
+  List<GeneratedColumn> get $columns => [
+        channelCid,
+        messageId,
+        userId,
+        latitude,
+        longitude,
+        createdByDeviceId,
+        endAt,
+        createdAt,
+        updatedAt
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'locations';
+  @override
+  VerificationContext validateIntegrity(Insertable<LocationEntity> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('channel_cid')) {
+      context.handle(
+          _channelCidMeta,
+          channelCid.isAcceptableOrUnknown(
+              data['channel_cid']!, _channelCidMeta));
+    }
+    if (data.containsKey('message_id')) {
+      context.handle(_messageIdMeta,
+          messageId.isAcceptableOrUnknown(data['message_id']!, _messageIdMeta));
+    }
+    if (data.containsKey('user_id')) {
+      context.handle(_userIdMeta,
+          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
+    }
+    if (data.containsKey('latitude')) {
+      context.handle(_latitudeMeta,
+          latitude.isAcceptableOrUnknown(data['latitude']!, _latitudeMeta));
+    } else if (isInserting) {
+      context.missing(_latitudeMeta);
+    }
+    if (data.containsKey('longitude')) {
+      context.handle(_longitudeMeta,
+          longitude.isAcceptableOrUnknown(data['longitude']!, _longitudeMeta));
+    } else if (isInserting) {
+      context.missing(_longitudeMeta);
+    }
+    if (data.containsKey('created_by_device_id')) {
+      context.handle(
+          _createdByDeviceIdMeta,
+          createdByDeviceId.isAcceptableOrUnknown(
+              data['created_by_device_id']!, _createdByDeviceIdMeta));
+    } else if (isInserting) {
+      context.missing(_createdByDeviceIdMeta);
+    }
+    if (data.containsKey('end_at')) {
+      context.handle(
+          _endAtMeta, endAt.isAcceptableOrUnknown(data['end_at']!, _endAtMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {messageId};
+  @override
+  LocationEntity map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return LocationEntity(
+      channelCid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}channel_cid']),
+      messageId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}message_id']),
+      userId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}user_id']),
+      latitude: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}latitude'])!,
+      longitude: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}longitude'])!,
+      createdByDeviceId: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}created_by_device_id'])!,
+      endAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}end_at']),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+    );
+  }
+
+  @override
+  $LocationsTable createAlias(String alias) {
+    return $LocationsTable(attachedDatabase, alias);
+  }
+}
+
+class LocationEntity extends DataClass implements Insertable<LocationEntity> {
+  /// The channel CID where the location is shared
+  final String? channelCid;
+
+  /// The ID of the message that contains this shared location
+  final String? messageId;
+
+  /// The ID of the user who shared the location
+  final String? userId;
+
+  /// The latitude of the shared location
+  final double latitude;
+
+  /// The longitude of the shared location
+  final double longitude;
+
+  /// The ID of the device that created the location
+  final String createdByDeviceId;
+
+  /// The date at which the shared location will end (for live locations)
+  /// If null, this is a static location
+  final DateTime? endAt;
+
+  /// The date at which the location was created
+  final DateTime createdAt;
+
+  /// The date at which the location was last updated
+  final DateTime updatedAt;
+  const LocationEntity(
+      {this.channelCid,
+      this.messageId,
+      this.userId,
+      required this.latitude,
+      required this.longitude,
+      required this.createdByDeviceId,
+      this.endAt,
+      required this.createdAt,
+      required this.updatedAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (!nullToAbsent || channelCid != null) {
+      map['channel_cid'] = Variable<String>(channelCid);
+    }
+    if (!nullToAbsent || messageId != null) {
+      map['message_id'] = Variable<String>(messageId);
+    }
+    if (!nullToAbsent || userId != null) {
+      map['user_id'] = Variable<String>(userId);
+    }
+    map['latitude'] = Variable<double>(latitude);
+    map['longitude'] = Variable<double>(longitude);
+    map['created_by_device_id'] = Variable<String>(createdByDeviceId);
+    if (!nullToAbsent || endAt != null) {
+      map['end_at'] = Variable<DateTime>(endAt);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  factory LocationEntity.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return LocationEntity(
+      channelCid: serializer.fromJson<String?>(json['channelCid']),
+      messageId: serializer.fromJson<String?>(json['messageId']),
+      userId: serializer.fromJson<String?>(json['userId']),
+      latitude: serializer.fromJson<double>(json['latitude']),
+      longitude: serializer.fromJson<double>(json['longitude']),
+      createdByDeviceId: serializer.fromJson<String>(json['createdByDeviceId']),
+      endAt: serializer.fromJson<DateTime?>(json['endAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'channelCid': serializer.toJson<String?>(channelCid),
+      'messageId': serializer.toJson<String?>(messageId),
+      'userId': serializer.toJson<String?>(userId),
+      'latitude': serializer.toJson<double>(latitude),
+      'longitude': serializer.toJson<double>(longitude),
+      'createdByDeviceId': serializer.toJson<String>(createdByDeviceId),
+      'endAt': serializer.toJson<DateTime?>(endAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  LocationEntity copyWith(
+          {Value<String?> channelCid = const Value.absent(),
+          Value<String?> messageId = const Value.absent(),
+          Value<String?> userId = const Value.absent(),
+          double? latitude,
+          double? longitude,
+          String? createdByDeviceId,
+          Value<DateTime?> endAt = const Value.absent(),
+          DateTime? createdAt,
+          DateTime? updatedAt}) =>
+      LocationEntity(
+        channelCid: channelCid.present ? channelCid.value : this.channelCid,
+        messageId: messageId.present ? messageId.value : this.messageId,
+        userId: userId.present ? userId.value : this.userId,
+        latitude: latitude ?? this.latitude,
+        longitude: longitude ?? this.longitude,
+        createdByDeviceId: createdByDeviceId ?? this.createdByDeviceId,
+        endAt: endAt.present ? endAt.value : this.endAt,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
+  LocationEntity copyWithCompanion(LocationsCompanion data) {
+    return LocationEntity(
+      channelCid:
+          data.channelCid.present ? data.channelCid.value : this.channelCid,
+      messageId: data.messageId.present ? data.messageId.value : this.messageId,
+      userId: data.userId.present ? data.userId.value : this.userId,
+      latitude: data.latitude.present ? data.latitude.value : this.latitude,
+      longitude: data.longitude.present ? data.longitude.value : this.longitude,
+      createdByDeviceId: data.createdByDeviceId.present
+          ? data.createdByDeviceId.value
+          : this.createdByDeviceId,
+      endAt: data.endAt.present ? data.endAt.value : this.endAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('LocationEntity(')
+          ..write('channelCid: $channelCid, ')
+          ..write('messageId: $messageId, ')
+          ..write('userId: $userId, ')
+          ..write('latitude: $latitude, ')
+          ..write('longitude: $longitude, ')
+          ..write('createdByDeviceId: $createdByDeviceId, ')
+          ..write('endAt: $endAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(channelCid, messageId, userId, latitude,
+      longitude, createdByDeviceId, endAt, createdAt, updatedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LocationEntity &&
+          other.channelCid == this.channelCid &&
+          other.messageId == this.messageId &&
+          other.userId == this.userId &&
+          other.latitude == this.latitude &&
+          other.longitude == this.longitude &&
+          other.createdByDeviceId == this.createdByDeviceId &&
+          other.endAt == this.endAt &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class LocationsCompanion extends UpdateCompanion<LocationEntity> {
+  final Value<String?> channelCid;
+  final Value<String?> messageId;
+  final Value<String?> userId;
+  final Value<double> latitude;
+  final Value<double> longitude;
+  final Value<String> createdByDeviceId;
+  final Value<DateTime?> endAt;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const LocationsCompanion({
+    this.channelCid = const Value.absent(),
+    this.messageId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.latitude = const Value.absent(),
+    this.longitude = const Value.absent(),
+    this.createdByDeviceId = const Value.absent(),
+    this.endAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  LocationsCompanion.insert({
+    this.channelCid = const Value.absent(),
+    this.messageId = const Value.absent(),
+    this.userId = const Value.absent(),
+    required double latitude,
+    required double longitude,
+    required String createdByDeviceId,
+    this.endAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  })  : latitude = Value(latitude),
+        longitude = Value(longitude),
+        createdByDeviceId = Value(createdByDeviceId);
+  static Insertable<LocationEntity> custom({
+    Expression<String>? channelCid,
+    Expression<String>? messageId,
+    Expression<String>? userId,
+    Expression<double>? latitude,
+    Expression<double>? longitude,
+    Expression<String>? createdByDeviceId,
+    Expression<DateTime>? endAt,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (channelCid != null) 'channel_cid': channelCid,
+      if (messageId != null) 'message_id': messageId,
+      if (userId != null) 'user_id': userId,
+      if (latitude != null) 'latitude': latitude,
+      if (longitude != null) 'longitude': longitude,
+      if (createdByDeviceId != null) 'created_by_device_id': createdByDeviceId,
+      if (endAt != null) 'end_at': endAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  LocationsCompanion copyWith(
+      {Value<String?>? channelCid,
+      Value<String?>? messageId,
+      Value<String?>? userId,
+      Value<double>? latitude,
+      Value<double>? longitude,
+      Value<String>? createdByDeviceId,
+      Value<DateTime?>? endAt,
+      Value<DateTime>? createdAt,
+      Value<DateTime>? updatedAt,
+      Value<int>? rowid}) {
+    return LocationsCompanion(
+      channelCid: channelCid ?? this.channelCid,
+      messageId: messageId ?? this.messageId,
+      userId: userId ?? this.userId,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      createdByDeviceId: createdByDeviceId ?? this.createdByDeviceId,
+      endAt: endAt ?? this.endAt,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (channelCid.present) {
+      map['channel_cid'] = Variable<String>(channelCid.value);
+    }
+    if (messageId.present) {
+      map['message_id'] = Variable<String>(messageId.value);
+    }
+    if (userId.present) {
+      map['user_id'] = Variable<String>(userId.value);
+    }
+    if (latitude.present) {
+      map['latitude'] = Variable<double>(latitude.value);
+    }
+    if (longitude.present) {
+      map['longitude'] = Variable<double>(longitude.value);
+    }
+    if (createdByDeviceId.present) {
+      map['created_by_device_id'] = Variable<String>(createdByDeviceId.value);
+    }
+    if (endAt.present) {
+      map['end_at'] = Variable<DateTime>(endAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('LocationsCompanion(')
+          ..write('channelCid: $channelCid, ')
+          ..write('messageId: $messageId, ')
+          ..write('userId: $userId, ')
+          ..write('latitude: $latitude, ')
+          ..write('longitude: $longitude, ')
+          ..write('createdByDeviceId: $createdByDeviceId, ')
+          ..write('endAt: $endAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $PinnedMessagesTable extends PinnedMessages
     with TableInfo<$PinnedMessagesTable, PinnedMessageEntity> {
   @override
@@ -8355,6 +8833,7 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
   late final $ChannelsTable channels = $ChannelsTable(this);
   late final $MessagesTable messages = $MessagesTable(this);
   late final $DraftMessagesTable draftMessages = $DraftMessagesTable(this);
+  late final $LocationsTable locations = $LocationsTable(this);
   late final $PinnedMessagesTable pinnedMessages = $PinnedMessagesTable(this);
   late final $PollsTable polls = $PollsTable(this);
   late final $PollVotesTable pollVotes = $PollVotesTable(this);
@@ -8372,6 +8851,7 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
   late final MessageDao messageDao = MessageDao(this as DriftChatDatabase);
   late final DraftMessageDao draftMessageDao =
       DraftMessageDao(this as DriftChatDatabase);
+  late final LocationDao locationDao = LocationDao(this as DriftChatDatabase);
   late final PinnedMessageDao pinnedMessageDao =
       PinnedMessageDao(this as DriftChatDatabase);
   late final PinnedMessageReactionDao pinnedMessageReactionDao =
@@ -8393,6 +8873,7 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
         channels,
         messages,
         draftMessages,
+        locations,
         pinnedMessages,
         polls,
         pollVotes,
@@ -8426,6 +8907,20 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
                 limitUpdateKind: UpdateKind.delete),
             result: [
               TableUpdate('draft_messages', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('channels',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('locations', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('messages',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('locations', kind: UpdateKind.delete),
             ],
           ),
           WritePropagation(
@@ -8531,6 +9026,21 @@ final class $$ChannelsTableReferences
             (f) => f.channelCid.cid.sqlEquals($_itemColumn<String>('cid')!));
 
     final cache = $_typedResult.readTableOrNull(_draftMessagesRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
+
+  static MultiTypedResultKey<$LocationsTable, List<LocationEntity>>
+      _locationsRefsTable(_$DriftChatDatabase db) =>
+          MultiTypedResultKey.fromTable(db.locations,
+              aliasName: $_aliasNameGenerator(
+                  db.channels.cid, db.locations.channelCid));
+
+  $$LocationsTableProcessedTableManager get locationsRefs {
+    final manager = $$LocationsTableTableManager($_db, $_db.locations).filter(
+        (f) => f.channelCid.cid.sqlEquals($_itemColumn<String>('cid')!));
+
+    final cache = $_typedResult.readTableOrNull(_locationsRefsTable($_db));
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
@@ -8656,6 +9166,27 @@ class $$ChannelsTableFilterComposer
             $$DraftMessagesTableFilterComposer(
               $db: $db,
               $table: $db.draftMessages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
+  Expression<bool> locationsRefs(
+      Expression<bool> Function($$LocationsTableFilterComposer f) f) {
+    final $$LocationsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.cid,
+        referencedTable: $db.locations,
+        getReferencedColumn: (t) => t.channelCid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$LocationsTableFilterComposer(
+              $db: $db,
+              $table: $db.locations,
               $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
               joinBuilder: joinBuilder,
               $removeJoinBuilderFromRootComposer:
@@ -8850,6 +9381,27 @@ class $$ChannelsTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> locationsRefs<T extends Object>(
+      Expression<T> Function($$LocationsTableAnnotationComposer a) f) {
+    final $$LocationsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.cid,
+        referencedTable: $db.locations,
+        getReferencedColumn: (t) => t.channelCid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$LocationsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.locations,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
   Expression<T> membersRefs<T extends Object>(
       Expression<T> Function($$MembersTableAnnotationComposer a) f) {
     final $$MembersTableAnnotationComposer composer = $composerBuilder(
@@ -8907,6 +9459,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
     PrefetchHooks Function(
         {bool messagesRefs,
         bool draftMessagesRefs,
+        bool locationsRefs,
         bool membersRefs,
         bool readsRefs})> {
   $$ChannelsTableTableManager(_$DriftChatDatabase db, $ChannelsTable table)
@@ -8990,6 +9543,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
           prefetchHooksCallback: (
               {messagesRefs = false,
               draftMessagesRefs = false,
+              locationsRefs = false,
               membersRefs = false,
               readsRefs = false}) {
             return PrefetchHooks(
@@ -8997,6 +9551,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
               explicitlyWatchedTables: [
                 if (messagesRefs) db.messages,
                 if (draftMessagesRefs) db.draftMessages,
+                if (locationsRefs) db.locations,
                 if (membersRefs) db.members,
                 if (readsRefs) db.reads
               ],
@@ -9025,6 +9580,19 @@ class $$ChannelsTableTableManager extends RootTableManager<
                         managerFromTypedResult: (p0) =>
                             $$ChannelsTableReferences(db, table, p0)
                                 .draftMessagesRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.channelCid == item.cid),
+                        typedResults: items),
+                  if (locationsRefs)
+                    await $_getPrefetchedData<ChannelEntity, $ChannelsTable,
+                            LocationEntity>(
+                        currentTable: table,
+                        referencedTable:
+                            $$ChannelsTableReferences._locationsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$ChannelsTableReferences(db, table, p0)
+                                .locationsRefs,
                         referencedItemsForCurrentItem:
                             (item, referencedItems) => referencedItems
                                 .where((e) => e.channelCid == item.cid),
@@ -9075,6 +9643,7 @@ typedef $$ChannelsTableProcessedTableManager = ProcessedTableManager<
     PrefetchHooks Function(
         {bool messagesRefs,
         bool draftMessagesRefs,
+        bool locationsRefs,
         bool membersRefs,
         bool readsRefs})>;
 typedef $$MessagesTableCreateCompanionBuilder = MessagesCompanion Function({
@@ -9176,6 +9745,21 @@ final class $$MessagesTableReferences
         .filter((f) => f.parentId.id.sqlEquals($_itemColumn<String>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_draftMessagesRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
+
+  static MultiTypedResultKey<$LocationsTable, List<LocationEntity>>
+      _locationsRefsTable(_$DriftChatDatabase db) =>
+          MultiTypedResultKey.fromTable(db.locations,
+              aliasName:
+                  $_aliasNameGenerator(db.messages.id, db.locations.messageId));
+
+  $$LocationsTableProcessedTableManager get locationsRefs {
+    final manager = $$LocationsTableTableManager($_db, $_db.locations)
+        .filter((f) => f.messageId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_locationsRefsTable($_db));
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
@@ -9353,6 +9937,27 @@ class $$MessagesTableFilterComposer
             $$DraftMessagesTableFilterComposer(
               $db: $db,
               $table: $db.draftMessages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
+  Expression<bool> locationsRefs(
+      Expression<bool> Function($$LocationsTableFilterComposer f) f) {
+    final $$LocationsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.locations,
+        getReferencedColumn: (t) => t.messageId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$LocationsTableFilterComposer(
+              $db: $db,
+              $table: $db.locations,
               $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
               joinBuilder: joinBuilder,
               $removeJoinBuilderFromRootComposer:
@@ -9662,6 +10267,27 @@ class $$MessagesTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> locationsRefs<T extends Object>(
+      Expression<T> Function($$LocationsTableAnnotationComposer a) f) {
+    final $$LocationsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.locations,
+        getReferencedColumn: (t) => t.messageId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$LocationsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.locations,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
   Expression<T> reactionsRefs<T extends Object>(
       Expression<T> Function($$ReactionsTableAnnotationComposer a) f) {
     final $$ReactionsTableAnnotationComposer composer = $composerBuilder(
@@ -9696,7 +10322,10 @@ class $$MessagesTableTableManager extends RootTableManager<
     (MessageEntity, $$MessagesTableReferences),
     MessageEntity,
     PrefetchHooks Function(
-        {bool channelCid, bool draftMessagesRefs, bool reactionsRefs})> {
+        {bool channelCid,
+        bool draftMessagesRefs,
+        bool locationsRefs,
+        bool reactionsRefs})> {
   $$MessagesTableTableManager(_$DriftChatDatabase db, $MessagesTable table)
       : super(TableManagerState(
           db: db,
@@ -9852,11 +10481,13 @@ class $$MessagesTableTableManager extends RootTableManager<
           prefetchHooksCallback: (
               {channelCid = false,
               draftMessagesRefs = false,
+              locationsRefs = false,
               reactionsRefs = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [
                 if (draftMessagesRefs) db.draftMessages,
+                if (locationsRefs) db.locations,
                 if (reactionsRefs) db.reactions
               ],
               addJoins: <
@@ -9900,6 +10531,19 @@ class $$MessagesTableTableManager extends RootTableManager<
                                 referencedItems) =>
                             referencedItems.where((e) => e.parentId == item.id),
                         typedResults: items),
+                  if (locationsRefs)
+                    await $_getPrefetchedData<MessageEntity, $MessagesTable,
+                            LocationEntity>(
+                        currentTable: table,
+                        referencedTable:
+                            $$MessagesTableReferences._locationsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$MessagesTableReferences(db, table, p0)
+                                .locationsRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.messageId == item.id),
+                        typedResults: items),
                   if (reactionsRefs)
                     await $_getPrefetchedData<MessageEntity, $MessagesTable,
                             ReactionEntity>(
@@ -9932,7 +10576,10 @@ typedef $$MessagesTableProcessedTableManager = ProcessedTableManager<
     (MessageEntity, $$MessagesTableReferences),
     MessageEntity,
     PrefetchHooks Function(
-        {bool channelCid, bool draftMessagesRefs, bool reactionsRefs})>;
+        {bool channelCid,
+        bool draftMessagesRefs,
+        bool locationsRefs,
+        bool reactionsRefs})>;
 typedef $$DraftMessagesTableCreateCompanionBuilder = DraftMessagesCompanion
     Function({
   required String id,
@@ -10435,6 +11082,417 @@ typedef $$DraftMessagesTableProcessedTableManager = ProcessedTableManager<
     (DraftMessageEntity, $$DraftMessagesTableReferences),
     DraftMessageEntity,
     PrefetchHooks Function({bool parentId, bool channelCid})>;
+typedef $$LocationsTableCreateCompanionBuilder = LocationsCompanion Function({
+  Value<String?> channelCid,
+  Value<String?> messageId,
+  Value<String?> userId,
+  required double latitude,
+  required double longitude,
+  required String createdByDeviceId,
+  Value<DateTime?> endAt,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+  Value<int> rowid,
+});
+typedef $$LocationsTableUpdateCompanionBuilder = LocationsCompanion Function({
+  Value<String?> channelCid,
+  Value<String?> messageId,
+  Value<String?> userId,
+  Value<double> latitude,
+  Value<double> longitude,
+  Value<String> createdByDeviceId,
+  Value<DateTime?> endAt,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+  Value<int> rowid,
+});
+
+final class $$LocationsTableReferences extends BaseReferences<
+    _$DriftChatDatabase, $LocationsTable, LocationEntity> {
+  $$LocationsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $ChannelsTable _channelCidTable(_$DriftChatDatabase db) =>
+      db.channels.createAlias(
+          $_aliasNameGenerator(db.locations.channelCid, db.channels.cid));
+
+  $$ChannelsTableProcessedTableManager? get channelCid {
+    final $_column = $_itemColumn<String>('channel_cid');
+    if ($_column == null) return null;
+    final manager = $$ChannelsTableTableManager($_db, $_db.channels)
+        .filter((f) => f.cid.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_channelCidTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static $MessagesTable _messageIdTable(_$DriftChatDatabase db) =>
+      db.messages.createAlias(
+          $_aliasNameGenerator(db.locations.messageId, db.messages.id));
+
+  $$MessagesTableProcessedTableManager? get messageId {
+    final $_column = $_itemColumn<String>('message_id');
+    if ($_column == null) return null;
+    final manager = $$MessagesTableTableManager($_db, $_db.messages)
+        .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_messageIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+}
+
+class $$LocationsTableFilterComposer
+    extends Composer<_$DriftChatDatabase, $LocationsTable> {
+  $$LocationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get userId => $composableBuilder(
+      column: $table.userId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get latitude => $composableBuilder(
+      column: $table.latitude, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get longitude => $composableBuilder(
+      column: $table.longitude, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get createdByDeviceId => $composableBuilder(
+      column: $table.createdByDeviceId,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get endAt => $composableBuilder(
+      column: $table.endAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  $$ChannelsTableFilterComposer get channelCid {
+    final $$ChannelsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.channelCid,
+        referencedTable: $db.channels,
+        getReferencedColumn: (t) => t.cid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$ChannelsTableFilterComposer(
+              $db: $db,
+              $table: $db.channels,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MessagesTableFilterComposer get messageId {
+    final $$MessagesTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.messageId,
+        referencedTable: $db.messages,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MessagesTableFilterComposer(
+              $db: $db,
+              $table: $db.messages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$LocationsTableOrderingComposer
+    extends Composer<_$DriftChatDatabase, $LocationsTable> {
+  $$LocationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get userId => $composableBuilder(
+      column: $table.userId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get latitude => $composableBuilder(
+      column: $table.latitude, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get longitude => $composableBuilder(
+      column: $table.longitude, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get createdByDeviceId => $composableBuilder(
+      column: $table.createdByDeviceId,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get endAt => $composableBuilder(
+      column: $table.endAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  $$ChannelsTableOrderingComposer get channelCid {
+    final $$ChannelsTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.channelCid,
+        referencedTable: $db.channels,
+        getReferencedColumn: (t) => t.cid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$ChannelsTableOrderingComposer(
+              $db: $db,
+              $table: $db.channels,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MessagesTableOrderingComposer get messageId {
+    final $$MessagesTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.messageId,
+        referencedTable: $db.messages,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MessagesTableOrderingComposer(
+              $db: $db,
+              $table: $db.messages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$LocationsTableAnnotationComposer
+    extends Composer<_$DriftChatDatabase, $LocationsTable> {
+  $$LocationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get userId =>
+      $composableBuilder(column: $table.userId, builder: (column) => column);
+
+  GeneratedColumn<double> get latitude =>
+      $composableBuilder(column: $table.latitude, builder: (column) => column);
+
+  GeneratedColumn<double> get longitude =>
+      $composableBuilder(column: $table.longitude, builder: (column) => column);
+
+  GeneratedColumn<String> get createdByDeviceId => $composableBuilder(
+      column: $table.createdByDeviceId, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get endAt =>
+      $composableBuilder(column: $table.endAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$ChannelsTableAnnotationComposer get channelCid {
+    final $$ChannelsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.channelCid,
+        referencedTable: $db.channels,
+        getReferencedColumn: (t) => t.cid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$ChannelsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.channels,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MessagesTableAnnotationComposer get messageId {
+    final $$MessagesTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.messageId,
+        referencedTable: $db.messages,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MessagesTableAnnotationComposer(
+              $db: $db,
+              $table: $db.messages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$LocationsTableTableManager extends RootTableManager<
+    _$DriftChatDatabase,
+    $LocationsTable,
+    LocationEntity,
+    $$LocationsTableFilterComposer,
+    $$LocationsTableOrderingComposer,
+    $$LocationsTableAnnotationComposer,
+    $$LocationsTableCreateCompanionBuilder,
+    $$LocationsTableUpdateCompanionBuilder,
+    (LocationEntity, $$LocationsTableReferences),
+    LocationEntity,
+    PrefetchHooks Function({bool channelCid, bool messageId})> {
+  $$LocationsTableTableManager(_$DriftChatDatabase db, $LocationsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$LocationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$LocationsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$LocationsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<String?> channelCid = const Value.absent(),
+            Value<String?> messageId = const Value.absent(),
+            Value<String?> userId = const Value.absent(),
+            Value<double> latitude = const Value.absent(),
+            Value<double> longitude = const Value.absent(),
+            Value<String> createdByDeviceId = const Value.absent(),
+            Value<DateTime?> endAt = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LocationsCompanion(
+            channelCid: channelCid,
+            messageId: messageId,
+            userId: userId,
+            latitude: latitude,
+            longitude: longitude,
+            createdByDeviceId: createdByDeviceId,
+            endAt: endAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            Value<String?> channelCid = const Value.absent(),
+            Value<String?> messageId = const Value.absent(),
+            Value<String?> userId = const Value.absent(),
+            required double latitude,
+            required double longitude,
+            required String createdByDeviceId,
+            Value<DateTime?> endAt = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LocationsCompanion.insert(
+            channelCid: channelCid,
+            messageId: messageId,
+            userId: userId,
+            latitude: latitude,
+            longitude: longitude,
+            createdByDeviceId: createdByDeviceId,
+            endAt: endAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$LocationsTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({channelCid = false, messageId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (channelCid) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.channelCid,
+                    referencedTable:
+                        $$LocationsTableReferences._channelCidTable(db),
+                    referencedColumn:
+                        $$LocationsTableReferences._channelCidTable(db).cid,
+                  ) as T;
+                }
+                if (messageId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.messageId,
+                    referencedTable:
+                        $$LocationsTableReferences._messageIdTable(db),
+                    referencedColumn:
+                        $$LocationsTableReferences._messageIdTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ));
+}
+
+typedef $$LocationsTableProcessedTableManager = ProcessedTableManager<
+    _$DriftChatDatabase,
+    $LocationsTable,
+    LocationEntity,
+    $$LocationsTableFilterComposer,
+    $$LocationsTableOrderingComposer,
+    $$LocationsTableAnnotationComposer,
+    $$LocationsTableCreateCompanionBuilder,
+    $$LocationsTableUpdateCompanionBuilder,
+    (LocationEntity, $$LocationsTableReferences),
+    LocationEntity,
+    PrefetchHooks Function({bool channelCid, bool messageId})>;
 typedef $$PinnedMessagesTableCreateCompanionBuilder = PinnedMessagesCompanion
     Function({
   required String id,
@@ -13772,6 +14830,8 @@ class $DriftChatDatabaseManager {
       $$MessagesTableTableManager(_db, _db.messages);
   $$DraftMessagesTableTableManager get draftMessages =>
       $$DraftMessagesTableTableManager(_db, _db.draftMessages);
+  $$LocationsTableTableManager get locations =>
+      $$LocationsTableTableManager(_db, _db.locations);
   $$PinnedMessagesTableTableManager get pinnedMessages =>
       $$PinnedMessagesTableTableManager(_db, _db.pinnedMessages);
   $$PollsTableTableManager get polls =>

--- a/packages/stream_chat_persistence/lib/src/entity/entity.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/entity.dart
@@ -2,6 +2,7 @@ export 'channel_queries.dart';
 export 'channels.dart';
 export 'connection_events.dart';
 export 'draft_messages.dart';
+export 'locations.dart';
 export 'members.dart';
 export 'messages.dart';
 export 'pinned_message_reactions.dart';

--- a/packages/stream_chat_persistence/lib/src/entity/locations.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/locations.dart
@@ -1,0 +1,43 @@
+// coverage:ignore-file
+import 'package:drift/drift.dart';
+import 'package:stream_chat_persistence/src/entity/channels.dart';
+import 'package:stream_chat_persistence/src/entity/messages.dart';
+
+/// Represents a [Locations] table in [DriftChatDatabase].
+@DataClassName('LocationEntity')
+class Locations extends Table {
+  /// The channel CID where the location is shared
+  TextColumn get channelCid => text()
+      .nullable()
+      .references(Channels, #cid, onDelete: KeyAction.cascade)();
+
+  /// The ID of the message that contains this shared location
+  TextColumn get messageId => text()
+      .nullable()
+      .references(Messages, #id, onDelete: KeyAction.cascade)();
+
+  /// The ID of the user who shared the location
+  TextColumn get userId => text().nullable()();
+
+  /// The latitude of the shared location
+  RealColumn get latitude => real()();
+
+  /// The longitude of the shared location
+  RealColumn get longitude => real()();
+
+  /// The ID of the device that created the location
+  TextColumn get createdByDeviceId => text()();
+
+  /// The date at which the shared location will end (for live locations)
+  /// If null, this is a static location
+  DateTimeColumn get endAt => dateTime().nullable()();
+
+  /// The date at which the location was created
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+
+  /// The date at which the location was last updated
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column> get primaryKey => {messageId};
+}

--- a/packages/stream_chat_persistence/lib/src/mapper/location_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/location_mapper.dart
@@ -1,0 +1,40 @@
+import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_persistence/src/db/drift_chat_database.dart';
+
+/// Useful mapping functions for [LocationEntity]
+extension LocationEntityX on LocationEntity {
+  /// Maps a [LocationEntity] into [Location]
+  Location toLocation({
+    ChannelModel? channel,
+    Message? message,
+  }) =>
+      Location(
+        channelCid: channelCid,
+        channel: channel,
+        messageId: messageId,
+        message: message,
+        userId: userId,
+        latitude: latitude,
+        longitude: longitude,
+        createdByDeviceId: createdByDeviceId,
+        endAt: endAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+}
+
+/// Useful mapping functions for [Location]
+extension LocationX on Location {
+  /// Maps a [Location] into [LocationEntity]
+  LocationEntity toEntity() => LocationEntity(
+        channelCid: channelCid,
+        messageId: messageId,
+        userId: userId,
+        latitude: latitude,
+        longitude: longitude,
+        createdByDeviceId: createdByDeviceId,
+        endAt: endAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+}

--- a/packages/stream_chat_persistence/lib/src/mapper/mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/mapper.dart
@@ -1,6 +1,7 @@
 export 'channel_mapper.dart';
 export 'draft_message_mapper.dart';
 export 'event_mapper.dart';
+export 'location_mapper.dart';
 export 'member_mapper.dart';
 export 'message_mapper.dart';
 export 'pinned_message_mapper.dart';

--- a/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
@@ -14,6 +14,7 @@ extension MessageEntityX on MessageEntity {
     Message? quotedMessage,
     Poll? poll,
     Draft? draft,
+    Location? sharedLocation,
   }) =>
       Message(
         shadowed: shadowed,
@@ -54,6 +55,7 @@ extension MessageEntityX on MessageEntity {
         i18n: i18n,
         restrictedVisibility: restrictedVisibility,
         draft: draft,
+        sharedLocation: sharedLocation,
       );
 }
 

--- a/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
@@ -13,6 +13,8 @@ extension PinnedMessageEntityX on PinnedMessageEntity {
     List<Reaction>? ownReactions,
     Message? quotedMessage,
     Poll? poll,
+    Draft? draft,
+    Location? sharedLocation,
   }) =>
       Message(
         shadowed: shadowed,
@@ -52,6 +54,8 @@ extension PinnedMessageEntityX on PinnedMessageEntity {
             mentionedUsers.map((e) => User.fromJson(jsonDecode(e))).toList(),
         i18n: i18n,
         restrictedVisibility: restrictedVisibility,
+        draft: draft,
+        sharedLocation: sharedLocation,
       );
 }
 
@@ -90,5 +94,6 @@ extension PMessageX on Message {
         pinnedByUserId: pinnedBy?.id,
         i18n: i18n,
         restrictedVisibility: restrictedVisibility,
+        draftMessageId: draft?.message.id,
       );
 }

--- a/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
+++ b/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
@@ -225,6 +225,20 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
   }
 
   @override
+  Future<List<Location>> getLocationsByCid(String cid) async {
+    assert(_debugIsConnected, '');
+    _logger.info('getLocationsByCid');
+    return db!.locationDao.getLocationsByCid(cid);
+  }
+
+  @override
+  Future<Location?> getLocationByMessageId(String messageId) async {
+    assert(_debugIsConnected, '');
+    _logger.info('getLocationByMessageId');
+    return db!.locationDao.getLocationByMessageId(messageId);
+  }
+
+  @override
   Future<List<Read>> getReadsByCid(String cid) async {
     assert(_debugIsConnected, '');
     _logger.info('getReadsByCid');
@@ -395,6 +409,13 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
   }
 
   @override
+  Future<void> updateLocations(List<Location> locations) async {
+    assert(_debugIsConnected, '');
+    _logger.info('updateLocations');
+    return db!.locationDao.updateLocations(locations);
+  }
+
+  @override
   Future<void> deletePinnedMessageReactionsByMessageId(
     List<String> messageIds,
   ) {
@@ -435,6 +456,20 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
       cid,
       parentId: parentId,
     );
+  }
+
+  @override
+  Future<void> deleteLocationsByCid(String cid) {
+    assert(_debugIsConnected, '');
+    _logger.info('deleteLocationsByCid');
+    return db!.locationDao.deleteLocationsByCid(cid);
+  }
+
+  @override
+  Future<void> deleteLocationsByMessageIds(List<String> messageIds) {
+    assert(_debugIsConnected, '');
+    _logger.info('deleteLocationsByMessageIds');
+    return db!.locationDao.deleteLocationsByMessageIds(messageIds);
   }
 
   @override

--- a/packages/stream_chat_persistence/test/mock_chat_database.dart
+++ b/packages/stream_chat_persistence/test/mock_chat_database.dart
@@ -64,6 +64,10 @@ class MockChatDatabase extends Mock implements DriftChatDatabase {
   DraftMessageDao? _draftMessageDao;
 
   @override
+  LocationDao get locationDao => _locationDao ??= MockLocationDao();
+  LocationDao? _locationDao;
+
+  @override
   Future<void> flush() => Future.value();
 
   @override
@@ -96,3 +100,5 @@ class MockPollDao extends Mock implements PollDao {}
 class MockPollVoteDao extends Mock implements PollVoteDao {}
 
 class MockDraftMessageDao extends Mock implements DraftMessageDao {}
+
+class MockLocationDao extends Mock implements LocationDao {}

--- a/packages/stream_chat_persistence/test/src/dao/location_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/location_dao_test.dart
@@ -1,0 +1,316 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_persistence/src/dao/dao.dart';
+import 'package:stream_chat_persistence/src/db/drift_chat_database.dart';
+
+import '../../stream_chat_persistence_client_test.dart';
+
+void main() {
+  late LocationDao locationDao;
+  late DriftChatDatabase database;
+
+  setUp(() {
+    database = testDatabaseProvider('testUserId');
+    locationDao = database.locationDao;
+  });
+
+  Future<List<Location>> _prepareLocationData({
+    String cid = 'test:Cid',
+    int count = 3,
+  }) async {
+    final channels = [ChannelModel(cid: cid)];
+    final users = List.generate(count, (index) => User(id: 'testUserId$index'));
+    final messages = List.generate(
+      count,
+      (index) => Message(
+        id: 'testMessageId$cid$index',
+        type: 'testType',
+        user: users[index],
+        createdAt: DateTime.now(),
+        text: 'Test message #$index',
+      ),
+    );
+
+    final locations = List.generate(
+      count,
+      (index) => Location(
+        channelCid: cid,
+        messageId: messages[index].id,
+        userId: users[index].id,
+        latitude: 37.7749 + index * 0.001, // San Francisco area
+        longitude: -122.4194 + index * 0.001,
+        createdByDeviceId: 'testDevice$index',
+        endAt: index % 2 == 0
+            ? DateTime.now().add(Duration(hours: 1))
+            : null, // Some live, some static
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+
+    await database.userDao.updateUsers(users);
+    await database.channelDao.updateChannels(channels);
+    await database.messageDao.updateMessages(cid, messages);
+    await locationDao.updateLocations(locations);
+
+    return locations;
+  }
+
+  test('getLocationsByCid', () async {
+    const cid = 'test:Cid';
+
+    // Should be empty initially
+    final locations = await locationDao.getLocationsByCid(cid);
+    expect(locations, isEmpty);
+
+    // Adding sample locations
+    final insertedLocations = await _prepareLocationData(cid: cid);
+    expect(insertedLocations, isNotEmpty);
+
+    // Fetched locations length should match inserted locations length
+    final fetchedLocations = await locationDao.getLocationsByCid(cid);
+    expect(fetchedLocations.length, insertedLocations.length);
+
+    // Every location channelCid should match the provided cid
+    expect(fetchedLocations.every((it) => it.channelCid == cid), true);
+  });
+
+  test('updateLocations', () async {
+    const cid = 'test:Cid';
+
+    // Preparing test data
+    final insertedLocations = await _prepareLocationData(cid: cid);
+
+    // Adding a new location
+    final newUser = User(id: 'newUserId');
+    final newMessage = Message(
+      id: 'newMessageId',
+      type: 'testType',
+      user: newUser,
+      createdAt: DateTime.now(),
+      text: 'New test message',
+    );
+    final newLocation = Location(
+      channelCid: cid,
+      messageId: newMessage.id,
+      userId: newUser.id,
+      latitude: 40.7128, // New York
+      longitude: -74.0060,
+      createdByDeviceId: 'newDevice',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    await database.userDao.updateUsers([newUser]);
+    await database.messageDao.updateMessages(cid, [newMessage]);
+    await locationDao.updateLocations([newLocation]);
+
+    // Fetched locations length should be one more than inserted locations
+    // Fetched locations should contain the newLocation
+    final fetchedLocations = await locationDao.getLocationsByCid(cid);
+    expect(fetchedLocations.length, insertedLocations.length + 1);
+    expect(
+      fetchedLocations.any((it) =>
+          it.messageId == newLocation.messageId &&
+          it.latitude == newLocation.latitude &&
+          it.longitude == newLocation.longitude),
+      isTrue,
+    );
+  });
+
+  test('getLocationByMessageId', () async {
+    const cid = 'test:Cid';
+
+    // Preparing test data
+    final insertedLocations = await _prepareLocationData(cid: cid);
+
+    // Fetched location should not be null
+    final locationToFetch = insertedLocations.first;
+    final fetchedLocation =
+        await locationDao.getLocationByMessageId(locationToFetch.messageId!);
+    expect(fetchedLocation, isNotNull);
+    expect(fetchedLocation!.messageId, locationToFetch.messageId);
+    expect(fetchedLocation.latitude, locationToFetch.latitude);
+    expect(fetchedLocation.longitude, locationToFetch.longitude);
+  });
+
+  test(
+    'getLocationByMessageId should return null for non-existent messageId',
+    () async {
+      // Should return null for non-existent messageId
+      final fetchedLocation =
+          await locationDao.getLocationByMessageId('nonExistentMessageId');
+      expect(fetchedLocation, isNull);
+    },
+  );
+
+  test('deleteLocationsByCid', () async {
+    const cid = 'test:Cid';
+
+    // Preparing test data
+    final insertedLocations = await _prepareLocationData(cid: cid);
+
+    // Verify locations exist
+    final locationsBeforeDelete = await locationDao.getLocationsByCid(cid);
+    expect(locationsBeforeDelete.length, insertedLocations.length);
+
+    // Deleting all locations for the channel
+    await locationDao.deleteLocationsByCid(cid);
+
+    // Fetched location list should be empty
+    final fetchedLocations = await locationDao.getLocationsByCid(cid);
+    expect(fetchedLocations, isEmpty);
+  });
+
+  test('deleteLocationsByMessageIds', () async {
+    const cid = 'test:Cid';
+
+    // Preparing test data
+    final insertedLocations = await _prepareLocationData(cid: cid);
+
+    // Deleting the first two locations by their message IDs
+    final messageIdsToDelete =
+        insertedLocations.take(2).map((it) => it.messageId!).toList();
+    await locationDao.deleteLocationsByMessageIds(messageIdsToDelete);
+
+    // Fetched location list should be one less than inserted locations
+    final fetchedLocations = await locationDao.getLocationsByCid(cid);
+    expect(fetchedLocations.length,
+        insertedLocations.length - messageIdsToDelete.length);
+
+    // Deleted locations should not exist in fetched locations
+    expect(
+      fetchedLocations.any((it) => messageIdsToDelete.contains(it.messageId)),
+      isFalse,
+    );
+  });
+
+  group('deleteLocationsByMessageIds', () {
+    test('should delete locations for specific message IDs only', () async {
+      const cid1 = 'test:Cid1';
+      const cid2 = 'test:Cid2';
+
+      // Preparing test data for two channels
+      final insertedLocations1 =
+          await _prepareLocationData(cid: cid1, count: 2);
+      final insertedLocations2 =
+          await _prepareLocationData(cid: cid2, count: 2);
+
+      // Verify all locations exist
+      final locations1 = await locationDao.getLocationsByCid(cid1);
+      final locations2 = await locationDao.getLocationsByCid(cid2);
+      expect(locations1.length, insertedLocations1.length);
+      expect(locations2.length, insertedLocations2.length);
+
+      // Delete only locations from the first channel
+      final messageIdsToDelete =
+          insertedLocations1.map((it) => it.messageId!).toList();
+      await locationDao.deleteLocationsByMessageIds(messageIdsToDelete);
+
+      // Only locations from cid1 should be deleted
+      final fetchedLocations1 = await locationDao.getLocationsByCid(cid1);
+      final fetchedLocations2 = await locationDao.getLocationsByCid(cid2);
+      expect(fetchedLocations1, isEmpty);
+      expect(fetchedLocations2.length, insertedLocations2.length);
+    });
+  });
+
+  group('Location entity references', () {
+    test(
+      'should delete locations when referenced channel is deleted',
+      () async {
+        const cid = 'test:channelRefCascade';
+
+        // Prepare test data
+        await _prepareLocationData(cid: cid, count: 2);
+
+        // Verify locations exist before channel deletion
+        final locationsBeforeDelete = await locationDao.getLocationsByCid(cid);
+        expect(locationsBeforeDelete, isNotEmpty);
+        expect(locationsBeforeDelete.length, 2);
+
+        // Delete the channel
+        await database.channelDao.deleteChannelByCids([cid]);
+
+        // Verify locations have been deleted (cascade)
+        final locationsAfterDelete = await locationDao.getLocationsByCid(cid);
+        expect(locationsAfterDelete, isEmpty);
+      },
+    );
+
+    test(
+      'should delete locations when referenced message is deleted',
+      () async {
+        const cid = 'test:messageRefCascade';
+
+        // Prepare test data
+        final insertedLocations =
+            await _prepareLocationData(cid: cid, count: 3);
+        final messageToDelete = insertedLocations.first.messageId!;
+
+        // Verify location exists before message deletion
+        final locationBeforeDelete =
+            await locationDao.getLocationByMessageId(messageToDelete);
+        expect(locationBeforeDelete, isNotNull);
+        expect(locationBeforeDelete!.messageId, messageToDelete);
+
+        // Verify all locations exist
+        final allLocationsBeforeDelete =
+            await locationDao.getLocationsByCid(cid);
+        expect(allLocationsBeforeDelete.length, 3);
+
+        // Delete the message
+        await database.messageDao.deleteMessageByIds([messageToDelete]);
+
+        // Verify the specific location has been deleted (cascade)
+        final locationAfterDelete =
+            await locationDao.getLocationByMessageId(messageToDelete);
+        expect(locationAfterDelete, isNull);
+
+        // Verify other locations still exist
+        final allLocationsAfterDelete =
+            await locationDao.getLocationsByCid(cid);
+        expect(allLocationsAfterDelete.length, 2);
+        expect(
+          allLocationsAfterDelete.any((it) => it.messageId == messageToDelete),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'should delete all locations when multiple messages are deleted',
+      () async {
+        const cid = 'test:multipleMessageRefCascade';
+
+        // Prepare test data
+        final insertedLocations =
+            await _prepareLocationData(cid: cid, count: 3);
+        final messageIdsToDelete =
+            insertedLocations.take(2).map((it) => it.messageId!).toList();
+
+        // Verify locations exist before message deletion
+        final allLocationsBeforeDelete =
+            await locationDao.getLocationsByCid(cid);
+        expect(allLocationsBeforeDelete.length, 3);
+
+        // Delete multiple messages
+        await database.messageDao.deleteMessageByIds(messageIdsToDelete);
+
+        // Verify corresponding locations have been deleted (cascade)
+        final allLocationsAfterDelete =
+            await locationDao.getLocationsByCid(cid);
+        expect(allLocationsAfterDelete.length, 1);
+        expect(
+          allLocationsAfterDelete
+              .any((it) => messageIdsToDelete.contains(it.messageId)),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  tearDown(() async {
+    await database.disconnect();
+  });
+}

--- a/packages/stream_chat_persistence/test/src/mapper/location_mapper_test.dart
+++ b/packages/stream_chat_persistence/test/src/mapper/location_mapper_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat/stream_chat.dart';
+import 'package:stream_chat_persistence/src/db/drift_chat_database.dart';
+import 'package:stream_chat_persistence/src/mapper/location_mapper.dart';
+
+void main() {
+  group('LocationMapper', () {
+    test('toLocation should map the entity into Location', () {
+      final createdAt = DateTime.now();
+      final updatedAt = DateTime.now();
+      final endAt = DateTime.now().add(const Duration(hours: 1));
+
+      final entity = LocationEntity(
+        channelCid: 'testCid',
+        userId: 'testUserId',
+        messageId: 'testMessageId',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        createdByDeviceId: 'testDeviceId',
+        endAt: endAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      final location = entity.toLocation();
+
+      expect(location, isA<Location>());
+      expect(location.channelCid, entity.channelCid);
+      expect(location.userId, entity.userId);
+      expect(location.messageId, entity.messageId);
+      expect(location.latitude, entity.latitude);
+      expect(location.longitude, entity.longitude);
+      expect(location.createdByDeviceId, entity.createdByDeviceId);
+      expect(location.endAt, entity.endAt);
+      expect(location.createdAt, entity.createdAt);
+      expect(location.updatedAt, entity.updatedAt);
+    });
+
+    test('toEntity should map the Location into LocationEntity', () {
+      final createdAt = DateTime.now();
+      final updatedAt = DateTime.now();
+      final endAt = DateTime.now().add(const Duration(hours: 1));
+
+      final location = Location(
+        channelCid: 'testCid',
+        userId: 'testUserId',
+        messageId: 'testMessageId',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        createdByDeviceId: 'testDeviceId',
+        endAt: endAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      final entity = location.toEntity();
+
+      expect(entity, isA<LocationEntity>());
+      expect(entity.channelCid, location.channelCid);
+      expect(entity.userId, location.userId);
+      expect(entity.messageId, location.messageId);
+      expect(entity.latitude, location.latitude);
+      expect(entity.longitude, location.longitude);
+      expect(entity.createdByDeviceId, location.createdByDeviceId);
+      expect(entity.endAt, location.endAt);
+      expect(entity.createdAt, location.createdAt);
+      expect(entity.updatedAt, location.updatedAt);
+    });
+
+    test('roundtrip conversion should preserve data', () {
+      final createdAt = DateTime.now();
+      final updatedAt = DateTime.now();
+      final endAt = DateTime.now().add(const Duration(hours: 1));
+
+      final originalLocation = Location(
+        channelCid: 'testCid',
+        userId: 'testUserId',
+        messageId: 'testMessageId',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        createdByDeviceId: 'testDeviceId',
+        endAt: endAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      final entity = originalLocation.toEntity();
+      final convertedLocation = entity.toLocation();
+
+      expect(convertedLocation.channelCid, originalLocation.channelCid);
+      expect(convertedLocation.userId, originalLocation.userId);
+      expect(convertedLocation.messageId, originalLocation.messageId);
+      expect(convertedLocation.latitude, originalLocation.latitude);
+      expect(convertedLocation.longitude, originalLocation.longitude);
+      expect(convertedLocation.createdByDeviceId,
+          originalLocation.createdByDeviceId);
+      expect(convertedLocation.endAt, originalLocation.endAt);
+      expect(convertedLocation.createdAt, originalLocation.createdAt);
+      expect(convertedLocation.updatedAt, originalLocation.updatedAt);
+    });
+
+    test('should handle live location conversion', () {
+      final endAt = DateTime.now().add(const Duration(hours: 1));
+      final location = Location(
+        channelCid: 'testCid',
+        userId: 'testUserId',
+        messageId: 'testMessageId',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        createdByDeviceId: 'testDeviceId',
+        endAt: endAt,
+      );
+
+      final entity = location.toEntity();
+      final convertedLocation = entity.toLocation();
+
+      expect(convertedLocation.isLive, isTrue);
+      expect(convertedLocation.isStatic, isFalse);
+      expect(convertedLocation.endAt, endAt);
+    });
+
+    test('should handle static location conversion', () {
+      final location = Location(
+        channelCid: 'testCid',
+        userId: 'testUserId',
+        messageId: 'testMessageId',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        createdByDeviceId: 'testDeviceId',
+        // No endAt = static location
+      );
+
+      final entity = location.toEntity();
+      final convertedLocation = entity.toLocation();
+
+      expect(convertedLocation.isLive, isFalse);
+      expect(convertedLocation.isStatic, isTrue);
+      expect(convertedLocation.endAt, isNull);
+    });
+  });
+}

--- a/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
+++ b/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
@@ -689,6 +689,96 @@ void main() {
           .deleteDraftMessageByCid(cid, parentId: parentId)).called(1);
     });
 
+    test('getLocationsByCid', () async {
+      const cid = 'testCid';
+      final locations = List.generate(
+        3,
+        (index) => Location(
+          channelCid: cid,
+          messageId: 'testMessageId$index',
+          userId: 'testUserId$index',
+          latitude: 37.7749 + index * 0.001,
+          longitude: -122.4194 + index * 0.001,
+          createdByDeviceId: 'testDevice$index',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      when(() => mockDatabase.locationDao.getLocationsByCid(cid))
+          .thenAnswer((_) async => locations);
+
+      final fetchedLocations = await client.getLocationsByCid(cid);
+      expect(fetchedLocations.length, locations.length);
+      verify(() => mockDatabase.locationDao.getLocationsByCid(cid)).called(1);
+    });
+
+    test('getLocationByMessageId', () async {
+      const messageId = 'testMessageId';
+      final location = Location(
+        channelCid: 'testCid',
+        messageId: messageId,
+        userId: 'testUserId',
+        latitude: 37.7749,
+        longitude: -122.4194,
+        createdByDeviceId: 'testDevice',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      );
+
+      when(() => mockDatabase.locationDao.getLocationByMessageId(messageId))
+          .thenAnswer((_) async => location);
+
+      final fetchedLocation = await client.getLocationByMessageId(messageId);
+      expect(fetchedLocation, isNotNull);
+      expect(fetchedLocation!.messageId, messageId);
+      verify(() => mockDatabase.locationDao.getLocationByMessageId(messageId))
+          .called(1);
+    });
+
+    test('updateLocations', () async {
+      final locations = List.generate(
+        3,
+        (index) => Location(
+          channelCid: 'testCid$index',
+          messageId: 'testMessageId$index',
+          userId: 'testUserId$index',
+          latitude: 37.7749 + index * 0.001,
+          longitude: -122.4194 + index * 0.001,
+          createdByDeviceId: 'testDevice$index',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      when(() => mockDatabase.locationDao.updateLocations(locations))
+          .thenAnswer((_) async {});
+
+      await client.updateLocations(locations);
+      verify(() => mockDatabase.locationDao.updateLocations(locations))
+          .called(1);
+    });
+
+    test('deleteLocationsByCid', () async {
+      const cid = 'testCid';
+      when(() => mockDatabase.locationDao.deleteLocationsByCid(cid))
+          .thenAnswer((_) async {});
+
+      await client.deleteLocationsByCid(cid);
+      verify(() => mockDatabase.locationDao.deleteLocationsByCid(cid))
+          .called(1);
+    });
+
+    test('deleteLocationsByMessageIds', () async {
+      final messageIds = <String>['testMessageId1', 'testMessageId2'];
+      when(() => mockDatabase.locationDao.deleteLocationsByMessageIds(messageIds))
+          .thenAnswer((_) async {});
+
+      await client.deleteLocationsByMessageIds(messageIds);
+      verify(() => mockDatabase.locationDao.deleteLocationsByMessageIds(messageIds))
+          .called(1);
+    });
+
     tearDown(() async {
       await client.disconnect(flush: true);
     });


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-198

## Description of the pull request
Adds support for `Location` entity in the database.

Adds new methods in `ChatPersistenceClient`:
- `getLocationsByCid`
- `getLocationByMessageId`
- `updateLocations`
- `deleteLocationsByCid`
- `deleteLocationsByMessageIds`

Updates `Message` and `PinnedMessage` mappers to include `sharedLocation`.