### PR TITLE
fix: mentions highlighting escaping username

### DIFF
--- a/packages/stream_chat_flutter/lib/src/utils/extensions.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/extensions.dart
@@ -388,12 +388,12 @@ extension MessageX on Message {
       final userName = user.name;
       if (linkify) {
         messageTextToRender = messageTextToRender?.replaceAll(
-          RegExp('@($userId|$userName)'),
+          RegExp('@(${RegExp.escape(userName)}|$userName)'),
           '[@$userName]($userId)',
         );
       } else {
         messageTextToRender = messageTextToRender?.replaceAll(
-          RegExp('@($userId|$userName)'),
+          RegExp('@($userId|${RegExp.escape(userName)})'),
           '@$userName',
         );
       }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Highlighting usernames was broken when usernames with characters breaking regexp (eg. `Tester (X)`)

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| img | img |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mentions now correctly detect usernames containing special characters, ensuring accurate matching.
  * Resolves cases where mentions were missed or incorrectly highlighted/linkified in messages.
  * Applies to both linkified and non-linkified message displays, improving consistency when viewing or tapping mentions.
  * No changes to settings or visible options; behavior is more reliable without altering the interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->