### PR TITLE
feat(llc, persistence): add messageCount to channel model and event

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- Added support for `Channel.messageCount` field.
+
 ## 9.17.0
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2169,6 +2169,8 @@ class ChannelClientState {
 
     _listenChannelUpdated();
 
+    _listenChannelMessageCount();
+
     _listenMemberAdded();
 
     _listenMemberRemoved();
@@ -2345,6 +2347,23 @@ class ChannelClientState {
         members: channel.members,
       ));
     }));
+  }
+
+  void _listenChannelMessageCount() {
+    _subscriptions.add(_channel.on().listen(
+      (Event e) {
+        final messageCount = e.channelMessageCount;
+        if (messageCount == null) return;
+
+        updateChannelState(
+          channelState.copyWith(
+            channel: channelState.channel?.copyWith(
+              messageCount: messageCount,
+            ),
+          ),
+        );
+      },
+    ));
   }
 
   void _listenChannelTruncated() {

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -416,6 +416,24 @@ class Channel {
     return state!.channelStateStream.map((cs) => cs.channel?.memberCount);
   }
 
+  /// Channel message count.
+  ///
+  /// Note: This field is only populated if the `count_messages` option is
+  /// enabled for your app.
+  int? get messageCount {
+    _checkInitialized();
+    return state!._channelState.channel?.messageCount;
+  }
+
+  /// Channel message count as a stream.
+  ///
+  /// Note: This field is only populated if the `count_messages` option is
+  /// enabled for your app.
+  Stream<int?> get messageCountStream {
+    _checkInitialized();
+    return state!.channelStateStream.map((cs) => cs.channel?.messageCount);
+  }
+
   /// Channel id.
   String? get id => state?._channelState.channel?.id ?? _id;
 

--- a/packages/stream_chat/lib/src/core/models/channel_model.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.dart
@@ -31,6 +31,7 @@ class ChannelModel {
     bool? disabled,
     bool? hidden,
     DateTime? truncatedAt,
+    this.messageCount,
   })  : assert(
           (cid != null && cid.contains(':')) || (id != null && type != null),
           'provide either a cid or an id and type',
@@ -151,6 +152,13 @@ class ChannelModel {
     return null;
   }
 
+  /// The total number of messages in the channel.
+  ///
+  /// Note: This field is only populated if the `count_messages` option is
+  /// enabled for your app.
+  @JsonKey(includeToJson: false)
+  final int? messageCount;
+
   /// Known top level fields.
   /// Useful for [Serializer] methods.
   static const topLevelFields = [
@@ -169,6 +177,7 @@ class ChannelModel {
     'members',
     'team',
     'cooldown',
+    'message_count',
   ];
 
   /// Serialize to json
@@ -197,6 +206,7 @@ class ChannelModel {
     bool? disabled,
     bool? hidden,
     DateTime? truncatedAt,
+    int? messageCount,
   }) =>
       ChannelModel(
         id: id ?? this.id,
@@ -223,6 +233,7 @@ class ChannelModel {
                 // ignore: cast_nullable_to_non_nullable
                 : DateTime.parse(extraData?['truncated_at'] as String)) ??
             this.truncatedAt,
+        messageCount: messageCount ?? this.messageCount,
       );
 
   /// Returns a new [ChannelModel] that is a combination of this channelModel
@@ -249,6 +260,7 @@ class ChannelModel {
       disabled: other.disabled,
       hidden: other.hidden,
       truncatedAt: other.truncatedAt,
+      messageCount: other.messageCount,
     );
   }
 }

