### PR TITLE
feat(samples): update parent message reactively in `ThreadPage`

### DIFF
--- a/sample_app/lib/pages/thread_list_page.dart
+++ b/sample_app/lib/pages/thread_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:sample_app/pages/thread_page.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
@@ -52,8 +53,8 @@ class _ThreadListPageState extends State<ThreadListPage> {
                       initialMessageId: thread.draft?.parentId,
                       child: BetterStreamBuilder(
                         stream: channel.state?.messagesStream.map(
-                          (messages) => messages.firstWhere(
-                            (m) => m.id == thread.parentMessage!.id,
+                          (messages) => messages.firstWhereOrNull(
+                            (m) => m.id == thread.parentMessage?.id,
                           ),
                         ),
                         builder: (_, parentMessage) {


### PR DESCRIPTION
## Description of the pull request
Update `ThreadPage` in `thread_list_page.dart` to use `BetterStreamBuilder` to listen for updates to the parent message from the channel's message stream. This ensures the parent message remains up-to-date within the thread view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread pages now resolve parent messages from the channel's live message stream so parent message data is loaded reactively; this ensures thread pages reflect up-to-date parent content but may briefly show a missing/placeholder parent while the stream resolves.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->