### PR TITLE
fix(core): Prevent race condition on initial connection

### DIFF
--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed race condition where `connectUser` could be blocked when connectivity monitoring triggers
+  during initial connection. [[#2409]](https://github.com/GetStream/stream-chat-flutter/issues/2409)
+
 ## 9.19.0
 
 - Updated `stream_chat` dependency to [`9.19.0`](https://pub.dev/packages/stream_chat/changelog).

--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -237,7 +237,13 @@ class StreamChatCoreState extends State<StreamChatCore>
     _unsubscribeFromConnectivityChange();
 
     final stream = connectivityStream ?? Connectivity().onConnectivityChanged;
-    _connectivitySubscription = stream.listen(
+
+    // Skip the first connectivity event which emits immediately on subscription
+    // to avoid racing with initial connectUser call.
+    // See: https://github.com/GetStream/stream-chat-flutter/issues/2409
+    final skippedStream = stream.skip(1);
+
+    _connectivitySubscription = skippedStream.listen(
       _lifecycleManager.onConnectivityChanged,
     );
   }


### PR DESCRIPTION
# Submit a pull request
<!--Optional to add github issue which is solved by this PR-->
Fixes: #2409 

## Description of the pull request
A race condition could occur where the connectivity monitoring stream would emit an event immediately upon subscription. This could interfere with the initial `connectUser` call, potentially blocking it.

This change avoids the race condition by skipping the first event from the connectivity stream, ensuring the initial connection process is not interrupted by a premature connectivity change event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition that could block user connection when connectivity monitoring triggers during initial connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->