### PR TITLE
feat(ui): add custom context menu implementation

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -29,7 +29,6 @@ command:
       chewie: ^1.8.1
       collection: ^1.17.2
       connectivity_plus: ^6.0.3
-      contextmenu: ^3.0.0
       cupertino_icons: ^1.0.3
       desktop_drop: '>=0.5.0 <0.7.0'
       device_info_plus: '>=10.1.2 <12.0.0'

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed context menu being truncated and scrollable on web when there was enough space to display it
+  fully. [[#2317]](https://github.com/GetStream/stream-chat-flutter/issues/2317)
+
 ## 9.15.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/context_menu/context_menu.dart
+++ b/packages/stream_chat_flutter/lib/src/context_menu/context_menu.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+const double _kContextMenuScreenPadding = 8;
+const double _kContextMenuWidth = 222;
+
+/// Signature for a builder function that wraps the context menu widget.
+///
+/// This builder can be used to customize the appearance of the menu
+/// container by wrapping [child] in additional UI elements.
+typedef ContextMenuBuilder = Widget Function(
+  BuildContext context,
+  Widget child,
+);
+
+/// A widget that displays a context menu anchored to a specific [Offset].
+///
+/// The menu will try to position itself as close to the [anchor] as possible,
+/// while respecting screen padding and safe areas.
+class ContextMenu extends StatelessWidget {
+  /// Creates a [ContextMenu].
+  ///
+  /// The [anchor] defines where the menu is shown, and [menuItems] are the
+  /// widgets displayed within the menu. An optional [menuBuilder] can be used
+  /// to customize the menu's container.
+  ///
+  /// The [menuItems] list must not be empty.
+  const ContextMenu({
+    super.key,
+    required this.anchor,
+    required this.menuItems,
+    this.menuBuilder = _defaultMenuBuilder,
+  }) : assert(menuItems.length > 0, 'Context menu must have at least one item');
+
+  /// The target position on screen where the context menu should appear.
+  final Offset anchor;
+
+  /// The list of menu items to display inside the menu.
+  ///
+  /// These can be [ListTile] widgets, buttons, or any other widget.
+  final List<Widget> menuItems;
+
+  /// Builds the outer container for the menu.
+  ///
+  /// The [menuBuilder] receives the current context and a [child] widget
+  /// containing all the [menuItems].
+  ///
+  /// Defaults to a card-style scrollable container with fixed width.
+  final ContextMenuBuilder menuBuilder;
+
+  /// Default menu container with standard styling.
+  ///
+  /// Wraps the menu content in a card-like [Material] with scroll support,
+  /// applying max width and height constraints.
+  static Widget _defaultMenuBuilder(BuildContext context, Widget child) {
+    final availableHeight = MediaQuery.of(context).size.height;
+    final maxHeight = availableHeight - _kContextMenuScreenPadding * 2;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minWidth: _kContextMenuWidth,
+        maxWidth: _kContextMenuWidth,
+        maxHeight: maxHeight,
+      ),
+      child: Material(
+        elevation: 1,
+        type: MaterialType.card,
+        clipBehavior: Clip.antiAlias,
+        borderRadius: const BorderRadius.all(Radius.circular(7)),
+        child: SingleChildScrollView(child: child),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasMediaQuery(context), '');
+
+    final safePadding = MediaQuery.paddingOf(context);
+    final paddingAbove = safePadding.top + _kContextMenuScreenPadding;
+    final localAdjustment = Offset(_kContextMenuScreenPadding, paddingAbove);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        _kContextMenuScreenPadding,
+        paddingAbove,
+        _kContextMenuScreenPadding,
+        _kContextMenuScreenPadding,
+      ),
+      child: CustomSingleChildLayout(
+        delegate: DesktopTextSelectionToolbarLayoutDelegate(
+          anchor: anchor - localAdjustment,
+        ),
+        child: menuBuilder.call(
+          context,
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: menuItems,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/stream_chat_flutter/lib/src/context_menu/context_menu_region.dart
+++ b/packages/stream_chat_flutter/lib/src/context_menu/context_menu_region.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
+
+/// Signature for a function that builds a context menu widget.
+///
+/// The function receives the [BuildContext] and the [Offset] where
+/// the menu should appear.
+typedef ContextMenuBuilder = Widget Function(
+  BuildContext context,
+  Offset offset,
+);
+
+/// Displays a custom context menu as a general dialog.
+///
+/// The [contextMenuBuilder] is used to construct the contents of the
+/// context menu, typically positioned based on the triggering gesture.
+///
+/// The dialog can be customized using parameters such as [barrierColor],
+/// [barrierLabel], [transitionDuration], [transitionBuilder], etc.
+///
+/// Returns a [Future] that resolves when the menu is dismissed.
+Future<T?> showContextMenu<T>({
+  required BuildContext context,
+  required WidgetBuilder contextMenuBuilder,
+  String? barrierLabel,
+  Color? barrierColor,
+  Duration transitionDuration = const Duration(milliseconds: 150),
+  RouteTransitionsBuilder? transitionBuilder,
+  bool useRootNavigator = true,
+  RouteSettings? routeSettings,
+}) async {
+  assert(debugCheckHasMaterialLocalizations(context), '');
+  final localizations = MaterialLocalizations.of(context);
+
+  final capturedThemes = InheritedTheme.capture(
+    from: context,
+    to: Navigator.of(context, rootNavigator: useRootNavigator).context,
+  );
+
+  return showGeneralDialog(
+    context: context,
+    barrierDismissible: true,
+    useRootNavigator: useRootNavigator,
+    routeSettings: routeSettings,
+    transitionDuration: transitionDuration,
+    barrierColor: barrierColor ?? Colors.transparent,
+    barrierLabel: barrierLabel ?? localizations.modalBarrierDismissLabel,
+    transitionBuilder: (context, animation, secondaryAnimation, child) {
+      if (transitionBuilder case final builder?) {
+        return builder(context, animation, secondaryAnimation, child);
+      }
+
+      final fadeAnimation = CurveTween(curve: const Interval(0, 0.3));
+
+      return FadeTransition(
+        opacity: fadeAnimation.animate(animation),
+        child: child,
+      );
+    },
+    pageBuilder: (context, animation, secondaryAnimation) {
+      final pageChild = Builder(builder: contextMenuBuilder);
+      return capturedThemes.wrap(pageChild);
+    },
+  );
+}
+
+/// A widget that provides a region for showing a context menu.
+///
+/// When the user performs a long-press (on touch devices) or right-click
+/// (on desktop/web), a custom context menu is displayed at the gesture location.
+class ContextMenuRegion extends StatefulWidget {
+  /// Creates a [ContextMenuRegion].
+  ///
+  /// The [child] is the widget wrapped by this region. When a gesture is
+  /// detected on it, the [contextMenuBuilder] is used to construct the menu.
+  const ContextMenuRegion({
+    super.key,
+    required this.child,
+    required this.contextMenuBuilder,
+  });
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// Called to build the context menu when the gesture is triggered.
+  ///
+  /// The builder is given the [BuildContext] and the [Offset] of the gesture.
+  final ContextMenuBuilder contextMenuBuilder;
+
+  @override
+  State<ContextMenuRegion> createState() => _ContextMenuRegionState();
+}
+
+class _ContextMenuRegionState extends State<ContextMenuRegion> {
+  @override
+  void initState() {
+    super.initState();
+    // Prevent the browser's native context menu on web.
+    if (CurrentPlatform.isWeb) BrowserContextMenu.disableContextMenu();
+  }
+
+  @override
+  void dispose() {
+    // Restore browser context menu behavior.
+    if (CurrentPlatform.isWeb) BrowserContextMenu.enableContextMenu();
+    super.dispose();
+  }
+
+  Future<void> _showContextMenu(BuildContext context, Offset position) async {
+    print('ContextMenuRegion: Showing context menu at $position');
+    await showContextMenu(
+      context: context,
+      contextMenuBuilder: (context) {
+        return widget.contextMenuBuilder(context, position);
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onLongPressStart: (it) => _showContextMenu(context, it.globalPosition),
+      onSecondaryTapUp: (it) => _showContextMenu(context, it.globalPosition),
+      child: widget.child,
+    );
+  }
+}

--- a/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media_desktop.dart
+++ b/packages/stream_chat_flutter/lib/src/fullscreen_media/full_screen_media_desktop.dart
@@ -1,8 +1,9 @@
-import 'package:contextmenu/contextmenu.dart';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:photo_view/photo_view.dart';
+import 'package:stream_chat_flutter/src/context_menu/context_menu.dart';
+import 'package:stream_chat_flutter/src/context_menu/context_menu_region.dart';
 import 'package:stream_chat_flutter/src/context_menu_items/download_menu_item.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/full_screen_media_widget.dart';
 import 'package:stream_chat_flutter/src/fullscreen_media/gallery_navigation_item.dart';
@@ -121,14 +122,18 @@ class _FullScreenMediaDesktopState extends State<FullScreenMediaDesktop> {
   Widget _buildVideoPageView() {
     return Stack(
       children: [
-        ContextMenuArea(
-          verticalPadding: 0,
-          builder: (_) => [
-            DownloadMenuItem(
-              attachment:
-                  widget.mediaAttachmentPackages[_currentPage.value].attachment,
-            ),
-          ],
+        ContextMenuRegion(
+          contextMenuBuilder: (_, anchor) {
+            return ContextMenu(
+              anchor: anchor,
+              menuItems: [
+                DownloadMenuItem(
+                  attachment: widget
+                      .mediaAttachmentPackages[_currentPage.value].attachment,
+                ),
+              ],
+            );
+          },
           child: _PlaylistPlayer(
             packages: videoPackages.values.toList(),
             autoStart: widget.autoplayVideos,
@@ -356,13 +361,17 @@ class _FullScreenMediaDesktopState extends State<FullScreenMediaDesktop> {
                                   ? kToolbarHeight + bottomPadding
                                   : 0,
                             ),
-                            child: ContextMenuArea(
-                              verticalPadding: 0,
-                              builder: (_) => [
-                                DownloadMenuItem(
-                                  attachment: attachment,
-                                ),
-                              ],
+                            child: ContextMenuRegion(
+                              contextMenuBuilder: (_, anchor) {
+                                return ContextMenu(
+                                  anchor: anchor,
+                                  menuItems: [
+                                    DownloadMenuItem(
+                                      attachment: attachment,
+                                    ),
+                                  ],
+                                );
+                              },
                               child: Video(
                                 controller: package.controller,
                               ),

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -1,9 +1,10 @@
-import 'package:contextmenu/contextmenu.dart';
 import 'package:flutter/material.dart' hide ButtonStyle;
 import 'package:flutter/services.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:stream_chat_flutter/conditional_parent_builder/conditional_parent_builder.dart';
 import 'package:stream_chat_flutter/platform_widget_builder/platform_widget_builder.dart';
+import 'package:stream_chat_flutter/src/context_menu/context_menu.dart';
+import 'package:stream_chat_flutter/src/context_menu/context_menu_region.dart';
 import 'package:stream_chat_flutter/src/context_menu_items/context_menu_reaction_picker.dart';
 import 'package:stream_chat_flutter/src/context_menu_items/stream_chat_context_menu_item.dart';
 import 'package:stream_chat_flutter/src/dialogs/dialogs.dart';
@@ -696,9 +697,14 @@ class _StreamMessageWidgetState extends State<StreamMessageWidget>
         // context menu actions.
         if (message.state.isDeleted || message.state.isOutgoing) return child;
 
-        return ContextMenuArea(
-          verticalPadding: 0,
-          builder: (_) => _buildDesktopOrWebActions(context, message),
+        final menuItems = _buildDesktopOrWebActions(context, message);
+        if (menuItems.isEmpty) return child;
+
+        return ContextMenuRegion(
+          contextMenuBuilder: (_, anchor) => ContextMenu(
+            anchor: anchor,
+            menuItems: menuItems,
+          ),
           child: child,
         );
       },

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   cached_network_image: ^3.3.1
   chewie: ^1.8.1
   collection: ^1.17.2
-  contextmenu: ^3.0.0
   desktop_drop: ">=0.5.0 <0.7.0"
   diacritic: ^0.1.5
   dio: ^5.4.3+1


### PR DESCRIPTION
# Submit a pull request
<!--Optional to add github issue which is solved by this PR-->
Fixes: #2317

## Description of the pull request
This PR introduces a custom context menu implementation to replace the `contextmenu` package.

The new implementation includes:
- `ContextMenuRegion`: A widget that provides a region for showing a context menu on long-press or right-click.
- `ContextMenu`: A widget that displays the actual context menu, anchored to a specific offset.
- `showContextMenu`: A function to display the context menu as a general dialog.

This change allows for more control and customization of the context menu behavior and appearance within the application.

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->


| Before | After |
| --- | --- |
| <img width="400" alt="Image" src="https://github.com/user-attachments/assets/7979e36a-d004-4e24-a4a5-559e02229204" /> | <img width="400" alt="Screenshot 2025-07-29 at 15 31 38" src="https://github.com/user-attachments/assets/ca967077-eded-42df-af15-3369f24d0d4d" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new customizable context menu system for desktop and web, including new widgets for displaying and anchoring context menus.
* **Refactor**
  * Replaced the external context menu dependency with an internally developed context menu solution across the application.
  * Updated message and media components to use the new context menu widgets for a consistent user experience.
* **Bug Fixes**
  * Fixed context menu display issues on web where menus were truncated and scrollable despite sufficient space.
* **Chores**
  * Removed the external context menu package from project dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->