### PR TITLE
fix(llc): prevent sending empty messages

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `Channel.sendMessage` to prevent sending empty messages when all attachments are cancelled
+  during upload.
+
 ## 9.16.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -658,6 +658,15 @@ class Channel {
     });
   }
 
+  bool _isMessageValidForUpload(Message message) {
+    final hasText = message.text?.trim().isNotEmpty == true;
+    final hasAttachments = message.attachments.isNotEmpty;
+    final hasQuotedMessage = message.quotedMessageId != null;
+    final hasPoll = message.pollId != null;
+
+    return hasText || hasAttachments || hasQuotedMessage || hasPoll;
+  }
+
   final _sendMessageLock = Lock();
 
   /// Send a [message] to this channel.
@@ -714,6 +723,15 @@ class Channel {
 
         // ignore: parameter_assignments
         message = await attachmentsUploadCompleter.future;
+      }
+
+      // Validate the final message before sending it to the server.
+      if (_isMessageValidForUpload(message) == false) {
+        client.logger.warning('Message is not valid for sending, removing it');
+
+        // Remove the message from state as it is invalid.
+        state!.deleteMessage(message, hardDelete: true);
+        throw const StreamChatError('Message is not valid for sending');
       }
 
       // Wait for the previous sendMessage call to finish. Otherwise, the order

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -461,6 +461,19 @@ void main() {
             )).called(1);
       });
 
+      test('should not send if the message is invalid', () async {
+        final message = Message(id: 'test-message-id');
+
+        expect(
+          () => channel.sendMessage(message),
+          throwsA(isA<StreamChatError>()),
+        );
+
+        verifyNever(
+          () => client.sendMessage(any(), channelId, channelType),
+        );
+      });
+
       test(
         'should not send empty message when all attachments are cancelled',
         () async {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-263

## Description of the pull request
This commit prevents the sending of messages that are considered empty by the backend.

A new private method `_isMessageValidForUpload` is added to the `Channel` class. This method checks if a message has:
- Non-empty text
- Attachments
- A quoted message ID
- A poll ID

If none of these conditions are met, the message is considered invalid.

The `sendMessage` method now calls `_isMessageValidForUpload` before attempting to send the message to the server. If the message is invalid, it is removed from the local state, a warning is logged, and a `StreamChatError` is thrown, preventing the message from being sent.