--- a/packages/stream_chat/lib/src/core/models/channel_model.g.dart
+++ b/packages/stream_chat/lib/src/core/models/channel_model.g.dart
@@ -39,6 +39,7 @@ ChannelModel _$ChannelModelFromJson(Map<String, dynamic> json) => ChannelModel(
       extraData: json['extra_data'] as Map<String, dynamic>? ?? const {},
       team: json['team'] as String?,
       cooldown: (json['cooldown'] as num?)?.toInt() ?? 0,
+      messageCount: (json['message_count'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$ChannelModelToJson(ChannelModel instance) =>

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -43,6 +43,7 @@ class Event {
     this.reminder,
     this.pushPreference,
     this.channelPushPreference,
+    this.channelMessageCount,
     this.extraData = const {},
     this.isLocal = true,
   }) : createdAt = createdAt?.toUtc() ?? DateTime.now().toUtc();
@@ -162,6 +163,9 @@ class Event {
   /// Push notification preferences for the current user for this channel.
   final ChannelPushPreference? channelPushPreference;
 
+  /// The total number of messages in the channel.
+  final int? channelMessageCount;
+
   /// Map of custom channel extraData
   final Map<String, Object?> extraData;
 
@@ -203,6 +207,7 @@ class Event {
     'reminder',
     'push_preference',
     'channel_push_preference',
+    'channel_message_count',
   ];
 
   /// Serialize to json
@@ -246,6 +251,7 @@ class Event {
     MessageReminder? reminder,
     PushPreference? pushPreference,
     ChannelPushPreference? channelPushPreference,
+    int? channelMessageCount,
     Map<String, Object?>? extraData,
   }) =>
       Event(
@@ -284,6 +290,7 @@ class Event {
         pushPreference: pushPreference ?? this.pushPreference,
         channelPushPreference:
             channelPushPreference ?? this.channelPushPreference,
+        channelMessageCount: channelMessageCount ?? this.channelMessageCount,
         isLocal: isLocal,
         extraData: extraData ?? this.extraData,
       );

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -76,6 +76,7 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
           ? null
           : ChannelPushPreference.fromJson(
               json['channel_push_preference'] as Map<String, dynamic>),
+      channelMessageCount: (json['channel_message_count'] as num?)?.toInt(),
       extraData: json['extra_data'] as Map<String, dynamic>? ?? const {},
       isLocal: json['is_local'] as bool? ?? false,
     );
@@ -124,6 +125,8 @@ Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
         'push_preference': value,
       if (instance.channelPushPreference?.toJson() case final value?)
         'channel_push_preference': value,
+      if (instance.channelMessageCount case final value?)
+        'channel_message_count': value,
       'extra_data': instance.extraData,
     };
 

--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Added support for `Channel.messageCount` field.
+
 ## 9.17.0
 
 - Updated `stream_chat` dependency to [`9.17.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -55,7 +55,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 23;
+  int get schemaVersion => 24;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -81,6 +81,12 @@ class $ChannelsTable extends Channels
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _messageCountMeta =
+      const VerificationMeta('messageCount');
+  @override
+  late final GeneratedColumn<int> messageCount = GeneratedColumn<int>(
+      'message_count', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _createdByIdMeta =
       const VerificationMeta('createdById');
   @override
@@ -106,6 +112,7 @@ class $ChannelsTable extends Channels
         updatedAt,
         deletedAt,
         memberCount,
+        messageCount,
         createdById,
         extraData
       ];
@@ -164,6 +171,12 @@ class $ChannelsTable extends Channels
           memberCount.isAcceptableOrUnknown(
               data['member_count']!, _memberCountMeta));
     }
+    if (data.containsKey('message_count')) {
+      context.handle(
+          _messageCountMeta,
+          messageCount.isAcceptableOrUnknown(
+              data['message_count']!, _messageCountMeta));
+    }
     if (data.containsKey('created_by_id')) {
       context.handle(
           _createdByIdMeta,
@@ -203,6 +216,8 @@ class $ChannelsTable extends Channels
           .read(DriftSqlType.dateTime, data['${effectivePrefix}deleted_at']),
       memberCount: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}member_count'])!,
+      messageCount: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}message_count']),
       createdById: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}created_by_id']),
       extraData: $ChannelsTable.$converterextraDatan.fromSql(attachedDatabase
@@ -262,6 +277,9 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
   /// The count of this channel members
   final int memberCount;
 
+  /// The count of messages in this channel
+  final int? messageCount;
+
   /// The id of the user that created this channel
   final String? createdById;
 
@@ -279,6 +297,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       required this.updatedAt,
       this.deletedAt,
       required this.memberCount,
+      this.messageCount,
       this.createdById,
       this.extraData});
   @override
@@ -305,6 +324,9 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       map['deleted_at'] = Variable<DateTime>(deletedAt);
     }
     map['member_count'] = Variable<int>(memberCount);
+    if (!nullToAbsent || messageCount != null) {
+      map['message_count'] = Variable<int>(messageCount);
+    }
     if (!nullToAbsent || createdById != null) {
       map['created_by_id'] = Variable<String>(createdById);
     }
@@ -331,6 +353,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
       deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
       memberCount: serializer.fromJson<int>(json['memberCount']),
+      messageCount: serializer.fromJson<int?>(json['messageCount']),
       createdById: serializer.fromJson<String?>(json['createdById']),
       extraData: serializer.fromJson<Map<String, dynamic>?>(json['extraData']),
     );
@@ -350,6 +373,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
       'deletedAt': serializer.toJson<DateTime?>(deletedAt),
       'memberCount': serializer.toJson<int>(memberCount),
+      'messageCount': serializer.toJson<int?>(messageCount),
       'createdById': serializer.toJson<String?>(createdById),
       'extraData': serializer.toJson<Map<String, dynamic>?>(extraData),
     };
@@ -367,6 +391,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
           DateTime? updatedAt,
           Value<DateTime?> deletedAt = const Value.absent(),
           int? memberCount,
+          Value<int?> messageCount = const Value.absent(),
           Value<String?> createdById = const Value.absent(),
           Value<Map<String, dynamic>?> extraData = const Value.absent()}) =>
       ChannelEntity(
@@ -384,6 +409,8 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
         updatedAt: updatedAt ?? this.updatedAt,
         deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
         memberCount: memberCount ?? this.memberCount,
+        messageCount:
+            messageCount.present ? messageCount.value : this.messageCount,
         createdById: createdById.present ? createdById.value : this.createdById,
         extraData: extraData.present ? extraData.value : this.extraData,
       );
@@ -405,6 +432,9 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
       memberCount:
           data.memberCount.present ? data.memberCount.value : this.memberCount,
+      messageCount: data.messageCount.present
+          ? data.messageCount.value
+          : this.messageCount,
       createdById:
           data.createdById.present ? data.createdById.value : this.createdById,
       extraData: data.extraData.present ? data.extraData.value : this.extraData,
@@ -425,6 +455,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
           ..write('updatedAt: $updatedAt, ')
           ..write('deletedAt: $deletedAt, ')
           ..write('memberCount: $memberCount, ')
+          ..write('messageCount: $messageCount, ')
           ..write('createdById: $createdById, ')
           ..write('extraData: $extraData')
           ..write(')'))
@@ -444,6 +475,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
       updatedAt,
       deletedAt,
       memberCount,
+      messageCount,
       createdById,
       extraData);
   @override
@@ -461,6 +493,7 @@ class ChannelEntity extends DataClass implements Insertable<ChannelEntity> {
           other.updatedAt == this.updatedAt &&
           other.deletedAt == this.deletedAt &&
           other.memberCount == this.memberCount &&
+          other.messageCount == this.messageCount &&
           other.createdById == this.createdById &&
           other.extraData == this.extraData);
 }
@@ -477,6 +510,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
   final Value<DateTime> updatedAt;
   final Value<DateTime?> deletedAt;
   final Value<int> memberCount;
+  final Value<int?> messageCount;
   final Value<String?> createdById;
   final Value<Map<String, dynamic>?> extraData;
   final Value<int> rowid;
@@ -492,6 +526,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
     this.updatedAt = const Value.absent(),
     this.deletedAt = const Value.absent(),
     this.memberCount = const Value.absent(),
+    this.messageCount = const Value.absent(),
     this.createdById = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -508,6 +543,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
     this.updatedAt = const Value.absent(),
     this.deletedAt = const Value.absent(),
     this.memberCount = const Value.absent(),
+    this.messageCount = const Value.absent(),
     this.createdById = const Value.absent(),
     this.extraData = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -527,6 +563,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
     Expression<DateTime>? updatedAt,
     Expression<DateTime>? deletedAt,
     Expression<int>? memberCount,
+    Expression<int>? messageCount,
     Expression<String>? createdById,
     Expression<String>? extraData,
     Expression<int>? rowid,
@@ -543,6 +580,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
       if (updatedAt != null) 'updated_at': updatedAt,
       if (deletedAt != null) 'deleted_at': deletedAt,
       if (memberCount != null) 'member_count': memberCount,
+      if (messageCount != null) 'message_count': messageCount,
       if (createdById != null) 'created_by_id': createdById,
       if (extraData != null) 'extra_data': extraData,
       if (rowid != null) 'rowid': rowid,
@@ -561,6 +599,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
       Value<DateTime>? updatedAt,
       Value<DateTime?>? deletedAt,
       Value<int>? memberCount,
+      Value<int?>? messageCount,
       Value<String?>? createdById,
       Value<Map<String, dynamic>?>? extraData,
       Value<int>? rowid}) {
@@ -576,6 +615,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
       updatedAt: updatedAt ?? this.updatedAt,
       deletedAt: deletedAt ?? this.deletedAt,
       memberCount: memberCount ?? this.memberCount,
+      messageCount: messageCount ?? this.messageCount,
       createdById: createdById ?? this.createdById,
       extraData: extraData ?? this.extraData,
       rowid: rowid ?? this.rowid,
@@ -621,6 +661,9 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
     if (memberCount.present) {
       map['member_count'] = Variable<int>(memberCount.value);
     }
+    if (messageCount.present) {
+      map['message_count'] = Variable<int>(messageCount.value);
+    }
     if (createdById.present) {
       map['created_by_id'] = Variable<String>(createdById.value);
     }
@@ -648,6 +691,7 @@ class ChannelsCompanion extends UpdateCompanion<ChannelEntity> {
           ..write('updatedAt: $updatedAt, ')
           ..write('deletedAt: $deletedAt, ')
           ..write('memberCount: $memberCount, ')
+          ..write('messageCount: $messageCount, ')
           ..write('createdById: $createdById, ')
           ..write('extraData: $extraData, ')
           ..write('rowid: $rowid')
@@ -8435,6 +8479,7 @@ typedef $$ChannelsTableCreateCompanionBuilder = ChannelsCompanion Function({
   Value<DateTime> updatedAt,
   Value<DateTime?> deletedAt,
   Value<int> memberCount,
+  Value<int?> messageCount,
   Value<String?> createdById,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
@@ -8451,6 +8496,7 @@ typedef $$ChannelsTableUpdateCompanionBuilder = ChannelsCompanion Function({
   Value<DateTime> updatedAt,
   Value<DateTime?> deletedAt,
   Value<int> memberCount,
+  Value<int?> messageCount,
   Value<String?> createdById,
   Value<Map<String, dynamic>?> extraData,
   Value<int> rowid,
@@ -8568,6 +8614,9 @@ class $$ChannelsTableFilterComposer
 
   ColumnFilters<int> get memberCount => $composableBuilder(
       column: $table.memberCount, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get messageCount => $composableBuilder(
+      column: $table.messageCount, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get createdById => $composableBuilder(
       column: $table.createdById, builder: (column) => ColumnFilters(column));
@@ -8707,6 +8756,10 @@ class $$ChannelsTableOrderingComposer
   ColumnOrderings<int> get memberCount => $composableBuilder(
       column: $table.memberCount, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get messageCount => $composableBuilder(
+      column: $table.messageCount,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get createdById => $composableBuilder(
       column: $table.createdById, builder: (column) => ColumnOrderings(column));
 
@@ -8756,6 +8809,9 @@ class $$ChannelsTableAnnotationComposer
 
   GeneratedColumn<int> get memberCount => $composableBuilder(
       column: $table.memberCount, builder: (column) => column);
+
+  GeneratedColumn<int> get messageCount => $composableBuilder(
+      column: $table.messageCount, builder: (column) => column);
 
   GeneratedColumn<String> get createdById => $composableBuilder(
       column: $table.createdById, builder: (column) => column);
@@ -8887,6 +8943,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
             Value<DateTime> updatedAt = const Value.absent(),
             Value<DateTime?> deletedAt = const Value.absent(),
             Value<int> memberCount = const Value.absent(),
+            Value<int?> messageCount = const Value.absent(),
             Value<String?> createdById = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -8903,6 +8960,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
             updatedAt: updatedAt,
             deletedAt: deletedAt,
             memberCount: memberCount,
+            messageCount: messageCount,
             createdById: createdById,
             extraData: extraData,
             rowid: rowid,
@@ -8919,6 +8977,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
             Value<DateTime> updatedAt = const Value.absent(),
             Value<DateTime?> deletedAt = const Value.absent(),
             Value<int> memberCount = const Value.absent(),
+            Value<int?> messageCount = const Value.absent(),
             Value<String?> createdById = const Value.absent(),
             Value<Map<String, dynamic>?> extraData = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -8935,6 +8994,7 @@ class $$ChannelsTableTableManager extends RootTableManager<
             updatedAt: updatedAt,
             deletedAt: deletedAt,
             memberCount: memberCount,
+            messageCount: messageCount,
             createdById: createdById,
             extraData: extraData,
             rowid: rowid,

--- a/packages/stream_chat_persistence/lib/src/entity/channels.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/channels.dart
@@ -39,6 +39,9 @@ class Channels extends Table {
   /// The count of this channel members
   IntColumn get memberCount => integer().withDefault(const Constant(0))();
 
+  /// The count of messages in this channel
+  IntColumn get messageCount => integer().nullable()();
+
   /// The id of the user that created this channel
   TextColumn get createdById => text().nullable()();
 

--- a/packages/stream_chat_persistence/lib/src/mapper/channel_mapper.dart
+++ b/packages/stream_chat_persistence/lib/src/mapper/channel_mapper.dart
@@ -15,6 +15,7 @@ extension ChannelEntityX on ChannelEntity {
       createdAt: createdAt,
       updatedAt: updatedAt,
       memberCount: memberCount,
+      messageCount: messageCount,
       cid: cid,
       lastMessageAt: lastMessageAt,
       deletedAt: deletedAt,
@@ -55,6 +56,7 @@ extension ChannelModelX on ChannelModel {
         updatedAt: updatedAt,
         deletedAt: deletedAt,
         memberCount: memberCount,
+        messageCount: messageCount,
         createdById: createdBy?.id,
         extraData: extraData,
       );

--- a/packages/stream_chat_persistence/test/src/mapper/channel_mapper_test.dart
+++ b/packages/stream_chat_persistence/test/src/mapper/channel_mapper_test.dart
@@ -22,6 +22,7 @@ void main() {
       updatedAt: DateTime.now(),
       deletedAt: DateTime.now(),
       memberCount: 33,
+      messageCount: 42,
       createdById: user.id,
       extraData: {'test_extra_data': 'testData'},
     );
@@ -36,6 +37,7 @@ void main() {
       expect(channelModel.createdAt, isSameDateAs(entity.createdAt));
       expect(channelModel.updatedAt, isSameDateAs(entity.updatedAt));
       expect(channelModel.memberCount, entity.memberCount);
+      expect(channelModel.messageCount, entity.messageCount);
       expect(channelModel.cid, entity.cid);
       expect(channelModel.lastMessageAt, isSameDateAs(entity.lastMessageAt));
       expect(channelModel.deletedAt, isSameDateAs(entity.deletedAt));
@@ -77,6 +79,7 @@ void main() {
       expect(channelModel.createdAt, isSameDateAs(entity.createdAt));
       expect(channelModel.updatedAt, isSameDateAs(entity.updatedAt));
       expect(channelModel.memberCount, entity.memberCount);
+      expect(channelModel.messageCount, entity.messageCount);
       expect(channelModel.cid, entity.cid);
       expect(channelModel.lastMessageAt, isSameDateAs(entity.lastMessageAt));
       expect(channelModel.deletedAt, isSameDateAs(entity.deletedAt));
@@ -99,6 +102,7 @@ void main() {
       updatedAt: DateTime.now(),
       deletedAt: DateTime.now(),
       memberCount: 33,
+      messageCount: 75,
       createdBy: createdBy,
       extraData: {'test_extra_data': 'testData'},
     );
@@ -115,6 +119,7 @@ void main() {
     expect(channelEntity.createdAt, isSameDateAs(model.createdAt));
     expect(channelEntity.updatedAt, isSameDateAs(model.updatedAt));
     expect(channelEntity.memberCount, model.memberCount);
+    expect(channelEntity.messageCount, model.messageCount);
     expect(channelEntity.cid, model.cid);
     expect(channelEntity.lastMessageAt, isSameDateAs(model.lastMessageAt));
     expect(channelEntity.deletedAt, isSameDateAs(model.deletedAt));


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-241

## Description of the pull request
This commit introduces a new `messageCount` field to the `ChannelModel` and `Event` classes.

This field represents the total number of messages in a channel and is populated when the `count_messages` option is enabled for the app.

The channel state is now updated to reflect changes in `messageCount` by listening to channel events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel message count exposed with a reactive stream and real-time updates when enabled.
* **Persistence**
  * Message counts are persisted locally for faster access and reliability.
* **Tests**
  * Added tests for live updates, count changes from created/deleted messages, mapping, and preserved channel properties.
* **Documentation**
  * CHANGELOGs updated to note message count support.
* **Chores**
  * Local database schema version bumped to support message count storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->