### PR TITLE
fix(ui): StreamCommandAutocompleteOptions command name styling

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -14,6 +14,7 @@
 🐞 Fixed
 
 - Fixed `StreamMessageInput` tries to expand to full height when used in a unconstrained environment.
+- Fixed `StreamCommandAutocompleteOptions` to style the command name with `textHighEmphasis` style.
 
 ## 9.13.0
 

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
@@ -623,7 +623,7 @@ class StreamAutocompleteOptions<T extends Object> extends StatelessWidget {
         children: [
           if (headerBuilder != null) ...[
             headerBuilder!(context),
-            Divider(height: 0, color: color ?? colorTheme.barsBg),
+            Divider(height: 0, color: colorTheme.borders),
           ],
           LimitedBox(
             maxHeight: maxHeight ?? height * 0.5,

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_autocomplete.dart
@@ -623,7 +623,7 @@ class StreamAutocompleteOptions<T extends Object> extends StatelessWidget {
         children: [
           if (headerBuilder != null) ...[
             headerBuilder!(context),
-            const Divider(height: 0),
+            Divider(height: 0, color: color ?? colorTheme.barsBg),
           ],
           LimitedBox(
             maxHeight: maxHeight ?? height * 0.5,

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
@@ -51,9 +51,8 @@ class StreamCommandAutocompleteOptions extends StatelessWidget {
           ),
           title: Text(
             context.translations.instantCommandsLabel,
-            style: TextStyle(
-              // ignore: deprecated_member_use
-              color: colorTheme.textHighEmphasis.withOpacity(0.5),
+            style: textTheme.body.copyWith(
+              color: colorTheme.textLowEmphasis,
             ),
           ),
         );
@@ -67,8 +66,7 @@ class StreamCommandAutocompleteOptions extends StatelessWidget {
             children: [
               Text(
                 command.name.capitalize(),
-                style: textTheme.body.copyWith(
-                  fontWeight: FontWeight.bold,
+                style: textTheme.bodyBold.copyWith(
                   color: colorTheme.textHighEmphasis,
                 ),
               ),

--- a/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
+++ b/packages/stream_chat_flutter/lib/src/autocomplete/stream_command_autocomplete_options.dart
@@ -67,8 +67,9 @@ class StreamCommandAutocompleteOptions extends StatelessWidget {
             children: [
               Text(
                 command.name.capitalize(),
-                style: const TextStyle(
+                style: textTheme.body.copyWith(
                   fontWeight: FontWeight.bold,
+                  color: colorTheme.textHighEmphasis,
                 ),
               ),
               const SizedBox(width: 8),


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable) 

## Description of the pull request
The `StreamCommandAutocompleteOptions` widget always rendered the name with default text styling with bold applied. This meant it did not render correctly in dark modes.

This updates it to use the `textHighEmphasis` styling, along with still applying `FontWeight.bold`.

I could not find any existing tests for the behavior - nor for autocomplete widgets in general, so I'm unsure where we'd like to place tests. Also appears to be no goldens for these widgets either.

Also updates the 0 height divider to simply match the background color. Since it was 0 height, I figured the intent (atleast on light mode) is that it wouldn't show at all, but it did show in dark mode.

## Screenshots / Videos

Text:
| Before | After |
| --- | --- |
|<img width="511" height="60" alt="image" src="https://github.com/user-attachments/assets/658daac3-7661-4dba-a0a6-7cf8103509c1" /><img width="508" height="51" alt="image" src="https://github.com/user-attachments/assets/48022f94-dd3b-498d-8bad-53cd706fb934" />|<img width="516" height="66" alt="image" src="https://github.com/user-attachments/assets/cb3f4c22-9dfd-4330-bebc-196625ea9931" /><img width="515" height="55" alt="image" src="https://github.com/user-attachments/assets/b75b84b2-f7f8-4cb7-9fe1-84e3954ffb76" />|

Divider: 
| Before | After |
| --- | --- |
|<img width="509" height="121" alt="image" src="https://github.com/user-attachments/assets/1bd1baa2-a5ac-4637-8fec-809a076daac7" />|<img width="508" height="122" alt="image" src="https://github.com/user-attachments/assets/457b068a-c5f9-49f0-82e5-8a780a8f642f" />|






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visual appearance of dividers in autocomplete options to better match the app’s theme.
  * Updated the command name styling in autocomplete options to use dynamic theme-based colors for better consistency and readability.

* **Documentation**
  * Updated the changelog to include additional styling fixes for autocomplete command names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->