### PR TITLE
fix(llc): Fixed build in dart2wasm environment

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `OwnUser` specific fields getting lost when creating a new `OwnUser` instance from
   an `User` instance.
 - Fixed `Client.currentUser` specific fields getting reset on `user.updated` events.
+- Fixed build in dart2wasm environment.
 
 ✅ Added
 

--- a/packages/stream_chat/lib/src/core/platform_detector/platform_detector.dart
+++ b/packages/stream_chat/lib/src/core/platform_detector/platform_detector.dart
@@ -1,5 +1,5 @@
 import 'package:stream_chat/src/core/platform_detector/platform_detector_stub.dart'
-    if (dart.library.html) 'platform_detector_web.dart'
+    if (dart.library.js_interop) 'platform_detector_web.dart'
     if (dart.library.io) 'platform_detector_io.dart';
 
 /// Possible platforms

--- a/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler.dart
@@ -1,4 +1,4 @@
 export 'stream_attachment_handler_base.dart'
-    if (dart.library.html) 'stream_attachment_handler_html.dart'
+    if (dart.library.js_interop) 'stream_attachment_handler_html.dart'
     if (dart.library.io) 'stream_attachment_handler_io.dart'
     show StreamAttachmentHandler;

--- a/packages/stream_chat_persistence/lib/src/db/shared/shared_db.dart
+++ b/packages/stream_chat_persistence/lib/src/db/shared/shared_db.dart
@@ -1,3 +1,3 @@
 export 'unsupported_db.dart'
     if (dart.library.io) 'native_db.dart' // implementation using dart:io
-    if (dart.library.html) 'web_db.dart';
+    if (dart.library.js_interop) 'web_db.dart';


### PR DESCRIPTION
According to https://dart.dev/interop/js-interop/past-js-interop we should now "prefer using dart:js_interop going forwards and migrate usages of old interop libraries when possible" and this change does that in order to make the library compatible with `--wasm` builds.

# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable): No test is added yet as support of `--wasm` on this project needs https://github.com/simolus3/drift/pull/3657 (already merged but not released) and https://github.com/Alberto-Monteiro/video_thumbnail/pull/9 also but having all of them it's possible to make it in the CI also AFAICS.

## Description of the pull request
When I'm building example of this project in `flutter run -d chrome --wasm` mode the web mode isn't recognized correctly and raises errors like this on the console 

<img width="1117" height="381" alt="image" src="https://github.com/user-attachments/assets/e54e154b-460b-4eda-86d5-c72c522e220a" />

Which this change fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed web build issues (including dart2wasm) to improve stability for web users.

* **Refactor**
  * Standardized web platform detection and handling across core, attachment handling, and persistence layers.

* **Chores**
  * Aligned web targeting with current Dart/Flutter tooling for broader browser compatibility.
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->