### PR TITLE
fix(llc, ui): improve read status handling

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed thread messages increasing the unread count in the main channel.
+
 ## 9.17.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -3242,7 +3242,7 @@ class ChannelClientState {
     if (message.isEphemeral) return false;
 
     // Don't count thread replies which are not shown in the channel as unread.
-    if (message.parentId != null && message.showInChannel == false) {
+    if (message.parentId != null && message.showInChannel != true) {
       return false;
     }
 
@@ -3263,6 +3263,18 @@ class ChannelClientState {
     // Don't count messages from muted users as unread.
     final isMuted = currentUser.mutes.any((it) => it.user.id == messageUser.id);
     if (isMuted) return false;
+
+    final lastRead = currentUserRead?.lastRead;
+    // Don't count messages created before the last read time as unread.
+    if (lastRead case final read? when message.createdAt.isBefore(read)) {
+      return false;
+    }
+
+    final lastReadMessageId = currentUserRead?.lastReadMessageId;
+    // Don't count if the last read message id is the same as the message id.
+    if (lastReadMessageId case final id? when message.id == id) {
+      return false;
+    }
 
     // If we've passed all checks, count the message as unread.
     return true;

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `StreamMessageListView` not marking thread messages as read when scrolled to the bottom of the list.
+- Fixed `StreamMessageInput` not validating draft messages before creating/updating them.
+
 ## 9.17.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -463,11 +463,11 @@ class StreamMessageInput extends StatefulWidget {
   }
 
   static bool _defaultValidator(Message message) {
-    // The message is valid if it has text or attachments.
-    if (message.attachments.isNotEmpty) return true;
-    if (message.text?.trim() case final text? when text.isNotEmpty) return true;
+    final hasText = message.text?.trim().isNotEmpty == true;
+    final hasAttachments = message.attachments.isNotEmpty;
+    final hasPoll = message.pollId != null;
 
-    return false;
+    return hasText || hasAttachments || hasPoll;
   }
 
   static bool _defaultSendMessageKeyPredicate(
@@ -1593,6 +1593,10 @@ class StreamMessageInputState extends State<StreamMessageInput>
     };
 
     final draftMessage = message.toDraftMessage();
+
+    // If the draft message is not valid, we don't need to update it.
+    final isDraftValid = widget.validator.call(draftMessage.toMessage());
+    if (!isDraftValid) return;
 
     // If the draft message didn't change, we don't need to update it.
     if (draft?.message == draftMessage) return;

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -467,8 +467,8 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
 
   @override
   void dispose() {
-    debouncedMarkRead?.cancel();
-    debouncedMarkThreadRead?.cancel();
+    debouncedMarkRead.cancel();
+    debouncedMarkThreadRead.cancel();
     _messageNewListener?.cancel();
     _userReadListener?.cancel();
     _itemPositionListener.itemPositions
@@ -954,29 +954,23 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     }
   }
 
-  late final debouncedMarkRead = switch (streamChannel) {
-    final streamChannel? => debounce(
-        streamChannel.channel.markRead,
-        const Duration(seconds: 1),
-      ),
-    _ => null,
-  };
+  late final debouncedMarkRead = debounce(
+    ([String? id]) => streamChannel?.channel.markRead(messageId: id),
+    const Duration(seconds: 1),
+  );
 
-  late final debouncedMarkThreadRead = switch (streamChannel) {
-    final streamChannel? => debounce(
-        streamChannel.channel.markThreadRead,
-        const Duration(seconds: 1),
-      ),
-    _ => null,
-  };
+  late final debouncedMarkThreadRead = debounce(
+    (String parentId) => streamChannel?.channel.markThreadRead(parentId),
+    const Duration(seconds: 1),
+  );
 
   Future<void> _markMessagesAsRead() async {
-    // Mark regular messages as read.
-    debouncedMarkRead?.call();
-
-    // Mark thread messages as read.
     if (widget.parentMessage case final parent?) {
-      debouncedMarkThreadRead?.call([parent.id]);
+      // If we are in a thread, mark the thread as read.
+      debouncedMarkThreadRead.call([parent.id]);
+    } else {
+      // Otherwise, mark the channel as read.
+      debouncedMarkRead.call();
     }
   }
 
