### PR TITLE
fix(llc): preserve OwnUser fields on user.updated events

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fixed `Channel` methods to throw proper `StateError` exceptions instead of relying on assertions
   for state validation.
+- Fixed `OwnUser` specific fields getting lost when creating a new `OwnUser` instance from
+  an `User` instance.
+- Fixed `Client.currentUser` specific fields getting reset on `user.updated` events.
 
 ## 9.15.0
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -2125,10 +2125,24 @@ class ClientState {
   void _listenUserUpdated() {
     _eventsSubscription?.add(
       _client.on(EventType.userUpdated).listen((event) {
-        if (event.user!.id == currentUser!.id) {
-          currentUser = OwnUser.fromUser(event.user!);
+        var user = event.user;
+        if (user == null) return;
+
+        if (user.id == currentUser?.id) {
+          final updatedUser = OwnUser.fromUser(user);
+          currentUser = user = updatedUser.copyWith(
+            // PRESERVE these fields (we don't get them in user.updated events)
+            devices: currentUser?.devices,
+            mutes: currentUser?.mutes,
+            channelMutes: currentUser?.channelMutes,
+            totalUnreadCount: currentUser?.totalUnreadCount,
+            unreadChannels: currentUser?.unreadChannels,
+            unreadThreads: currentUser?.unreadThreads,
+            blockedUserIds: currentUser?.blockedUserIds,
+          );
         }
-        updateUser(event.user);
+
+        updateUser(user);
       }),
     );
   }


### PR DESCRIPTION

# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes FLU-228

## Description of the pull request
This commit addresses an issue where `OwnUser` specific fields (like `devices`, `mutes`, `totalUnreadCount`, etc.) were being reset to their default values (null or 0) when a `user.updated` event was received.

The `OwnUser.fromUser` factory constructor now correctly extracts `OwnUser`-specific fields from the `User.extraData` if they exist. It also sanitizes the `extraData` to remove these specific fields, preventing duplication.

Additionally, the `_listenUserUpdated` method in the `StreamChatClient` now ensures that if the updated user is the current user, the existing `OwnUser` specific fields are preserved from the `currentUser` object before updating it with the new data from the event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues where certain user-specific fields were lost or reset during user updates, ensuring consistent retention of user data such as devices, mutes, and unread counts.

* **Documentation**
  * Updated the changelog to reflect recent bug fixes related to user state consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->