### PR TITLE
fix(ui): prevent cooldown resume crash if channel state is null

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `Channel` methods to throw proper `StateError` exceptions instead of relying on assertions
+  for state validation.
+
 ## 9.15.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2049,15 +2049,18 @@ class Channel {
   void dispose() {
     client.state.removeChannel('$cid');
     state?.dispose();
+    state = null;
     _muteExpirationTimer?.cancel();
     _keyStrokeHandler.cancel();
   }
 
   void _checkInitialized() {
-    assert(
-      _initializedCompleter.isCompleted,
-      "Channel $cid hasn't been initialized yet. Make sure to call .watch()"
-      ' or to instantiate the client using [Channel.fromState]',
+    if (_initializedCompleter.isCompleted && state != null) return;
+
+    throw StateError(
+      "Channel $cid hasn't been initialized yet or has been disposed. "
+      'Make sure to call .watch() or instantiate the client using '
+      '[Channel.fromState]',
     );
   }
 }

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed context menu being truncated and scrollable on web when there was enough space to display it
   fully. [[#2317]](https://github.com/GetStream/stream-chat-flutter/issues/2317)
+- Fixed `StreamMessageInput` cooldown resume error if channel state is not yet initialized.
+  [[#2338]](https://github.com/GetStream/stream-chat-flutter/issues/2338)
 
 ✅ Added
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -571,7 +571,7 @@ class StreamMessageInputState extends State<StreamMessageInput>
     final config = StreamChatConfiguration.of(context);
 
     // Resumes the cooldown if the channel has currently an active cooldown.
-    if (!_isEditing) {
+    if (!_isEditing && channel.state != null) {
       _effectiveController.startCooldown(channel.getRemainingCooldown());
     }
 


### PR DESCRIPTION
Submit a pull request
<!--Optional to add github issue which is solved by this PR-->
Fixes: #2338

## Description of the pull request

This PR addresses a potential null pointer exception in `StreamMessageInput`.

Previously, when the `StreamMessageInput` was initialized and not in editing mode, it would attempt to resume a message cooldown by calling `channel.getRemainingCooldown()`. However, if `channel.state` was null (e.g., if the channel hadn't been fully initialized or loaded yet), this would lead to a crash.

The fix adds a check to ensure `channel.state` is not null before attempting to resume the cooldown. This prevents the crash and ensures the cooldown logic is only applied when the channel state is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in channel methods to provide clearer exceptions when channels are uninitialized or disposed.
  * Fixed an issue where the message input widget could incorrectly attempt to resume cooldown when the channel state was not initialized.

* **Tests**
  * Added new tests to verify correct error handling and cooldown behavior for channels in various states (uninitialized, initialized, disposed).

* **Documentation**
  * Updated changelogs to reflect recent bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->