### PR TITLE
fix(ui): enable sending reply in threads for users with sendReply capability

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming Beta
+
+🐞 Fixed
+
+- Fixed users with `sendReply` capability unable to send replies in threads.
+
 ## Upcoming
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -632,9 +632,6 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
       return result;
     }
-    //fix(ui): enable sending reply in threads for users with sendReply capability
-    //
-    // This commit allows users with the `sendReply` capability to send replies within a thread, even if they don't have broader send message permission.
 
     final channel = StreamChannel.of(context).channel;
     final messageInput = switch (_buildAutocompleteMessageInput(context)) {

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -619,6 +619,12 @@ class StreamMessageInputState extends State<StreamMessageInput>
   Widget build(BuildContext context) {
     bool canSendOrUpdateMessage(List<ChannelCapability> capabilities) {
       var result = capabilities.contains(ChannelCapability.sendMessage);
+
+      final insideThread = _effectiveController.message.parentId != null;
+      if (insideThread) {
+        result |= capabilities.contains(ChannelCapability.sendReply);
+      }
+
       if (_isEditing) {
         result |= capabilities.contains(ChannelCapability.updateOwnMessage);
         result |= capabilities.contains(ChannelCapability.updateAnyMessage);
@@ -626,6 +632,9 @@ class StreamMessageInputState extends State<StreamMessageInput>
 
       return result;
     }
+    //fix(ui): enable sending reply in threads for users with sendReply capability
+    //
+    // This commit allows users with the `sendReply` capability to send replies within a thread, even if they don't have broader send message permission.
 
     final channel = StreamChannel.of(context).channel;
     final messageInput = switch (_buildAutocompleteMessageInput(context)) {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-234

## Description of the pull request
This PR allows users with the `sendReply` capability to send replies within a thread, even if they don't have broader send message permission.
