### PR TITLE
feat(ui): add optionsBuilder to custom attachment options

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Upcoming
+
+✅ Added
+
+- Added `optionsBuilder` to `showStreamAttachmentPickerModalBottomSheet`, 
+  `mobileAttachmentPickerBuilder`, and `webOrDesktopAttachmentPickerBuilder` 
+  to allow full control over the attachment picker options ordering / display.
+
 ## 9.16.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_bottom_sheet.dart
@@ -65,6 +65,7 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
   required BuildContext context,
   Iterable<AttachmentPickerOption>? customOptions,
+  AttachmentPickerOptionsBuilder? optionsBuilder,
   List<AttachmentPickerType> allowedTypes = AttachmentPickerType.values,
   Poll? initialPoll,
   PollConfig? pollConfig,
@@ -91,6 +92,13 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
   int attachmentThumbnailQuality = 100,
   double attachmentThumbnailScale = 1,
 }) {
+  assert(
+    optionsBuilder == null || customOptions == null,
+    'Cannot use both optionsBuilder and customOptions. '
+    'Use optionsBuilder for full control over options, '
+    'or customOptions for simple prepending of options.',
+  );
+
   final colorTheme = StreamChatTheme.of(context).colorTheme;
   final color = backgroundColor ?? colorTheme.inputBg;
 
@@ -135,6 +143,22 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
               customOptions: customOptions?.map(
                 WebOrDesktopAttachmentPickerOption.fromAttachmentPickerOption,
               ),
+              optionsBuilder: optionsBuilder == null
+                  ? null
+                  : (context, defaultOptions) {
+                      final attachmentOptions = defaultOptions
+                          .map((option) => AttachmentPickerOption(
+                                key: option.key,
+                                icon: option.icon,
+                                title: option.title,
+                                supportedTypes: option.supportedTypes,
+                              ))
+                          .toList();
+                      return optionsBuilder(context, attachmentOptions)
+                          .map(WebOrDesktopAttachmentPickerOption
+                              .fromAttachmentPickerOption)
+                          .toList();
+                    },
               initialPoll: initialPoll,
               pollConfig: pollConfig,
               attachmentThumbnailSize: attachmentThumbnailSize,
@@ -150,6 +174,7 @@ Future<T?> showStreamAttachmentPickerModalBottomSheet<T>({
             controller: controller,
             allowedTypes: allowedTypes,
             customOptions: customOptions,
+            optionsBuilder: optionsBuilder,
             initialPoll: initialPoll,
             pollConfig: pollConfig,
             attachmentThumbnailSize: attachmentThumbnailSize,

--- a/packages/stream_chat_flutter/test/src/message_input/attachment_picker/options_builder_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/attachment_picker/options_builder_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+void main() {
+  group('AttachmentPickerOptionsBuilder', () {
+    testWidgets(
+        'mobileAttachmentPickerBuilder uses optionsBuilder when provided',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final controller = StreamAttachmentPickerController();
+
+              const customOption = AttachmentPickerOption(
+                key: 'custom-option',
+                icon: Icon(Icons.star),
+                supportedTypes: [AttachmentPickerType.files],
+              );
+
+              final widget = mobileAttachmentPickerBuilder(
+                context: context,
+                controller: controller,
+                optionsBuilder: (context, defaultOptions) {
+                  // Custom options after default options
+                  return [
+                    ...defaultOptions,
+                    customOption,
+                  ];
+                },
+              );
+
+              expect(widget, isA<StreamMobileAttachmentPickerBottomSheet>());
+
+              final bottomSheet =
+                  widget as StreamMobileAttachmentPickerBottomSheet;
+              final options = bottomSheet.options.toList();
+
+              // Custom option should be last when added after default options
+              expect(options.last.key, equals('custom-option'));
+
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets(
+        'mobileAttachmentPickerBuilder can reorder options with optionsBuilder',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final controller = StreamAttachmentPickerController();
+
+              const customOption = AttachmentPickerOption(
+                key: 'custom-option',
+                icon: Icon(Icons.star),
+                supportedTypes: [AttachmentPickerType.files],
+              );
+
+              final widget = mobileAttachmentPickerBuilder(
+                context: context,
+                controller: controller,
+                optionsBuilder: (context, defaultOptions) {
+                  // Custom option first, then only specific default options
+                  return [
+                    customOption,
+                    // Only include gallery picker from defaults
+                    ...defaultOptions
+                        .where((option) => option.key == 'gallery-picker'),
+                  ];
+                },
+              );
+
+              expect(widget, isA<StreamMobileAttachmentPickerBottomSheet>());
+
+              final bottomSheet =
+                  widget as StreamMobileAttachmentPickerBottomSheet;
+              final options = bottomSheet.options.toList();
+
+              // Should have exactly 2 options: custom + gallery
+              expect(options.length, equals(2));
+              expect(options.first.key, equals('custom-option'));
+              expect(options.last.key, equals('gallery-picker'));
+
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+
+    test('AttachmentPickerOptionsBuilder typedef is defined correctly', () {
+      // Test that the typedef is properly defined and can be used
+      AttachmentPickerOptionsBuilder? builder;
+
+      builder = (context, defaultOptions) {
+        return [
+          ...defaultOptions,
+          const AttachmentPickerOption(
+            key: 'test-option',
+            icon: Icon(Icons.star),
+            supportedTypes: [AttachmentPickerType.files],
+          ),
+        ];
+      };
+
+      expect(builder, isNotNull);
+      expect(builder, isA<AttachmentPickerOptionsBuilder>());
+    });
+
+    test(
+        'WebOrDesktopAttachmentPickerOptionsBuilder typedef is defined correctly',
+        () {
+      // Test that the typedef is properly defined and can be used
+      WebOrDesktopAttachmentPickerOptionsBuilder? builder;
+
+      builder = (context, defaultOptions) {
+        return [
+          ...defaultOptions,
+          WebOrDesktopAttachmentPickerOption(
+            key: 'test-option',
+            type: AttachmentPickerType.files,
+            icon: const Icon(Icons.star),
+            title: 'Test Option',
+          ),
+        ];
+      };
+
+      expect(builder, isNotNull);
+      expect(builder, isA<WebOrDesktopAttachmentPickerOptionsBuilder>());
+    });
+
+    testWidgets(
+        'customOptions behavior still works when optionsBuilder is null',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final controller = StreamAttachmentPickerController();
+
+              const customOption = AttachmentPickerOption(
+                key: 'custom-option',
+                icon: Icon(Icons.star),
+                supportedTypes: [AttachmentPickerType.files],
+              );
+
+              final widget = mobileAttachmentPickerBuilder(
+                context: context,
+                controller: controller,
+                customOptions: [customOption],
+              );
+
+              expect(widget, isA<StreamMobileAttachmentPickerBottomSheet>());
+
+              final bottomSheet =
+                  widget as StreamMobileAttachmentPickerBottomSheet;
+              final options = bottomSheet.options.toList();
+
+              expect(options.first.key, equals('custom-option'));
+
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('Cannot use both customOptions and optionsBuilder',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              expect(
+                () => showStreamAttachmentPickerModalBottomSheet(
+                  context: context,
+                  customOptions: [
+                    const AttachmentPickerOption(
+                      key: 'custom',
+                      icon: Icon(Icons.star),
+                      supportedTypes: [AttachmentPickerType.files],
+                    ),
+                  ],
+                  optionsBuilder: (context, defaultOptions) => defaultOptions,
+                ),
+                throwsAssertionError,
+              );
+
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Adds `optionsBuilder` to `mobileAttachmentPickerBuilder`, `webOrDesktopAttachmentPickerBuilder`, and `showStreamAttachmentPickerModalBottomSheet` so that the order of the options can be fully controlled. 

Today, options are strictly prepended, with no option to control ordering custom options after the default options.

## Screenshots

| Before | After |
| --- | --- |
|<img width="454" height="43" alt="image" src="https://github.com/user-attachments/assets/c09149ea-224a-44d2-ad8c-2b0c027fb772" />|<img width="461" height="61" alt="image" src="https://github.com/user-attachments/assets/8733bb29-7e66-4caf-acaf-bb681a988657" />|

Would also allow interspersing, or putting an exact picker in an exact index location, or reversing the list, etc. Below, the red indicate dummy options interspersed with `defaultOptions`
<img width="460" height="70" alt="image" src="https://github.com/user-attachments/assets/7cea88c5-762c-4609-ba81-cec0c2f8ccb1" />
