### PR TITLE
feat(llc): add skipPush to updateMessage

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -3,6 +3,8 @@
 ✅ Added
 
 - Added `avgResponseTime` field to the `User` model to track average response time in seconds.
+- Added support for `skipPush` while updating a channel message, which allows you to update a
+  message without sending a push notification.
 
 🐞 Fixed
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -758,6 +758,7 @@ class Channel {
   /// before actually updating the message.
   Future<UpdateMessageResponse> updateMessage(
     Message message, {
+    bool skipPush = false,
     bool skipEnrichUrl = false,
   }) async {
     _checkInitialized();
@@ -803,6 +804,7 @@ class Channel {
       final response = await _updateMessageLock.synchronized(
         () => _client.updateMessage(
           message,
+          skipPush: skipPush,
           skipEnrichUrl: skipEnrichUrl,
         ),
       );

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1672,10 +1672,12 @@ class StreamChatClient {
   /// Update the given message
   Future<UpdateMessageResponse> updateMessage(
     Message message, {
+    bool skipPush = false,
     bool skipEnrichUrl = false,
   }) =>
       _chatApi.message.updateMessage(
         message,
+        skipPush: skipPush,
         skipEnrichUrl: skipEnrichUrl,
       );
 

--- a/packages/stream_chat/lib/src/core/api/message_api.dart
+++ b/packages/stream_chat/lib/src/core/api/message_api.dart
@@ -136,12 +136,14 @@ class MessageApi {
   /// Updates the given [message]
   Future<UpdateMessageResponse> updateMessage(
     Message message, {
+    bool skipPush = false,
     bool skipEnrichUrl = false,
   }) async {
     final response = await _client.post(
       '/messages/${message.id}',
       data: {
         'message': message,
+        'skip_push': skipPush,
         'skip_enrich_url': skipEnrichUrl,
       },
     );

--- a/packages/stream_chat/test/src/core/api/message_api_test.dart
+++ b/packages/stream_chat/test/src/core/api/message_api_test.dart
@@ -143,6 +143,7 @@ void main() {
           path,
           data: {
             'message': message,
+            'skip_push': false,
             'skip_enrich_url': false,
           },
         )).thenAnswer(


### PR DESCRIPTION
## Description of the pull request
This commit introduces a new optional parameter `skipPush` to the `updateMessage` method in `Channel`, `StreamChatClient`, and `MessageApi`.

When `skipPush` is set to `true`, push notifications will not be sent for the updated message. This is useful for scenarios where you want to update a message without notifying users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for skipping push notifications when updating a message. You can now update messages without triggering a push notification by using the new option.

* **Documentation**
  * Updated the changelog to reflect the new skip push notification feature.

* **Tests**
  * Enhanced tests to verify the correct handling of the skip push notification option during message updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->