### PR TITLE
fix(llc): improve persistence updates for channel state and threads

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `ChannelState.memberCount`, `ChannelState.config` and `ChannelState.extraData` getting reset
+  on first load.
+
 ## 9.17.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/db/chat_persistence_client.dart
+++ b/packages/stream_chat/lib/src/db/chat_persistence_client.dart
@@ -248,7 +248,11 @@ abstract class ChatPersistenceClient {
     String cid,
     Map<String, List<Message>> threads,
   ) async {
+    if (threads.isEmpty) return;
+
+    // Flattening the messages from threads
     final messages = threads.values.expand((it) => it).toList();
+    if (messages.isEmpty) return;
 
     // Removing old reactions before saving the new
     final oldReactions = messages.map((it) => it.id).toList();
@@ -276,6 +280,8 @@ abstract class ChatPersistenceClient {
 
   /// Update list of channel states
   Future<void> updateChannelStates(List<ChannelState> channelStates) async {
+    if (channelStates.isEmpty) return;
+
     final reactionsToDelete = <String>[];
     final pinnedReactionsToDelete = <String>[];
     final membersToDelete = <String>[];

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -606,7 +606,7 @@ void main() {
           final persistentChannelStates = List.generate(
             3,
             (index) => ChannelState(
-              channel: ChannelModel(cid: 'p-test-type-$index:p-test-id-$index'),
+              channel: ChannelModel(cid: 'test-type-$index:test-id-$index'),
             ),
           );
 
@@ -685,11 +685,11 @@ void main() {
               )).called(1);
 
           verify(() => persistence.getChannelThreads(any()))
-              .called((persistentChannelStates + channelStates).length);
+              .called(channelStates.length);
           verify(() => persistence.updateChannelState(any()))
-              .called((persistentChannelStates + channelStates).length);
+              .called(channelStates.length);
           verify(() => persistence.updateChannelThreads(any(), any()))
-              .called((persistentChannelStates + channelStates).length);
+              .called(channelStates.length);
           verify(() => persistence.updateChannelQueries(any(), any(),
               clearQueryCache: any(named: 'clearQueryCache'))).called(1);
         },
@@ -701,7 +701,7 @@ void main() {
           final persistentChannelStates = List.generate(
             3,
             (index) => ChannelState(
-              channel: ChannelModel(cid: 'p-test-type-$index:p-test-id-$index'),
+              channel: ChannelModel(cid: 'test-type-$index:test-id-$index'),
             ),
           );
 

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -8,10 +8,6 @@ import '../matchers.dart';
 import '../mocks.dart';
 import '../utils.dart';
 
-void abc(String abc) {
-  print(abc);
-}
-
 void main() {
   group('Fake web-socket connection functions', () {
     const apiKey = 'test-api-key';


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-258, FLU-235
<!--Optional to add github issue which is solved by this PR-->
Fixes: #2397 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Channel details (member count, config, extra data) no longer reset on first load.

- Refactor
  - Debounced persistence for channel state and threads to reduce redundant writes and improve startup ordering.
  - Improved offline thread loading and cleanup of debounce timers.
  - Early-return guards to skip persistence when no data present.

- Documentation
  - Changelog updated with an Upcoming entry describing the bug fix.

- Tests
  - Updated tests and timing to reflect the new persistence/debounce behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->