### PR TITLE
fix(llc, persistence): fix draft message persistence and retrieval issues

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -3,6 +3,8 @@
 🐞 Fixed
 
 - Fixed `WebSocket` race condition where reconnection could access null user during disconnect.
+- Fixed draft message persistence issues where removed drafts were not properly deleted from the
+  database.
 
 ## 9.14.0
 
@@ -47,6 +49,7 @@
   `message.reactionGroups`.
 
 🐞 Fixed
+
 - `Null check operator used on a null value` in Websocket connect.
 - Ensure query cache is cleared when refreshing channel queries.
 
@@ -54,7 +57,8 @@
 
 🐞 Fixed
 
-- [[#2013]](https://github.com/GetStream/stream-chat-flutter/issues/2013) Fix pinned message get duplicated.
+- [[#2013]](https://github.com/GetStream/stream-chat-flutter/issues/2013) Fix pinned message get
+  duplicated.
 
 🔄 Changed
 
@@ -102,9 +106,10 @@
 - Added support for message moderation feature.
 
 - Improved user blocking functionality by updating client state when blocking/unblocking users:
-  - `client.blockUser` now updates `currentUser.blockedUserIds` list with newly blocked user IDs.
-  - `client.unblockUser` now removes the unblocked user ID from `currentUser.blockedUserIds` list.
-  - `client.queryBlockedUsers` now updates `currentUser.blockedUserIds` with the latest blocked users data.
+    - `client.blockUser` now updates `currentUser.blockedUserIds` list with newly blocked user IDs.
+    - `client.unblockUser` now removes the unblocked user ID from `currentUser.blockedUserIds` list.
+    - `client.queryBlockedUsers` now updates `currentUser.blockedUserIds` with the latest blocked
+      users data.
 
 🐞 Fixed
 
@@ -122,24 +127,30 @@
 
 🐞 Fixed
 
-- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message order.
+- [[#1775]](https://github.com/GetStream/stream-chat-flutter/issues/1775) Fix incorrect message
+  order.
 
 ## 9.5.0
 
 ✅ Added
 
-- [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system messages not updating `channel.lastMessageAt`.
+- [[#2101]](https://github.com/GetStream/stream-chat-flutter/issues/2101) Added support for system
+  messages not updating `channel.lastMessageAt`.
 - Added support for sending private or restricted visibility messages.
 - Add `member.extraData` field.
 
 🐞 Fixed
 
-- [[#1774]](https://github.com/GetStream/stream-chat-flutter/issues/1774) Fixed failed to execute 'close' on 'WebSocket'.
-- [[#2016]](https://github.com/GetStream/stream-chat-flutter/issues/2016) Fix muted channel's unreadCount incorrectly updated.
-  
+- [[#1774]](https://github.com/GetStream/stream-chat-flutter/issues/1774) Fixed failed to execute '
+  close' on 'WebSocket'.
+- [[#2016]](https://github.com/GetStream/stream-chat-flutter/issues/2016) Fix muted channel's
+  unreadCount incorrectly updated.
+
 🔄 Changed
 
-- Refactored identifying the `Attachment.uploadState` logic for local and remote attachments. Also updated the logic for determining the attachment type to check for ogScrapeUrl instead of `AttachmentType.giphy`.
+- Refactored identifying the `Attachment.uploadState` logic for local and remote attachments. Also
+  updated the logic for determining the attachment type to check for ogScrapeUrl instead of
+  `AttachmentType.giphy`.
 - Improved the `x-stream-client` header generation for better client identification and analytics.
 
 ## 9.4.0
@@ -247,7 +258,7 @@
 
 🐞 Fixed
 
-- [[#1837]](https://github.com/GetStream/stream-chat-flutter/issues/1837) Delete image and file 
+- [[#1837]](https://github.com/GetStream/stream-chat-flutter/issues/1837) Delete image and file
   attachments from the CDN, when the message get's hard deleted.
 - [[#1819]](https://github.com/GetStream/stream-chat-flutter/issues/1819) Handle network errors
   with String payload.
@@ -256,8 +267,10 @@
 
 🐞 Fixed
 
-- [[#1811]](https://github.com/GetStream/stream-chat-flutter/issues/1811) Bumped `UUID` dependency to `^4.2.1`. This
-  **might** produce a **breaking change** if you your code depends in `UUID` `3.x.x` directly or indirectly.
+- [[#1811]](https://github.com/GetStream/stream-chat-flutter/issues/1811) Bumped `UUID` dependency
+  to `^4.2.1`. This
+  **might** produce a **breaking change** if you your code depends in `UUID` `3.x.x` directly or
+  indirectly.
 
 ## 7.0.0
 
@@ -265,19 +278,20 @@
 
 - Removed deprecated `channelQuery.sort` property. Use `channelStateSort` instead.
 - Removed deprecated `RetryPolicy.retryTimeout` property. Use `delayFactor` instead.
-- Removed deprecated `StreamChatNetworkError.fromDioError` constructor. Use `StreamChatNetworkError.fromDioException`
+- Removed deprecated `StreamChatNetworkError.fromDioError` constructor. Use
+  `StreamChatNetworkError.fromDioException`
   instead.
 - Removed deprecated `MessageSendingStatus` enum. Use `MessageState` instead.
 
 🔄 Changed
 
 - Updated minimum supported `SDK` version to Flutter 3.13/Dart 3.1
-  
+
 # 6.10.0
 
 🐞 Fixed
 
-- [[#1753]](https://github.com/GetStream/stream-chat-flutter/issues/1753) Fixed Unhandled null 
+- [[#1753]](https://github.com/GetStream/stream-chat-flutter/issues/1753) Fixed Unhandled null
   check operator exception when user is removed from a channel.
 
 ## 6.9.0
@@ -297,7 +311,8 @@
 
 ✅ Added
 
-- Added support for `channel.countUnreadMentions()` to get the count of unread messages mentioning the current user on a
+- Added support for `channel.countUnreadMentions()` to get the count of unread messages mentioning
+  the current user on a
   channel. [#1692](https://github.com/GetStream/stream-chat-flutter/issues/1692)
 
 🔄 Changed
@@ -308,7 +323,8 @@
 
 ✅ Added
 
-- Added support for setting `Message.type`. [#1682](https://github.com/GetStream/stream-chat-flutter/issues/1682)
+- Added support for setting
+  `Message.type`. [#1682](https://github.com/GetStream/stream-chat-flutter/issues/1682)
   ```
   It is now possible to send system messages. System messages differ from normal messages in the way they are
   presented to the user. Like the name says, system messages are normally send from the system itself, but a user is
@@ -333,16 +349,19 @@
 
 🐞 Fixed
 
-- [[#1293]](https://github.com/GetStream/stream-chat-flutter/issues/1293) Fixed wrong message order when sending
+- [[#1293]](https://github.com/GetStream/stream-chat-flutter/issues/1293) Fixed wrong message order
+  when sending
   messages quickly.
-- [[#1612]](https://github.com/GetStream/stream-chat-flutter/issues/1612) Fixed `Channel.isMutedStream` does not emit
+- [[#1612]](https://github.com/GetStream/stream-chat-flutter/issues/1612) Fixed
+  `Channel.isMutedStream` does not emit
   when channel mute expires.
 
 ## 6.3.0
 
 🐞 Fixed
 
-- [[#1585]](https://github.com/GetStream/stream-chat-flutter/issues/1585) Fixed channels left not being removed from
+- [[#1585]](https://github.com/GetStream/stream-chat-flutter/issues/1585) Fixed channels left not
+  being removed from
   the persistent storage.
 
 🔄 Changed
@@ -353,23 +372,28 @@
 
 🐞 Fixed
 
-- [[#1422]](https://github.com/GetStream/stream-chat-flutter/issues/1422) Fixed `User.createdAt` property using
+- [[#1422]](https://github.com/GetStream/stream-chat-flutter/issues/1422) Fixed `User.createdAt`
+  property using
   currentTime when the ws connection is not established.
 
 ✅ Added
 
-- Added support for `ChatPersistenceClient.isConnected` for checking if the client is connected to the database.
+- Added support for `ChatPersistenceClient.isConnected` for checking if the client is connected to
+  the database.
 - Added support for `ChatPersistenceClient.userId` for getting the current connected user id.
-- Added two new methods `ChatPersistenceClient.disconnect` and `ChatPersistenceClient.connect` for disconnecting and
+- Added two new methods `ChatPersistenceClient.disconnect` and `ChatPersistenceClient.connect` for
+  disconnecting and
   connecting to the database.
 
 ## 6.1.0
 
 🐞 Fixed
 
-- [[#1355]](https://github.com/GetStream/stream-chat-flutter/issues/1355) Fixed error while hiding channel and clearing
+- [[#1355]](https://github.com/GetStream/stream-chat-flutter/issues/1355) Fixed error while hiding
+  channel and clearing
   message history.
-- [[#1525]](https://github.com/GetStream/stream-chat-flutter/issues/1525) Fixed removing message not removing quoted
+- [[#1525]](https://github.com/GetStream/stream-chat-flutter/issues/1525) Fixed removing message not
+  removing quoted
   message reference.
 
 ✅ Added
@@ -377,7 +401,8 @@
 - Expose `ChannelMute` class. [#1473](https://github.com/GetStream/stream-chat-flutter/issues/1473)
 - Added synchronization to the `StreamChatClient.sync`
   api. [#1392](https://github.com/GetStream/stream-chat-flutter/issues/1392)
-- Added support for `StreamChatClient.chatApiInterceptors` to add custom interceptors to the API client.
+- Added support for `StreamChatClient.chatApiInterceptors` to add custom interceptors to the API
+  client.
   [#1265](https://github.com/GetStream/stream-chat-flutter/issues/1265).
 
   ```dart
@@ -409,7 +434,8 @@
 
 🐞 Fixed
 
-- Fixed streamWatchers. Before it was always new, now it is possible to follow the watchers of a channel.
+- Fixed streamWatchers. Before it was always new, now it is possible to follow the watchers of a
+  channel.
 - Make `Message.i18n` field read-only.
 
 🔄 Changed
@@ -839,7 +865,8 @@ the [V4 Migration Guide](https://getstream.io/chat/docs/sdk/flutter/guides/migra
     - `StreamChatError` -> parent type for all the stream errors.
     - `StreamWebSocketError` -> for user web socket related errors.
     - `StreamChatNetworkError` -> for network related errors.
-- `client.queryChannels()`, `channel.query()` options parameter is removed in favor of individual parameters
+- `client.queryChannels()`, `channel.query()` options parameter is removed in favor of individual
+  parameters
     - `option.state` -> bool state
     - `option.watch` -> bool watch
     - `option.presence` -> bool presence
@@ -887,7 +914,8 @@ the [V4 Migration Guide](https://getstream.io/chat/docs/sdk/flutter/guides/migra
     - `StreamChatError` -> parent type for all the stream errors.
     - `StreamWebSocketError` -> for user web socket related errors.
     - `StreamChatNetworkError` -> for network related errors.
-- `client.queryChannels()`, `channel.query()` options parameter is removed in favor of individual parameters
+- `client.queryChannels()`, `channel.query()` options parameter is removed in favor of individual
+  parameters
     - `option.state` -> bool state
     - `option.watch` -> bool watch
     - `option.presence` -> bool presence

--- a/packages/stream_chat/lib/src/db/chat_persistence_client.dart
+++ b/packages/stream_chat/lib/src/db/chat_persistence_client.dart
@@ -240,6 +240,9 @@ abstract class ChatPersistenceClient {
   /// Deletes all the members by channel [cids]
   Future<void> deleteMembersByCids(List<String> cids);
 
+  /// Deletes all the draft messages by channel [cids]
+  Future<void> deleteDraftMessagesByCids(List<String> cids);
+
   /// Updates the channel [cid] threads data along with reactions and users.
   Future<void> updateChannelThreads(
     String cid,
@@ -277,7 +280,6 @@ abstract class ChatPersistenceClient {
     final channelWithPinnedMessages = <String, List<Message>?>{};
     final channelWithReads = <String, List<Read>?>{};
     final channelWithMembers = <String, List<Member>?>{};
-    final drafts = <Draft>[];
 
     final users = <User>[];
     final reactions = <Reaction>[];
@@ -286,6 +288,9 @@ abstract class ChatPersistenceClient {
     final polls = <Poll>[];
     final pollVotes = <PollVote>[];
     final pollVotesToDelete = <String>[];
+
+    final drafts = <Draft>[];
+    final draftsToDelete = <String>[];
 
     for (final state in channelStates) {
       final channel = state.channel;
@@ -311,6 +316,7 @@ abstract class ChatPersistenceClient {
       membersToDelete.add(cid);
       reactionsToDelete.addAll(messages?.map((it) => it.id) ?? []);
       pinnedReactionsToDelete.addAll(pinnedMessages?.map((it) => it.id) ?? []);
+      draftsToDelete.add(cid);
 
       // preparing addition data
       channelWithReads[cid] = reads;
@@ -356,6 +362,7 @@ abstract class ChatPersistenceClient {
       deleteReactionsByMessageId(reactionsToDelete),
       deletePinnedMessageReactionsByMessageId(pinnedReactionsToDelete),
       deletePollVotesByPollIds(pollVotesToDelete),
+      deleteDraftMessagesByCids(draftsToDelete),
     ]);
 
     // Updating first as does not depend on any other table.

--- a/packages/stream_chat/test/src/db/chat_persistence_client_test.dart
+++ b/packages/stream_chat/test/src/db/chat_persistence_client_test.dart
@@ -33,6 +33,9 @@ class TestPersistenceClient extends ChatPersistenceClient {
   Future<void> deleteMembersByCids(List<String> cids) => Future.value();
 
   @override
+  Future<void> deleteDraftMessagesByCids(List<String> cids) => Future.value();
+
+  @override
   Future<void> deleteMessageByCids(List<String> cids) => Future.value();
 
   @override

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed draft message retrieval logic where channel drafts were incorrectly attached to all messages
+  instead of only thread drafts being attached to their respective parent messages.
+
 ## 9.14.0
 
 - Updated `stream_chat` dependency to [`9.14.0`](https://pub.dev/packages/stream_chat/changelog).
@@ -95,7 +102,8 @@
 
 ## 7.2.0-hotfix.1
 
-- Updated `stream_chat` dependency to [`7.2.0-hotfix.1`](https://pub.dev/packages/stream_chat/changelog).
+- Updated `stream_chat` dependency to [
+  `7.2.0-hotfix.1`](https://pub.dev/packages/stream_chat/changelog).
 
 ## 7.2.0
 
@@ -116,7 +124,8 @@
 ## 7.0.0
 
 - Updated minimum supported `SDK` version to Flutter 3.13/Dart 3.1
-- 🛑 **BREAKING** Removed deprecated `getChannelStates.sort` parameter. Use `getChannelStates.channelStateSort` instead.
+- 🛑 **BREAKING** Removed deprecated `getChannelStates.sort` parameter. Use
+  `getChannelStates.channelStateSort` instead.
 
 ## 6.10.0
 
@@ -133,7 +142,8 @@
 
 ## 6.7.0
 
-- [[#1683]](https://github.com/GetStream/stream-chat-flutter/issues/1683) Fixed SqliteException no such column `messages.state`.
+- [[#1683]](https://github.com/GetStream/stream-chat-flutter/issues/1683) Fixed SqliteException no
+  such column `messages.state`.
 - Updated `stream_chat` dependency to [`6.7.0`](https://pub.dev/packages/stream_chat/changelog).
 
 ## 6.6.0
@@ -154,12 +164,14 @@
 
 ## 6.2.0
 
-- Added support for `StreamChatPersistenceClient.isConnected` for checking if the client is connected to the database.
+- Added support for `StreamChatPersistenceClient.isConnected` for checking if the client is
+  connected to the database.
 - [[#1422]](https://github.com/GetStream/stream-chat-flutter/issues/1422) Removed default values
   from `UserEntity` `createdAt` and `updatedAt` fields.
 - Updated `stream_chat` dependency to [`6.2.0`](https://pub.dev/packages/stream_chat/changelog).
 - Added support for `StreamChatPersistenceClient.openPersistenceConnection`
-  and `StreamChatPersistenceClient.closePersistenceConnection` for opening and closing the database connection.
+  and `StreamChatPersistenceClient.closePersistenceConnection` for opening and closing the database
+  connection.
 
 ## 6.1.0
 
@@ -187,7 +199,8 @@
 
 ## 5.0.0-beta.1
 
-- Updated `stream_chat` dependency to [`5.0.0-beta.1`](https://pub.dev/packages/stream_chat/changelog).
+- Updated `stream_chat` dependency to [
+  `5.0.0-beta.1`](https://pub.dev/packages/stream_chat/changelog).
 
 ## 4.4.0
 
@@ -219,7 +232,8 @@
 
 ## 4.0.0-beta.0
 
-- Updated `stream_chat` dependency to [`4.0.0-beta.0`](https://pub.dev/packages/stream_chat/changelog).
+- Updated `stream_chat` dependency to [
+  `4.0.0-beta.0`](https://pub.dev/packages/stream_chat/changelog).
 
 ## 3.1.0
 
@@ -228,8 +242,10 @@
 ## 3.0.0
 
 - Updated `stream_chat` dependency to [`3.0.0`](https://pub.dev/packages/stream_chat/changelog).
-- [[#604]](https://github.com/GetStream/stream-chat-flutter/issues/604) Fix cascade deletion by enabling `pragma foreign_keys`.
-- Added a new table `PinnedMessageReactions` and dao `PinnedMessageReactionDao` specifically for pinned messages.
+- [[#604]](https://github.com/GetStream/stream-chat-flutter/issues/604) Fix cascade deletion by
+  enabling `pragma foreign_keys`.
+- Added a new table `PinnedMessageReactions` and dao `PinnedMessageReactionDao` specifically for
+  pinned messages.
 
 ## 2.2.0
 

--- a/packages/stream_chat_persistence/lib/src/dao/draft_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/draft_message_dao.dart
@@ -102,4 +102,9 @@ class DraftMessageDao extends DatabaseAccessor<DriftChatDatabase>
 
     return query.go();
   }
+
+  /// Deletes all the poll votes whose [DraftMessages.channelCid] is
+  /// present in [cids]
+  Future<void> deleteDraftMessagesByCids(List<String> cids) =>
+      (delete(draftMessages)..where((tbl) => tbl.channelCid.isIn(cids))).go();
 }

--- a/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
@@ -38,7 +38,7 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
 
   Future<Message> _messageFromJoinRow(
     TypedResult rows, {
-    bool fetchDraft = true,
+    bool fetchDraft = false,
   }) async {
     final userEntity = rows.readTableOrNull(_users);
     final pinnedByEntity = rows.readTableOrNull(_pinnedByUsers);
@@ -59,10 +59,10 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
       _ => null,
     };
 
-    final draft = await switch (fetchDraft) {
-      true => _db.draftMessageDao.getDraftMessageByCid(
+    final draft = await switch ((fetchDraft, msgEntity.parentId)) {
+      (true, final parentId?) => _db.draftMessageDao.getDraftMessageByCid(
           msgEntity.channelCid,
-          parentId: msgEntity.parentId,
+          parentId: parentId,
         ),
       _ => null,
     };
@@ -85,19 +85,24 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
   Future<Message?> getMessageById(
     String id, {
     bool fetchDraft = true,
-  }) async =>
-      await (select(messages).join(
-        [
-          leftOuterJoin(_users, messages.userId.equalsExp(_users.id)),
-          leftOuterJoin(
-            _pinnedByUsers,
-            messages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
-          ),
-        ],
-      )..where(messages.id.equals(id)))
-          .map((row) {
-        return _messageFromJoinRow(row, fetchDraft: fetchDraft);
-      }).getSingleOrNull();
+  }) async {
+    final query = select(messages).join([
+      leftOuterJoin(_users, messages.userId.equalsExp(_users.id)),
+      leftOuterJoin(
+        _pinnedByUsers,
+        messages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
+      ),
+    ])
+      ..where(messages.id.equals(id));
+
+    final result = await query.getSingleOrNull();
+    if (result == null) return null;
+
+    return _messageFromJoinRow(
+      result,
+      fetchDraft: fetchDraft,
+    );
+  }
 
   /// Returns all the messages of a particular thread by matching
   /// [Messages.channelCid] with [cid]
@@ -163,22 +168,31 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
   /// [Messages.channelCid] with [parentId]
   Future<List<Message>> getMessagesByCid(
     String cid, {
+    bool fetchDraft = true,
     PaginationParams? messagePagination,
   }) async {
-    final msgList = await Future.wait(await (select(messages).join([
+    final query = select(messages).join([
       leftOuterJoin(_users, messages.userId.equalsExp(_users.id)),
       leftOuterJoin(
         _pinnedByUsers,
         messages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
       ),
     ])
-          ..where(messages.channelCid.equals(cid))
-          ..where(
-            messages.parentId.isNull() | messages.showInChannel.equals(true),
-          )
-          ..orderBy([OrderingTerm.asc(messages.createdAt)]))
-        .map(_messageFromJoinRow)
-        .get());
+      ..where(messages.channelCid.equals(cid))
+      ..where(messages.parentId.isNull() | messages.showInChannel.equals(true))
+      ..orderBy([OrderingTerm.asc(messages.createdAt)]);
+
+    final result = await query.get();
+    if (result.isEmpty) return [];
+
+    final msgList = await Future.wait(
+      result.map(
+        (row) => _messageFromJoinRow(
+          row,
+          fetchDraft: fetchDraft,
+        ),
+      ),
+    );
 
     if (msgList.isNotEmpty) {
       if (messagePagination?.lessThan != null) {

--- a/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
@@ -35,8 +35,11 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
   Future<void> deleteMessageByCids(List<String> cids) async =>
       (delete(pinnedMessages)..where((tbl) => tbl.channelCid.isIn(cids))).go();
 
-  Future<Message> _messageFromJoinRow(TypedResult rows) async {
-    final userEntity = rows.readTableOrNull(users);
+  Future<Message> _messageFromJoinRow(
+    TypedResult rows, {
+    bool fetchDraft = false,
+  }) async {
+    final userEntity = rows.readTableOrNull(_users);
     final pinnedByEntity = rows.readTableOrNull(_pinnedByUsers);
     final msgEntity = rows.readTable(pinnedMessages);
     final latestReactions =
@@ -46,16 +49,25 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
       msgEntity.id,
       _db.userId,
     );
-    Message? quotedMessage;
-    final quotedMessageId = msgEntity.quotedMessageId;
-    if (quotedMessageId != null) {
-      quotedMessage = await getMessageById(quotedMessageId);
-    }
-    Poll? poll;
-    final pollId = msgEntity.pollId;
-    if (pollId != null) {
-      poll = await _db.pollDao.getPollById(pollId);
-    }
+
+    final quotedMessage = await switch (msgEntity.quotedMessageId) {
+      final id? => getMessageById(id),
+      _ => null,
+    };
+
+    final poll = await switch (msgEntity.pollId) {
+      final id? => _db.pollDao.getPollById(id),
+      _ => null,
+    };
+
+    final draft = await switch ((fetchDraft, msgEntity.parentId)) {
+      (true, final parentId?) => _db.draftMessageDao.getDraftMessageByCid(
+          msgEntity.channelCid,
+          parentId: parentId,
+        ),
+      _ => null,
+    };
+
     return msgEntity.toMessage(
       user: userEntity?.toUser(),
       pinnedBy: pinnedByEntity?.toUser(),
@@ -63,21 +75,32 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
       ownReactions: ownReactions,
       quotedMessage: quotedMessage,
       poll: poll,
+      draft: draft,
     );
   }
 
   /// Returns a single message by matching the [PinnedMessages.id] with [id]
-  Future<Message?> getMessageById(String id) async =>
-      await (select(pinnedMessages).join([
-        leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
-        leftOuterJoin(
-          _pinnedByUsers,
-          pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
-        ),
-      ])
-            ..where(pinnedMessages.id.equals(id)))
-          .map(_messageFromJoinRow)
-          .getSingleOrNull();
+  Future<Message?> getMessageById(
+    String id, {
+    bool fetchDraft = true,
+  }) async {
+    final query = select(pinnedMessages).join([
+      leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
+      leftOuterJoin(
+        _pinnedByUsers,
+        pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
+      ),
+    ])
+      ..where(pinnedMessages.id.equals(id));
+
+    final result = await query.getSingleOrNull();
+    if (result == null) return null;
+
+    return _messageFromJoinRow(
+      result,
+      fetchDraft: fetchDraft,
+    );
+  }
 
   /// Returns all the messages of a particular thread by matching
   /// [PinnedMessages.channelCid] with [cid]
@@ -142,21 +165,32 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
   /// [PinnedMessages.channelCid] with [parentId]
   Future<List<Message>> getMessagesByCid(
     String cid, {
+    bool fetchDraft = true,
     PaginationParams? messagePagination,
   }) async {
-    final msgList = await Future.wait(await (select(pinnedMessages).join([
+    final query = select(pinnedMessages).join([
       leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
       leftOuterJoin(
         _pinnedByUsers,
         pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
       ),
     ])
-          ..where(pinnedMessages.channelCid.equals(cid))
-          ..where(pinnedMessages.parentId.isNull() |
-              pinnedMessages.showInChannel.equals(true))
-          ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]))
-        .map(_messageFromJoinRow)
-        .get());
+      ..where(pinnedMessages.channelCid.equals(cid))
+      ..where(pinnedMessages.parentId.isNull() |
+          pinnedMessages.showInChannel.equals(true))
+      ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]);
+
+    final result = await query.get();
+    if (result.isEmpty) return [];
+
+    final msgList = await Future.wait(
+      result.map(
+        (row) => _messageFromJoinRow(
+          row,
+          fetchDraft: fetchDraft,
+        ),
+      ),
+    );
 
     if (msgList.isNotEmpty) {
       if (messagePagination?.lessThan != null) {

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -846,12 +846,6 @@ class $MessagesTable extends Messages
               type: DriftSqlType.string, requiredDuringInsert: false)
           .withConverter<List<String>?>(
               $MessagesTable.$converterrestrictedVisibilityn);
-  static const VerificationMeta _draftMessageIdMeta =
-      const VerificationMeta('draftMessageId');
-  @override
-  late final GeneratedColumn<String> draftMessageId = GeneratedColumn<String>(
-      'draft_message_id', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       extraData = GeneratedColumn<String>('extra_data', aliasedName, true,
@@ -889,7 +883,6 @@ class $MessagesTable extends Messages
         channelCid,
         i18n,
         restrictedVisibility,
-        draftMessageId,
         extraData
       ];
   @override
@@ -1031,12 +1024,6 @@ class $MessagesTable extends Messages
     } else if (isInserting) {
       context.missing(_channelCidMeta);
     }
-    if (data.containsKey('draft_message_id')) {
-      context.handle(
-          _draftMessageIdMeta,
-          draftMessageId.isAcceptableOrUnknown(
-              data['draft_message_id']!, _draftMessageIdMeta));
-    }
     return context;
   }
 
@@ -1109,8 +1096,6 @@ class $MessagesTable extends Messages
       restrictedVisibility: $MessagesTable.$converterrestrictedVisibilityn
           .fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string,
               data['${effectivePrefix}restricted_visibility'])),
-      draftMessageId: attachedDatabase.typeMapping.read(
-          DriftSqlType.string, data['${effectivePrefix}draft_message_id']),
       extraData: $MessagesTable.$converterextraDatan.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}extra_data'])),
@@ -1232,9 +1217,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
   /// The list of user ids that should be able to see the message.
   final List<String>? restrictedVisibility;
 
-  /// Id of the draft message if this message is a parent message.
-  final String? draftMessageId;
-
   /// Message custom extraData
   final Map<String, dynamic>? extraData;
   const MessageEntity(
@@ -1267,7 +1249,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       required this.channelCid,
       this.i18n,
       this.restrictedVisibility,
-      this.draftMessageId,
       this.extraData});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1352,9 +1333,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           .$converterrestrictedVisibilityn
           .toSql(restrictedVisibility));
     }
-    if (!nullToAbsent || draftMessageId != null) {
-      map['draft_message_id'] = Variable<String>(draftMessageId);
-    }
     if (!nullToAbsent || extraData != null) {
       map['extra_data'] = Variable<String>(
           $MessagesTable.$converterextraDatan.toSql(extraData));
@@ -1398,7 +1376,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       i18n: serializer.fromJson<Map<String, String>?>(json['i18n']),
       restrictedVisibility:
           serializer.fromJson<List<String>?>(json['restrictedVisibility']),
-      draftMessageId: serializer.fromJson<String?>(json['draftMessageId']),
       extraData: serializer.fromJson<Map<String, dynamic>?>(json['extraData']),
     );
   }
@@ -1438,7 +1415,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       'i18n': serializer.toJson<Map<String, String>?>(i18n),
       'restrictedVisibility':
           serializer.toJson<List<String>?>(restrictedVisibility),
-      'draftMessageId': serializer.toJson<String?>(draftMessageId),
       'extraData': serializer.toJson<Map<String, dynamic>?>(extraData),
     };
   }
@@ -1474,7 +1450,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           String? channelCid,
           Value<Map<String, String>?> i18n = const Value.absent(),
           Value<List<String>?> restrictedVisibility = const Value.absent(),
-          Value<String?> draftMessageId = const Value.absent(),
           Value<Map<String, dynamic>?> extraData = const Value.absent()}) =>
       MessageEntity(
         id: id ?? this.id,
@@ -1524,8 +1499,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
         restrictedVisibility: restrictedVisibility.present
             ? restrictedVisibility.value
             : this.restrictedVisibility,
-        draftMessageId:
-            draftMessageId.present ? draftMessageId.value : this.draftMessageId,
         extraData: extraData.present ? extraData.value : this.extraData,
       );
   MessageEntity copyWithCompanion(MessagesCompanion data) {
@@ -1590,9 +1563,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
       restrictedVisibility: data.restrictedVisibility.present
           ? data.restrictedVisibility.value
           : this.restrictedVisibility,
-      draftMessageId: data.draftMessageId.present
-          ? data.draftMessageId.value
-          : this.draftMessageId,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
     );
   }
@@ -1629,7 +1599,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
           ..write('restrictedVisibility: $restrictedVisibility, ')
-          ..write('draftMessageId: $draftMessageId, ')
           ..write('extraData: $extraData')
           ..write(')'))
         .toString();
@@ -1666,7 +1635,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
         channelCid,
         i18n,
         restrictedVisibility,
-        draftMessageId,
         extraData
       ]);
   @override
@@ -1702,7 +1670,6 @@ class MessageEntity extends DataClass implements Insertable<MessageEntity> {
           other.channelCid == this.channelCid &&
           other.i18n == this.i18n &&
           other.restrictedVisibility == this.restrictedVisibility &&
-          other.draftMessageId == this.draftMessageId &&
           other.extraData == this.extraData);
 }
 
@@ -1736,7 +1703,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
   final Value<String> channelCid;
   final Value<Map<String, String>?> i18n;
   final Value<List<String>?> restrictedVisibility;
-  final Value<String?> draftMessageId;
   final Value<Map<String, dynamic>?> extraData;
   final Value<int> rowid;
   const MessagesCompanion({
@@ -1769,7 +1735,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     this.channelCid = const Value.absent(),
     this.i18n = const Value.absent(),
     this.restrictedVisibility = const Value.absent(),
-    this.draftMessageId = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -1803,7 +1768,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     required String channelCid,
     this.i18n = const Value.absent(),
     this.restrictedVisibility = const Value.absent(),
-    this.draftMessageId = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -1841,7 +1805,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
     Expression<String>? channelCid,
     Expression<String>? i18n,
     Expression<String>? restrictedVisibility,
-    Expression<String>? draftMessageId,
     Expression<String>? extraData,
     Expression<int>? rowid,
   }) {
@@ -1877,7 +1840,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       if (i18n != null) 'i18n': i18n,
       if (restrictedVisibility != null)
         'restricted_visibility': restrictedVisibility,
-      if (draftMessageId != null) 'draft_message_id': draftMessageId,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
     });
@@ -1913,7 +1875,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       Value<String>? channelCid,
       Value<Map<String, String>?>? i18n,
       Value<List<String>?>? restrictedVisibility,
-      Value<String?>? draftMessageId,
       Value<Map<String, dynamic>?>? extraData,
       Value<int>? rowid}) {
     return MessagesCompanion(
@@ -1946,7 +1907,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
       channelCid: channelCid ?? this.channelCid,
       i18n: i18n ?? this.i18n,
       restrictedVisibility: restrictedVisibility ?? this.restrictedVisibility,
-      draftMessageId: draftMessageId ?? this.draftMessageId,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
     );
@@ -2049,9 +2009,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
           .$converterrestrictedVisibilityn
           .toSql(restrictedVisibility.value));
     }
-    if (draftMessageId.present) {
-      map['draft_message_id'] = Variable<String>(draftMessageId.value);
-    }
     if (extraData.present) {
       map['extra_data'] = Variable<String>(
           $MessagesTable.$converterextraDatan.toSql(extraData.value));
@@ -2094,7 +2051,6 @@ class MessagesCompanion extends UpdateCompanion<MessageEntity> {
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
           ..write('restrictedVisibility: $restrictedVisibility, ')
-          ..write('draftMessageId: $draftMessageId, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -2998,12 +2954,6 @@ class $PinnedMessagesTable extends PinnedMessages
               type: DriftSqlType.string, requiredDuringInsert: false)
           .withConverter<List<String>?>(
               $PinnedMessagesTable.$converterrestrictedVisibilityn);
-  static const VerificationMeta _draftMessageIdMeta =
-      const VerificationMeta('draftMessageId');
-  @override
-  late final GeneratedColumn<String> draftMessageId = GeneratedColumn<String>(
-      'draft_message_id', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       extraData = GeneratedColumn<String>('extra_data', aliasedName, true,
@@ -3041,7 +2991,6 @@ class $PinnedMessagesTable extends PinnedMessages
         channelCid,
         i18n,
         restrictedVisibility,
-        draftMessageId,
         extraData
       ];
   @override
@@ -3184,12 +3133,6 @@ class $PinnedMessagesTable extends PinnedMessages
     } else if (isInserting) {
       context.missing(_channelCidMeta);
     }
-    if (data.containsKey('draft_message_id')) {
-      context.handle(
-          _draftMessageIdMeta,
-          draftMessageId.isAcceptableOrUnknown(
-              data['draft_message_id']!, _draftMessageIdMeta));
-    }
     return context;
   }
 
@@ -3263,8 +3206,6 @@ class $PinnedMessagesTable extends PinnedMessages
       restrictedVisibility: $PinnedMessagesTable.$converterrestrictedVisibilityn
           .fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string,
               data['${effectivePrefix}restricted_visibility'])),
-      draftMessageId: attachedDatabase.typeMapping.read(
-          DriftSqlType.string, data['${effectivePrefix}draft_message_id']),
       extraData: $PinnedMessagesTable.$converterextraDatan.fromSql(
           attachedDatabase.typeMapping
               .read(DriftSqlType.string, data['${effectivePrefix}extra_data'])),
@@ -3387,9 +3328,6 @@ class PinnedMessageEntity extends DataClass
   /// The list of user ids that should be able to see the message.
   final List<String>? restrictedVisibility;
 
-  /// Id of the draft message if this message is a parent message.
-  final String? draftMessageId;
-
   /// Message custom extraData
   final Map<String, dynamic>? extraData;
   const PinnedMessageEntity(
@@ -3422,7 +3360,6 @@ class PinnedMessageEntity extends DataClass
       required this.channelCid,
       this.i18n,
       this.restrictedVisibility,
-      this.draftMessageId,
       this.extraData});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -3508,9 +3445,6 @@ class PinnedMessageEntity extends DataClass
           .$converterrestrictedVisibilityn
           .toSql(restrictedVisibility));
     }
-    if (!nullToAbsent || draftMessageId != null) {
-      map['draft_message_id'] = Variable<String>(draftMessageId);
-    }
     if (!nullToAbsent || extraData != null) {
       map['extra_data'] = Variable<String>(
           $PinnedMessagesTable.$converterextraDatan.toSql(extraData));
@@ -3554,7 +3488,6 @@ class PinnedMessageEntity extends DataClass
       i18n: serializer.fromJson<Map<String, String>?>(json['i18n']),
       restrictedVisibility:
           serializer.fromJson<List<String>?>(json['restrictedVisibility']),
-      draftMessageId: serializer.fromJson<String?>(json['draftMessageId']),
       extraData: serializer.fromJson<Map<String, dynamic>?>(json['extraData']),
     );
   }
@@ -3594,7 +3527,6 @@ class PinnedMessageEntity extends DataClass
       'i18n': serializer.toJson<Map<String, String>?>(i18n),
       'restrictedVisibility':
           serializer.toJson<List<String>?>(restrictedVisibility),
-      'draftMessageId': serializer.toJson<String?>(draftMessageId),
       'extraData': serializer.toJson<Map<String, dynamic>?>(extraData),
     };
   }
@@ -3630,7 +3562,6 @@ class PinnedMessageEntity extends DataClass
           String? channelCid,
           Value<Map<String, String>?> i18n = const Value.absent(),
           Value<List<String>?> restrictedVisibility = const Value.absent(),
-          Value<String?> draftMessageId = const Value.absent(),
           Value<Map<String, dynamic>?> extraData = const Value.absent()}) =>
       PinnedMessageEntity(
         id: id ?? this.id,
@@ -3680,8 +3611,6 @@ class PinnedMessageEntity extends DataClass
         restrictedVisibility: restrictedVisibility.present
             ? restrictedVisibility.value
             : this.restrictedVisibility,
-        draftMessageId:
-            draftMessageId.present ? draftMessageId.value : this.draftMessageId,
         extraData: extraData.present ? extraData.value : this.extraData,
       );
   PinnedMessageEntity copyWithCompanion(PinnedMessagesCompanion data) {
@@ -3746,9 +3675,6 @@ class PinnedMessageEntity extends DataClass
       restrictedVisibility: data.restrictedVisibility.present
           ? data.restrictedVisibility.value
           : this.restrictedVisibility,
-      draftMessageId: data.draftMessageId.present
-          ? data.draftMessageId.value
-          : this.draftMessageId,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
     );
   }
@@ -3785,7 +3711,6 @@ class PinnedMessageEntity extends DataClass
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
           ..write('restrictedVisibility: $restrictedVisibility, ')
-          ..write('draftMessageId: $draftMessageId, ')
           ..write('extraData: $extraData')
           ..write(')'))
         .toString();
@@ -3822,7 +3747,6 @@ class PinnedMessageEntity extends DataClass
         channelCid,
         i18n,
         restrictedVisibility,
-        draftMessageId,
         extraData
       ]);
   @override
@@ -3858,7 +3782,6 @@ class PinnedMessageEntity extends DataClass
           other.channelCid == this.channelCid &&
           other.i18n == this.i18n &&
           other.restrictedVisibility == this.restrictedVisibility &&
-          other.draftMessageId == this.draftMessageId &&
           other.extraData == this.extraData);
 }
 
@@ -3892,7 +3815,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
   final Value<String> channelCid;
   final Value<Map<String, String>?> i18n;
   final Value<List<String>?> restrictedVisibility;
-  final Value<String?> draftMessageId;
   final Value<Map<String, dynamic>?> extraData;
   final Value<int> rowid;
   const PinnedMessagesCompanion({
@@ -3925,7 +3847,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     this.channelCid = const Value.absent(),
     this.i18n = const Value.absent(),
     this.restrictedVisibility = const Value.absent(),
-    this.draftMessageId = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -3959,7 +3880,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     required String channelCid,
     this.i18n = const Value.absent(),
     this.restrictedVisibility = const Value.absent(),
-    this.draftMessageId = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -3997,7 +3917,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
     Expression<String>? channelCid,
     Expression<String>? i18n,
     Expression<String>? restrictedVisibility,
-    Expression<String>? draftMessageId,
     Expression<String>? extraData,
     Expression<int>? rowid,
   }) {
@@ -4033,7 +3952,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       if (i18n != null) 'i18n': i18n,
       if (restrictedVisibility != null)
         'restricted_visibility': restrictedVisibility,
-      if (draftMessageId != null) 'draft_message_id': draftMessageId,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
     });
@@ -4069,7 +3987,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       Value<String>? channelCid,
       Value<Map<String, String>?>? i18n,
       Value<List<String>?>? restrictedVisibility,
-      Value<String?>? draftMessageId,
       Value<Map<String, dynamic>?>? extraData,
       Value<int>? rowid}) {
     return PinnedMessagesCompanion(
@@ -4102,7 +4019,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
       channelCid: channelCid ?? this.channelCid,
       i18n: i18n ?? this.i18n,
       restrictedVisibility: restrictedVisibility ?? this.restrictedVisibility,
-      draftMessageId: draftMessageId ?? this.draftMessageId,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
     );
@@ -4207,9 +4123,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
           .$converterrestrictedVisibilityn
           .toSql(restrictedVisibility.value));
     }
-    if (draftMessageId.present) {
-      map['draft_message_id'] = Variable<String>(draftMessageId.value);
-    }
     if (extraData.present) {
       map['extra_data'] = Variable<String>(
           $PinnedMessagesTable.$converterextraDatan.toSql(extraData.value));
@@ -4252,7 +4165,6 @@ class PinnedMessagesCompanion extends UpdateCompanion<PinnedMessageEntity> {
           ..write('channelCid: $channelCid, ')
           ..write('i18n: $i18n, ')
           ..write('restrictedVisibility: $restrictedVisibility, ')
-          ..write('draftMessageId: $draftMessageId, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -9107,7 +9019,6 @@ typedef $$MessagesTableCreateCompanionBuilder = MessagesCompanion Function({
   required String channelCid,
   Value<Map<String, String>?> i18n,
   Value<List<String>?> restrictedVisibility,
-  Value<String?> draftMessageId,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -9141,7 +9052,6 @@ typedef $$MessagesTableUpdateCompanionBuilder = MessagesCompanion Function({
   Value<String> channelCid,
   Value<Map<String, String>?> i18n,
   Value<List<String>?> restrictedVisibility,
-  Value<String?> draftMessageId,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -9309,10 +9219,6 @@ class $$MessagesTableFilterComposer
       get restrictedVisibility => $composableBuilder(
           column: $table.restrictedVisibility,
           builder: (column) => ColumnWithTypeConverterFilters(column));
-
-  ColumnFilters<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId,
-      builder: (column) => ColumnFilters(column));
 
   ColumnWithTypeConverterFilters<Map<String, dynamic>?, Map<String, dynamic>,
           String>
@@ -9489,10 +9395,6 @@ class $$MessagesTableOrderingComposer
       column: $table.restrictedVisibility,
       builder: (column) => ColumnOrderings(column));
 
-  ColumnOrderings<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId,
-      builder: (column) => ColumnOrderings(column));
-
   ColumnOrderings<String> get extraData => $composableBuilder(
       column: $table.extraData, builder: (column) => ColumnOrderings(column));
 
@@ -9613,9 +9515,6 @@ class $$MessagesTableAnnotationComposer
   GeneratedColumnWithTypeConverter<List<String>?, String>
       get restrictedVisibility => $composableBuilder(
           column: $table.restrictedVisibility, builder: (column) => column);
-
-  GeneratedColumn<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId, builder: (column) => column);
 
   GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       get extraData => $composableBuilder(
@@ -9738,7 +9637,6 @@ class $$MessagesTableTableManager extends RootTableManager<
             Value<String> channelCid = const Value.absent(),
             Value<Map<String, String>?> i18n = const Value.absent(),
             Value<List<String>?> restrictedVisibility = const Value.absent(),
-            Value<String?> draftMessageId = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -9772,7 +9670,6 @@ class $$MessagesTableTableManager extends RootTableManager<
             channelCid: channelCid,
             i18n: i18n,
             restrictedVisibility: restrictedVisibility,
-            draftMessageId: draftMessageId,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -9807,7 +9704,6 @@ class $$MessagesTableTableManager extends RootTableManager<
             required String channelCid,
             Value<Map<String, String>?> i18n = const Value.absent(),
             Value<List<String>?> restrictedVisibility = const Value.absent(),
-            Value<String?> draftMessageId = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -9841,7 +9737,6 @@ class $$MessagesTableTableManager extends RootTableManager<
             channelCid: channelCid,
             i18n: i18n,
             restrictedVisibility: restrictedVisibility,
-            draftMessageId: draftMessageId,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -10466,7 +10361,6 @@ typedef $$PinnedMessagesTableCreateCompanionBuilder = PinnedMessagesCompanion
   required String channelCid,
   Value<Map<String, String>?> i18n,
   Value<List<String>?> restrictedVisibility,
-  Value<String?> draftMessageId,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -10501,7 +10395,6 @@ typedef $$PinnedMessagesTableUpdateCompanionBuilder = PinnedMessagesCompanion
   Value<String> channelCid,
   Value<Map<String, String>?> i18n,
   Value<List<String>?> restrictedVisibility,
-  Value<String?> draftMessageId,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
 });
@@ -10648,10 +10541,6 @@ class $$PinnedMessagesTableFilterComposer
           column: $table.restrictedVisibility,
           builder: (column) => ColumnWithTypeConverterFilters(column));
 
-  ColumnFilters<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId,
-      builder: (column) => ColumnFilters(column));
-
   ColumnWithTypeConverterFilters<Map<String, dynamic>?, Map<String, dynamic>,
           String>
       get extraData => $composableBuilder(
@@ -10791,10 +10680,6 @@ class $$PinnedMessagesTableOrderingComposer
       column: $table.restrictedVisibility,
       builder: (column) => ColumnOrderings(column));
 
-  ColumnOrderings<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId,
-      builder: (column) => ColumnOrderings(column));
-
   ColumnOrderings<String> get extraData => $composableBuilder(
       column: $table.extraData, builder: (column) => ColumnOrderings(column));
 }
@@ -10899,9 +10784,6 @@ class $$PinnedMessagesTableAnnotationComposer
       get restrictedVisibility => $composableBuilder(
           column: $table.restrictedVisibility, builder: (column) => column);
 
-  GeneratedColumn<String> get draftMessageId => $composableBuilder(
-      column: $table.draftMessageId, builder: (column) => column);
-
   GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
       get extraData => $composableBuilder(
           column: $table.extraData, builder: (column) => column);
@@ -10984,7 +10866,6 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             Value<String> channelCid = const Value.absent(),
             Value<Map<String, String>?> i18n = const Value.absent(),
             Value<List<String>?> restrictedVisibility = const Value.absent(),
-            Value<String?> draftMessageId = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -11018,7 +10899,6 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             channelCid: channelCid,
             i18n: i18n,
             restrictedVisibility: restrictedVisibility,
-            draftMessageId: draftMessageId,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -11053,7 +10933,6 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             required String channelCid,
             Value<Map<String, String>?> i18n = const Value.absent(),
             Value<List<String>?> restrictedVisibility = const Value.absent(),
-            Value<String?> draftMessageId = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -11087,7 +10966,6 @@ class $$PinnedMessagesTableTableManager extends RootTableManager<
             channelCid: channelCid,
             i18n: i18n,
             restrictedVisibility: restrictedVisibility,
-            draftMessageId: draftMessageId,
             extraData: extraData,
             rowid: rowid,
           ),

--- a/packages/stream_chat_persistence/lib/src/entity/messages.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/messages.dart
@@ -129,9 +129,6 @@ class Messages extends Table {
   TextColumn get restrictedVisibility =>
       text().nullable().map(ListConverter<String>())();
 
-  /// Id of the draft message if this message is a parent message.
-  TextColumn get draftMessageId => text().nullable()();
-
   /// Message custom extraData
   TextColumn get extraData => text().nullable().map(MapConverter())();
 

--- a/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/message_mapper.dart
@@ -91,6 +91,5 @@ extension MessageX on Message {
         pinnedByUserId: pinnedBy?.id,
         i18n: i18n,
         restrictedVisibility: restrictedVisibility,
-        draftMessageId: draft?.message.id,
       );
 }

--- a/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/pinned_message_mapper.dart
@@ -13,6 +13,7 @@ extension PinnedMessageEntityX on PinnedMessageEntity {
     List<Reaction>? ownReactions,
     Message? quotedMessage,
     Poll? poll,
+    Draft? draft,
   }) =>
       Message(
         shadowed: shadowed,
@@ -52,6 +53,7 @@ extension PinnedMessageEntityX on PinnedMessageEntity {
             mentionedUsers.map((e) => User.fromJson(jsonDecode(e))).toList(),
         i18n: i18n,
         restrictedVisibility: restrictedVisibility,
+        draft: draft,
       );
 }
 

--- a/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
+++ b/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
@@ -425,6 +425,13 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
   }
 
   @override
+  Future<void> deleteDraftMessagesByCids(List<String> cids) {
+    assert(_debugIsConnected, '');
+    _logger.info('deleteDraftMessagesByCids');
+    return db!.draftMessageDao.deleteDraftMessagesByCids(cids);
+  }
+
+  @override
   Future<void> deleteDraftMessageByCid(
     String cid, {
     String? parentId,

--- a/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
+++ b/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
@@ -631,6 +631,16 @@ void main() {
       verify(() => mockDatabase.memberDao.deleteMemberByCids(cids)).called(1);
     });
 
+    test('deleteDraftMessagesByCids', () async {
+      final cids = <String>[];
+      when(() => mockDatabase.draftMessageDao.deleteDraftMessagesByCids(cids))
+          .thenAnswer((_) => Future.value());
+
+      await client.deleteDraftMessagesByCids(cids);
+      verify(() => mockDatabase.draftMessageDao.deleteDraftMessagesByCids(cids))
+          .called(1);
+    });
+
     test('getDraftMessageByCid', () async {
       const cid = 'testCid';
       const parentId = 'testParentId';


### PR DESCRIPTION
## Description of the pull request
Fix Draft Message Persistence and Retrieval Issues:
1. **Persistence Issue**: When channel states were updated, drafts that were removed from the state weren't being deleted from the database, leading to orphaned draft records.

2. **Retrieval Issue**: Channel drafts were being incorrectly attached to ALL messages in a channel instead of only attaching thread drafts to their respective parent messages.