### PR TITLE
fix(core): improve thread reply pagination logic

### DIFF
--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -1671,22 +1671,29 @@ class Channel {
     PaginationParams? options,
     bool preferOffline = false,
   }) async {
-    final cachedReplies = await _client.chatPersistenceClient?.getReplies(
-      parentId,
-      options: options,
-    );
-    if (cachedReplies != null && cachedReplies.isNotEmpty) {
-      state?.updateThreadInfo(parentId, cachedReplies);
-      if (preferOffline) {
-        return QueryRepliesResponse()..messages = cachedReplies;
+    QueryRepliesResponse? response;
+
+    // If we prefer offline, we first try to get the replies from the
+    // offline storage.
+    if (preferOffline) {
+      if (_client.chatPersistenceClient case final persistenceClient?) {
+        final cachedReplies = await persistenceClient.getReplies(
+          parentId,
+          options: options,
+        );
+
+        // If the cached replies are not empty, we can use them.
+        if (cachedReplies.isNotEmpty) {
+          response = QueryRepliesResponse()..messages = cachedReplies;
+        }
       }
     }
-    final repliesResponse = await _client.getReplies(
-      parentId,
-      options: options,
-    );
-    state?.updateThreadInfo(parentId, repliesResponse.messages);
-    return repliesResponse;
+
+    // If we still don't have the replies, we try to get them from the API.
+    response ??= await _client.getReplies(parentId, options: options);
+    state?.updateThreadInfo(parentId, response.messages);
+
+    return response;
   }
 
   /// List the reactions for a message in the channel.

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -462,10 +462,6 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
           _firstUnreadMessage = streamChannel?.getFirstUnreadMessage();
         }),
       );
-
-      if (_isThreadConversation) {
-        streamChannel!.getReplies(widget.parentMessage!.id);
-      }
     }
   }
 

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `MessageListCore` not properly loading and paginating thread replies.
+
+✅ Added
+
+- Added methods for paginating thread replies in `StreamChannel`.
+
 ## 9.15.0
 
 ✅ Added

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -178,8 +178,9 @@ class MessageListCoreState extends State<MessageListCore> {
         limit: widget.paginationLimit,
       );
     } else {
-      return _streamChannel!.getReplies(
+      return _streamChannel!.queryReplies(
         widget.parentMessage!.id,
+        direction: direction,
         limit: widget.paginationLimit,
       );
     }

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -345,7 +345,7 @@ class StreamChannelState extends State<StreamChannel> {
     try {
       final pagination = PaginationParams(
         limit: limit,
-        greaterThanOrEqual: recentReply.id,
+        greaterThan: recentReply.id,
       );
 
       final response = await channel.getReplies(
@@ -651,7 +651,7 @@ class StreamChannelState extends State<StreamChannel> {
   }) {
     final pagination = PaginationParams(
       limit: limit,
-      greaterThanOrEqual: messageId,
+      greaterThan: messageId,
     );
 
     return channel.query(

--- a/packages/stream_chat_flutter_core/test/message_list_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/message_list_core_test.dart
@@ -412,6 +412,13 @@ void main() {
           .thenAnswer((_) => Stream.value(threads));
       when(() => mockChannel.state.unreadCount).thenReturn(0);
 
+      when(
+        () => mockChannel.getReplies(
+          parentMessage.id,
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async => QueryRepliesResponse()..messages = []);
+
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,

--- a/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
@@ -148,9 +148,9 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
           msgList.removeRange(lessThanIndex, msgList.length);
         }
       }
-      if (options?.greaterThanOrEqual != null) {
+      if (options?.greaterThan != null) {
         final greaterThanIndex = msgList.indexWhere(
-          (m) => m.id == options!.greaterThanOrEqual,
+          (m) => m.id == options!.greaterThan,
         );
         if (greaterThanIndex != -1) {
           msgList.removeRange(0, greaterThanIndex);
@@ -203,9 +203,9 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
           msgList.removeRange(lessThanIndex, msgList.length);
         }
       }
-      if (messagePagination?.greaterThanOrEqual != null) {
+      if (messagePagination?.greaterThan != null) {
         final greaterThanIndex = msgList.indexWhere(
-          (m) => m.id == messagePagination!.greaterThanOrEqual,
+          (m) => m.id == messagePagination!.greaterThan,
         );
         if (greaterThanIndex != -1) {
           msgList.removeRange(0, greaterThanIndex);

--- a/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
@@ -146,9 +146,9 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
           msgList.removeRange(lessThanIndex, msgList.length);
         }
       }
-      if (options?.greaterThanOrEqual != null) {
+      if (options?.greaterThan != null) {
         final greaterThanIndex = msgList.indexWhere(
-          (m) => m.id == options!.greaterThanOrEqual,
+          (m) => m.id == options!.greaterThan,
         );
         if (greaterThanIndex != -1) {
           msgList.removeRange(0, greaterThanIndex);
@@ -201,9 +201,9 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
           msgList.removeRange(lessThanIndex, msgList.length);
         }
       }
-      if (messagePagination?.greaterThanOrEqual != null) {
+      if (messagePagination?.greaterThan != null) {
         final greaterThanIndex = msgList.indexWhere(
-          (m) => m.id == messagePagination!.greaterThanOrEqual,
+          (m) => m.id == messagePagination!.greaterThan,
         );
         if (greaterThanIndex != -1) {
           msgList.removeRange(0, greaterThanIndex);

--- a/packages/stream_chat_persistence/test/src/dao/pinned_message_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/pinned_message_dao_test.dart
@@ -353,11 +353,11 @@ void main() {
     const cid = 'test:Cid';
     const limit = 15;
     const lessThan = 'testMessageId${cid}25';
-    const greaterThanOrEqual = 'testMessageId${cid}5';
+    const greaterThan = 'testMessageId${cid}5';
     const pagination = PaginationParams(
       limit: limit,
       lessThan: lessThan,
-      greaterThanOrEqual: greaterThanOrEqual,
+      greaterThan: greaterThan,
     );
 
     // Should be empty initially
@@ -377,7 +377,7 @@ void main() {
       messagePagination: pagination,
     );
     expect(fetchedMessages.length, limit);
-    expect(fetchedMessages.first.id, greaterThanOrEqual);
+    expect(fetchedMessages.first.id, greaterThan);
     expect(fetchedMessages.last.id != lessThan, true);
   });
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-223

## Description of the pull request

This PR fixes an issue where `MessageListCore` was not properly loading and paginating thread replies.

It introduces new methods in `StreamChannel` for paginating thread replies in both directions (top and bottom).

Key changes:
- `MessageListCore` now uses the new `queryReplies` method from `StreamChannel` for pagination.
- `StreamChannel.getReplies` is updated to query the latest replies and set pagination states accordingly.
- New private methods `_queryTopReplies` and `_queryBottomReplies` are added to `StreamChannel` to handle pagination in specific directions.
- The `MessageListView` no longer calls `getReplies` on initialization, as this is now handled by the initial query within `StreamChannel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new methods for paginating thread replies, allowing users to load older or newer replies in a thread.
  * Introduced a more flexible approach to querying thread replies with support for directional pagination.
  * Added a method to clear all replies in a thread for better thread management.

* **Bug Fixes**
  * Resolved issues with loading and paginating thread replies in message lists, ensuring smoother thread reply navigation.

* **Documentation**
  * Updated the changelog to reflect recent improvements and bug fixes related to thread replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->