### PR TITLE
feat(llc, persistence): add `avgResponseTime` to User model

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+✅ Added
+
+- Added `avgResponseTime` field to the `User` model to track average response time in seconds.
+
 🐞 Fixed
 
 - Fixed `WebSocket` race condition where reconnection could access null user during disconnect.

--- a/packages/stream_chat/lib/src/core/models/own_user.dart
+++ b/packages/stream_chat/lib/src/core/models/own_user.dart
@@ -32,6 +32,7 @@ class OwnUser extends User {
     super.teams,
     super.language,
     super.teamsRole,
+    super.avgResponseTime,
   });
 
   /// Create a new instance from json.
@@ -55,6 +56,7 @@ class OwnUser extends User {
         teams: user.teams,
         language: user.language,
         teamsRole: user.teamsRole,
+        avgResponseTime: user.avgResponseTime,
       );
 
   /// Creates a copy of [OwnUser] with specified attributes overridden.
@@ -81,6 +83,7 @@ class OwnUser extends User {
     int? unreadThreads,
     String? language,
     Map<String, String>? teamsRole,
+    int? avgResponseTime,
   }) =>
       OwnUser(
         id: id ?? this.id,
@@ -107,6 +110,7 @@ class OwnUser extends User {
         blockedUserIds: blockedUserIds ?? this.blockedUserIds,
         language: language ?? this.language,
         teamsRole: teamsRole ?? this.teamsRole,
+        avgResponseTime: avgResponseTime ?? this.avgResponseTime,
       );
 
   /// Returns a new [OwnUser] that is a combination of this ownUser
@@ -135,6 +139,7 @@ class OwnUser extends User {
       updatedAt: other.updatedAt,
       language: other.language,
       teamsRole: other.teamsRole,
+      avgResponseTime: other.avgResponseTime,
     );
   }
 

