### PR TITLE
chore(core, llc): skip generating freezed map and when options

### DIFF
--- a/packages/stream_chat_flutter_core/build.yaml
+++ b/packages/stream_chat_flutter_core/build.yaml
@@ -1,10 +1,6 @@
 targets:
   $default:
     builders:
-      json_serializable:
-        options:
-          explicit_to_json: true
-          field_rename: snake
       freezed:
         options:
           map: false


### PR DESCRIPTION
## Description of the pull request
This PR removes the `map` and `when` options from the `freezed` builder in the `build.yaml` files for `stream_chat` and `stream_chat_flutter_core`.