@@ -1473,22 +1467,41 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
       null => true, // Allows setting the initial value.
     };
 
-    // If the channel is upToDate and the last fully visible message has
-    // been changed, we need to update the value and mark the messages as read.
-    if (_upToDate && lastFullyVisibleMessageChanged) {
+    // If the last fully visible message has been changed, we need to update the
+    // value and maybe mark messages as read if needed.
+    if (lastFullyVisibleMessageChanged) {
       _lastFullyVisibleMessage = newLastFullyVisibleMessage;
 
-      if (streamChannel?.channel case final channel?) {
-        final hasUnread = (channel.state?.unreadCount ?? 0) > 0;
-        final allowMarkRead = channel.config?.readEvents == true;
-        final canMarkReadAtBottom = widget.markReadWhenAtTheBottom;
-
-        // Mark messages as read if it's allowed.
-        if (hasUnread && allowMarkRead && canMarkReadAtBottom) {
-          return _markMessagesAsRead().ignore();
-        }
+      // Mark messages as read if needed.
+      if (widget.markReadWhenAtTheBottom) {
+        _maybeMarkMessagesAsRead().ignore();
       }
     }
+  }
+
+  // Marks messages as read if the conditions are met.
+  //
+  // The conditions are:
+  // 1. The channel is up to date or we are in a thread conversation.
+  // 2. There are unread messages or we are in a thread conversation.
+  //
+  // If any of the conditions are not met, the function returns early.
+  // Otherwise, it calls the _markMessagesAsRead function to mark the messages
+  // as read.
+  Future<void> _maybeMarkMessagesAsRead() async {
+    final channel = streamChannel?.channel;
+    if (channel == null) return;
+
+    final isInThread = widget.parentMessage != null;
+
+    final isUpToDate = channel.state?.isUpToDate ?? false;
+    if (!isInThread && !isUpToDate) return;
+
+    final hasUnread = (channel.state?.unreadCount ?? 0) > 0;
+    if (!isInThread && !hasUnread) return;
+
+    // Mark messages as read if it's allowed.
+    return _markMessagesAsRead();
   }
 
   void _getOnThreadTap() {

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -417,6 +417,9 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (newStreamChannel != streamChannel) {
       streamChannel = newStreamChannel;
 
+      debouncedMarkRead.cancel();
+      debouncedMarkThreadRead.cancel();
+
       _messageNewListener?.cancel();
       _userReadListener?.cancel();
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-270

## Description of the pull request
This PR introduces several improvements to how read statuses are handled in the message list:

- **Debounced Mark Read:** The `debouncedMarkRead` and `debouncedMarkThreadRead` functions are now initialized directly, removing the conditional logic based on `streamChannel`. This simplifies the code and ensures that the debounced functions are always available.
- **Conditional Mark Read:** The `_markMessagesAsRead` function now checks if it's in a thread or a regular channel conversation and calls the appropriate mark read function.
- **Improved `_maybeMarkMessagesAsRead`:** This new function encapsulates the logic for deciding whether to mark messages as read. It checks if the channel is up to date (or if in a thread) and if there are unread messages (or if in a thread) before marking messages as read. This makes the logic clearer and more robust.
- **Refined Unread Message Counting:** The `_messageIsUnread` function in `Channel` now includes additional checks:
    - It ensures that thread replies not shown in the channel are not counted as unread.
    - It verifies that messages created before the `lastRead` time are not counted as unread.
    - It checks if the `lastReadMessageId` matches the current message's ID to avoid counting it as unread if it's already been marked as read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed channel unread counts by excluding hidden thread messages and respecting last-read time/message.
  - More reliable marking of messages and thread replies as read when scrolled to the bottom.

- Chores
  - Drafts are now validated before create/update; messages with polls are treated as valid.

- Documentation
  - Added Upcoming sections to changelogs highlighting the above fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->