--- a/packages/stream_chat/lib/src/core/models/own_user.g.dart
+++ b/packages/stream_chat/lib/src/core/models/own_user.g.dart
@@ -50,4 +50,5 @@ OwnUser _$OwnUserFromJson(Map<String, dynamic> json) => OwnUser(
       teamsRole: (json['teams_role'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
+      avgResponseTime: (json['avg_response_time'] as num?)?.toInt(),
     );

--- a/packages/stream_chat/lib/src/core/models/user.dart
+++ b/packages/stream_chat/lib/src/core/models/user.dart
@@ -47,6 +47,7 @@ class User extends Equatable implements ComparableFieldProvider {
     this.teams = const [],
     this.language,
     this.teamsRole,
+    this.avgResponseTime,
   }) :
         // For backwards compatibility, set 'name', 'image' in [extraData].
         extraData = {
@@ -74,6 +75,7 @@ class User extends Equatable implements ComparableFieldProvider {
     'teams',
     'language',
     'teams_role',
+    'avg_response_time',
   ];
 
   /// User id.
@@ -143,6 +145,10 @@ class User extends Equatable implements ComparableFieldProvider {
   @JsonKey(includeIfNull: false)
   final Map< /*Team*/ String, /*Role*/ String>? teamsRole;
 
+  /// The average response time of the user in seconds.
+  @JsonKey(includeToJson: false)
+  final int? avgResponseTime;
+
   /// Map of custom user extraData.
   final Map<String, Object?> extraData;
 
@@ -171,6 +177,7 @@ class User extends Equatable implements ComparableFieldProvider {
     List<String>? teams,
     String? language,
     Map<String, String>? teamsRole,
+    int? avgResponseTime,
   }) =>
       User(
         id: id ?? this.id,
@@ -190,6 +197,7 @@ class User extends Equatable implements ComparableFieldProvider {
         teams: teams ?? this.teams,
         language: language ?? this.language,
         teamsRole: teamsRole ?? this.teamsRole,
+        avgResponseTime: avgResponseTime ?? this.avgResponseTime,
       );
 
   @override
@@ -204,6 +212,7 @@ class User extends Equatable implements ComparableFieldProvider {
         teams,
         language,
         teamsRole,
+        avgResponseTime,
       ];
 
   @override

--- a/packages/stream_chat/lib/src/core/models/user.g.dart
+++ b/packages/stream_chat/lib/src/core/models/user.g.dart
@@ -31,6 +31,7 @@ User _$UserFromJson(Map<String, dynamic> json) => User(
       teamsRole: (json['teams_role'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
+      avgResponseTime: (json['avg_response_time'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{

--- a/packages/stream_chat/test/fixtures/user.json
+++ b/packages/stream_chat/test/fixtures/user.json
@@ -13,5 +13,7 @@
   "created_at": "2021-08-03 12:39:21.817646",
   "updated_at": "2021-08-04 12:39:21.817646",
   "last_active" : "2021-08-05 12:39:21.817646",
-  "language": "en"
+  "language": "en",
+  "teams_role": {"team-1": "admin", "team-2": "member"},
+  "avg_response_time": 120
 }

--- a/packages/stream_chat/test/src/core/models/user_test.dart
+++ b/packages/stream_chat/test/src/core/models/user_test.dart
@@ -18,6 +18,8 @@ void main() {
   const online = true;
   const banned = true;
   const teams = ['team-1', 'team-2'];
+  const teamsRole = {'team-1': 'admin', 'team-2': 'member'};
+  const avgResponseTime = 120;
   const createdAtString = '2021-08-03 12:39:21.817646';
   const updatedAtString = '2021-08-04 12:39:21.817646';
   const lastActiveString = '2021-08-05 12:39:21.817646';
@@ -41,6 +43,8 @@ void main() {
       expect(user.updatedAt, DateTime.parse(updatedAtString));
       expect(user.lastActive, DateTime.parse(lastActiveString));
       expect(user.language, 'en');
+      expect(user.teamsRole, teamsRole);
+      expect(user.avgResponseTime, avgResponseTime);
     });
 
     test('should serialize to json correctly', () {
@@ -62,6 +66,8 @@ void main() {
         online: banned,
         teams: const ['team-1', 'team-2'],
         language: 'fr',
+        teamsRole: teamsRole,
+        avgResponseTime: avgResponseTime,
       );
 
       expect(user.toJson(), {
@@ -73,6 +79,7 @@ void main() {
         'extraDataDoubleTest': extraDataDoubleTest,
         'extraDataBoolTest': extraDataBoolTest,
         'language': 'fr',
+        'teams_role': teamsRole,
       });
     });
 
@@ -91,6 +98,8 @@ void main() {
       expect(newUser.updatedAt, user.updatedAt);
       expect(newUser.lastActive, user.lastActive);
       expect(newUser.language, user.language);
+      expect(newUser.teamsRole, user.teamsRole);
+      expect(newUser.avgResponseTime, user.avgResponseTime);
 
       newUser = user.copyWith(
         id: 'test',
@@ -104,6 +113,8 @@ void main() {
         updatedAt: DateTime.parse('2021-05-04 12:39:21.817646'),
         lastActive: DateTime.parse('2021-05-06 12:39:21.817646'),
         language: 'it',
+        teamsRole: {'new-team1': 'owner', 'new-team2': 'moderator'},
+        avgResponseTime: 60,
       );
 
       expect(newUser.id, 'test');
@@ -118,6 +129,8 @@ void main() {
       expect(newUser.updatedAt, DateTime.parse('2021-05-04 12:39:21.817646'));
       expect(newUser.lastActive, DateTime.parse('2021-05-06 12:39:21.817646'));
       expect(newUser.language, 'it');
+      expect(newUser.teamsRole, {'new-team1': 'owner', 'new-team2': 'moderator'});
+      expect(newUser.avgResponseTime, 60);
     });
 
     test('name property and extraData manipulation', () {
@@ -202,6 +215,8 @@ void main() {
       expect(user.lastActive, null);
       expect(user.createdAt, null);
       expect(user.updatedAt, null);
+      expect(user.teamsRole, null);
+      expect(user.avgResponseTime, null);
     });
 
     test('default values, parse json', () {
@@ -218,6 +233,8 @@ void main() {
       expect(user.lastActive, null);
       expect(user.createdAt, null);
       expect(user.updatedAt, null);
+      expect(user.teamsRole, null);
+      expect(user.avgResponseTime, null);
     });
 
     group('ComparableFieldProvider', () {
@@ -449,6 +466,8 @@ User createTestUser({
   bool? banned,
   DateTime? lastActive,
   Map<String, Object?>? extraData,
+  Map<String, String>? teamsRole,
+  int? avgResponseTime,
 }) {
   return User(
     id: id,
@@ -457,5 +476,7 @@ User createTestUser({
     banned: banned ?? false,
     lastActive: lastActive,
     extraData: extraData ?? {},
+    teamsRole: teamsRole,
+    avgResponseTime: avgResponseTime,
   );
 }

--- a/packages/stream_chat/test/src/core/models/user_test.dart
+++ b/packages/stream_chat/test/src/core/models/user_test.dart
@@ -113,7 +113,7 @@ void main() {
         updatedAt: DateTime.parse('2021-05-04 12:39:21.817646'),
         lastActive: DateTime.parse('2021-05-06 12:39:21.817646'),
         language: 'it',
-        teamsRole: {'new-team1': 'owner', 'new-team2': 'moderator'},
+        teamsRole: {'new-team1': 'admin', 'new-team2': 'member'},
         avgResponseTime: 60,
       );
 
@@ -129,7 +129,7 @@ void main() {
       expect(newUser.updatedAt, DateTime.parse('2021-05-04 12:39:21.817646'));
       expect(newUser.lastActive, DateTime.parse('2021-05-06 12:39:21.817646'));
       expect(newUser.language, 'it');
-      expect(newUser.teamsRole, {'new-team1': 'owner', 'new-team2': 'moderator'});
+      expect(newUser.teamsRole, {'new-team1': 'admin', 'new-team2': 'member'});
       expect(newUser.avgResponseTime, 60);
     });
 

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fixed draft message retrieval logic where channel drafts were incorrectly attached to all messages
   instead of only thread drafts being attached to their respective parent messages.
 
+✅ Added
+
+- Added support for `User.avgResponseTime` field.
+
 ## 9.14.0
 
 - Updated `stream_chat` dependency to [`9.14.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -55,7 +55,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 22;
+  int get schemaVersion => 23;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -6185,6 +6185,12 @@ class $UsersTable extends Users with TableInfo<$UsersTable, UserEntity> {
               type: DriftSqlType.string, requiredDuringInsert: false)
           .withConverter<Map<String, String>?>(
               $UsersTable.$converterteamsRolen);
+  static const VerificationMeta _avgResponseTimeMeta =
+      const VerificationMeta('avgResponseTime');
+  @override
+  late final GeneratedColumn<int> avgResponseTime = GeneratedColumn<int>(
+      'avg_response_time', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
       extraData = GeneratedColumn<String>('extra_data', aliasedName, false,
@@ -6201,6 +6207,7 @@ class $UsersTable extends Users with TableInfo<$UsersTable, UserEntity> {
         online,
         banned,
         teamsRole,
+        avgResponseTime,
         extraData
       ];
   @override
@@ -6248,6 +6255,12 @@ class $UsersTable extends Users with TableInfo<$UsersTable, UserEntity> {
       context.handle(_bannedMeta,
           banned.isAcceptableOrUnknown(data['banned']!, _bannedMeta));
     }
+    if (data.containsKey('avg_response_time')) {
+      context.handle(
+          _avgResponseTimeMeta,
+          avgResponseTime.isAcceptableOrUnknown(
+              data['avg_response_time']!, _avgResponseTimeMeta));
+    }
     return context;
   }
 
@@ -6276,6 +6289,8 @@ class $UsersTable extends Users with TableInfo<$UsersTable, UserEntity> {
       teamsRole: $UsersTable.$converterteamsRolen.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}teams_role'])),
+      avgResponseTime: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}avg_response_time']),
       extraData: $UsersTable.$converterextraData.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}extra_data'])!),
@@ -6325,6 +6340,9 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
   /// eg: `{'teamId': 'role', 'teamId2': 'role2'}`
   final Map<String, String>? teamsRole;
 
+  /// The average response time for the user in seconds.
+  final int? avgResponseTime;
+
   /// Map of custom user extraData
   final Map<String, dynamic> extraData;
   const UserEntity(
@@ -6337,6 +6355,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
       required this.online,
       required this.banned,
       this.teamsRole,
+      this.avgResponseTime,
       required this.extraData});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -6363,6 +6382,9 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
       map['teams_role'] =
           Variable<String>($UsersTable.$converterteamsRolen.toSql(teamsRole));
     }
+    if (!nullToAbsent || avgResponseTime != null) {
+      map['avg_response_time'] = Variable<int>(avgResponseTime);
+    }
     {
       map['extra_data'] =
           Variable<String>($UsersTable.$converterextraData.toSql(extraData));
@@ -6383,6 +6405,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
       online: serializer.fromJson<bool>(json['online']),
       banned: serializer.fromJson<bool>(json['banned']),
       teamsRole: serializer.fromJson<Map<String, String>?>(json['teamsRole']),
+      avgResponseTime: serializer.fromJson<int?>(json['avgResponseTime']),
       extraData: serializer.fromJson<Map<String, dynamic>>(json['extraData']),
     );
   }
@@ -6399,6 +6422,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
       'online': serializer.toJson<bool>(online),
       'banned': serializer.toJson<bool>(banned),
       'teamsRole': serializer.toJson<Map<String, String>?>(teamsRole),
+      'avgResponseTime': serializer.toJson<int?>(avgResponseTime),
       'extraData': serializer.toJson<Map<String, dynamic>>(extraData),
     };
   }
@@ -6413,6 +6437,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
           bool? online,
           bool? banned,
           Value<Map<String, String>?> teamsRole = const Value.absent(),
+          Value<int?> avgResponseTime = const Value.absent(),
           Map<String, dynamic>? extraData}) =>
       UserEntity(
         id: id ?? this.id,
@@ -6424,6 +6449,9 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
         online: online ?? this.online,
         banned: banned ?? this.banned,
         teamsRole: teamsRole.present ? teamsRole.value : this.teamsRole,
+        avgResponseTime: avgResponseTime.present
+            ? avgResponseTime.value
+            : this.avgResponseTime,
         extraData: extraData ?? this.extraData,
       );
   UserEntity copyWithCompanion(UsersCompanion data) {
@@ -6438,6 +6466,9 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
       online: data.online.present ? data.online.value : this.online,
       banned: data.banned.present ? data.banned.value : this.banned,
       teamsRole: data.teamsRole.present ? data.teamsRole.value : this.teamsRole,
+      avgResponseTime: data.avgResponseTime.present
+          ? data.avgResponseTime.value
+          : this.avgResponseTime,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
     );
   }
@@ -6454,6 +6485,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
           ..write('online: $online, ')
           ..write('banned: $banned, ')
           ..write('teamsRole: $teamsRole, ')
+          ..write('avgResponseTime: $avgResponseTime, ')
           ..write('extraData: $extraData')
           ..write(')'))
         .toString();
@@ -6461,7 +6493,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
 
   @override
   int get hashCode => Object.hash(id, role, language, createdAt, updatedAt,
-      lastActive, online, banned, teamsRole, extraData);
+      lastActive, online, banned, teamsRole, avgResponseTime, extraData);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -6475,6 +6507,7 @@ class UserEntity extends DataClass implements Insertable<UserEntity> {
           other.online == this.online &&
           other.banned == this.banned &&
           other.teamsRole == this.teamsRole &&
+          other.avgResponseTime == this.avgResponseTime &&
           other.extraData == this.extraData);
 }
 
@@ -6488,6 +6521,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
   final Value<bool> online;
   final Value<bool> banned;
   final Value<Map<String, String>?> teamsRole;
+  final Value<int?> avgResponseTime;
   final Value<Map<String, dynamic>> extraData;
   final Value<int> rowid;
   const UsersCompanion({
@@ -6500,6 +6534,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
     this.online = const Value.absent(),
     this.banned = const Value.absent(),
     this.teamsRole = const Value.absent(),
+    this.avgResponseTime = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -6513,6 +6548,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
     this.online = const Value.absent(),
     this.banned = const Value.absent(),
     this.teamsRole = const Value.absent(),
+    this.avgResponseTime = const Value.absent(),
     required Map<String, dynamic> extraData,
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -6527,6 +6563,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
     Expression<bool>? online,
     Expression<bool>? banned,
     Expression<String>? teamsRole,
+    Expression<int>? avgResponseTime,
     Expression<String>? extraData,
     Expression<int>? rowid,
   }) {
@@ -6540,6 +6577,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
       if (online != null) 'online': online,
       if (banned != null) 'banned': banned,
       if (teamsRole != null) 'teams_role': teamsRole,
+      if (avgResponseTime != null) 'avg_response_time': avgResponseTime,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
     });
@@ -6555,6 +6593,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
       Value<bool>? online,
       Value<bool>? banned,
       Value<Map<String, String>?>? teamsRole,
+      Value<int?>? avgResponseTime,
       Value<Map<String, dynamic>>? extraData,
       Value<int>? rowid}) {
     return UsersCompanion(
@@ -6567,6 +6606,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
       online: online ?? this.online,
       banned: banned ?? this.banned,
       teamsRole: teamsRole ?? this.teamsRole,
+      avgResponseTime: avgResponseTime ?? this.avgResponseTime,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
     );
@@ -6603,6 +6643,9 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
       map['teams_role'] = Variable<String>(
           $UsersTable.$converterteamsRolen.toSql(teamsRole.value));
     }
+    if (avgResponseTime.present) {
+      map['avg_response_time'] = Variable<int>(avgResponseTime.value);
+    }
     if (extraData.present) {
       map['extra_data'] = Variable<String>(
           $UsersTable.$converterextraData.toSql(extraData.value));
@@ -6625,6 +6668,7 @@ class UsersCompanion extends UpdateCompanion<UserEntity> {
           ..write('online: $online, ')
           ..write('banned: $banned, ')
           ..write('teamsRole: $teamsRole, ')
+          ..write('avgResponseTime: $avgResponseTime, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -12375,6 +12419,7 @@ typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<bool> online,
   Value<bool> banned,
   Value<Map<String, String>?> teamsRole,
+  Value<int?> avgResponseTime,
   required Map<String, dynamic> extraData,
   Value<int> rowid,
 });
@@ -12388,6 +12433,7 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<bool> online,
   Value<bool> banned,
   Value<Map<String, String>?> teamsRole,
+  Value<int?> avgResponseTime,
   Value<Map<String, dynamic>> extraData,
   Value<int> rowid,
 });
@@ -12430,6 +12476,10 @@ class $$UsersTableFilterComposer
       get teamsRole => $composableBuilder(
           column: $table.teamsRole,
           builder: (column) => ColumnWithTypeConverterFilters(column));
+
+  ColumnFilters<int> get avgResponseTime => $composableBuilder(
+      column: $table.avgResponseTime,
+      builder: (column) => ColumnFilters(column));
 
   ColumnWithTypeConverterFilters<Map<String, dynamic>, Map<String, dynamic>,
           String>
@@ -12474,6 +12524,10 @@ class $$UsersTableOrderingComposer
   ColumnOrderings<String> get teamsRole => $composableBuilder(
       column: $table.teamsRole, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get avgResponseTime => $composableBuilder(
+      column: $table.avgResponseTime,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get extraData => $composableBuilder(
       column: $table.extraData, builder: (column) => ColumnOrderings(column));
 }
@@ -12515,6 +12569,9 @@ class $$UsersTableAnnotationComposer
       get teamsRole => $composableBuilder(
           column: $table.teamsRole, builder: (column) => column);
 
+  GeneratedColumn<int> get avgResponseTime => $composableBuilder(
+      column: $table.avgResponseTime, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
       get extraData => $composableBuilder(
           column: $table.extraData, builder: (column) => column);
@@ -12552,6 +12609,7 @@ class $$UsersTableTableManager extends RootTableManager<
             Value<bool> online = const Value.absent(),
             Value<bool> banned = const Value.absent(),
             Value<Map<String, String>?> teamsRole = const Value.absent(),
+            Value<int?> avgResponseTime = const Value.absent(),
             Value<Map<String, dynamic>> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -12565,6 +12623,7 @@ class $$UsersTableTableManager extends RootTableManager<
             online: online,
             banned: banned,
             teamsRole: teamsRole,
+            avgResponseTime: avgResponseTime,
             extraData: extraData,
             rowid: rowid,
           ),
@@ -12578,6 +12637,7 @@ class $$UsersTableTableManager extends RootTableManager<
             Value<bool> online = const Value.absent(),
             Value<bool> banned = const Value.absent(),
             Value<Map<String, String>?> teamsRole = const Value.absent(),
+            Value<int?> avgResponseTime = const Value.absent(),
             required Map<String, dynamic> extraData,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -12591,6 +12651,7 @@ class $$UsersTableTableManager extends RootTableManager<
             online: online,
             banned: banned,
             teamsRole: teamsRole,
+            avgResponseTime: avgResponseTime,
             extraData: extraData,
             rowid: rowid,
           ),

--- a/packages/stream_chat_persistence/lib/src/entity/users.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/users.dart
@@ -34,6 +34,9 @@ class Users extends Table {
   /// eg: `{'teamId': 'role', 'teamId2': 'role2'}`
   TextColumn get teamsRole => text().nullable().map(MapConverter<String>())();
 
+  /// The average response time for the user in seconds.
+  IntColumn get avgResponseTime => integer().nullable()();
+
   /// Map of custom user extraData
   TextColumn get extraData => text().map(MapConverter())();
 

--- a/packages/stream_chat_persistence/lib/src/mapper/user_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/user_mapper.dart
@@ -15,6 +15,7 @@ extension UserEntityX on UserEntity {
         banned: banned,
         createdAt: createdAt,
         teamsRole: teamsRole,
+        avgResponseTime: avgResponseTime,
       );
 }
 
@@ -31,6 +32,7 @@ extension UserX on User {
         online: online,
         banned: banned,
         teamsRole: teamsRole,
+        avgResponseTime: avgResponseTime,
         extraData: extraData,
       );
 }

--- a/packages/stream_chat_persistence/test/src/mapper/user_mapper_test.dart
+++ b/packages/stream_chat_persistence/test/src/mapper/user_mapper_test.dart
@@ -19,6 +19,7 @@ void main() {
       online: math.Random().nextBool(),
       banned: math.Random().nextBool(),
       teamsRole: const {'teamId': 'role', 'teamId2': 'role2'},
+      avgResponseTime: 120,
       extraData: {'test_extra_data': 'extraData'},
     );
     final user = entity.toUser();
@@ -32,6 +33,7 @@ void main() {
     expect(user.online, entity.online);
     expect(user.banned, entity.banned);
     expect(user.teamsRole, entity.teamsRole);
+    expect(user.avgResponseTime, entity.avgResponseTime);
     expect(user.extraData, entity.extraData);
   });
 
@@ -46,6 +48,7 @@ void main() {
       online: math.Random().nextBool(),
       banned: math.Random().nextBool(),
       teamsRole: const {'teamId': 'role', 'teamId2': 'role2'},
+      avgResponseTime: 120,
       extraData: const {'test_extra_data': 'extraData'},
     );
     final entity = user.toEntity();
@@ -59,6 +62,7 @@ void main() {
     expect(entity.online, user.online);
     expect(entity.banned, user.banned);
     expect(entity.teamsRole, user.teamsRole);
+    expect(entity.avgResponseTime, user.avgResponseTime);
     expect(entity.extraData, user.extraData);
   });
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-212

## Description of the pull request
This commit introduces a new field to the `User` model:

- `avgResponseTime`: An integer representing the average response time of the user in seconds.

These field is now included in:
- `User` and `OwnUser` model classes.
- JSON serialization and deserialization for `User` and `OwnUser`.
- The `UserEntity` in `stream_chat_persistence` and its corresponding database schema.
- Relevant tests have been updated to include this new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field to user profiles that tracks average response time in seconds.
  * Support for this new field is now integrated into user data handling and storage.

* **Bug Fixes**
  * None.

* **Tests**
  * Updated test coverage to verify correct parsing, serialization, and mapping of the average response time field.

* **Documentation**
  * Changelogs updated to reflect the addition of the new user field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->