### PR TITLE
refactor(ui)!: replace ArgumentError with typed errors 

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Upcoming Beta
 
+🛑️ Breaking
+
+- Replaced `ArgumentError` with typed errors in `StreamAttachmentPickerController`:
+  `AttachmentTooLargeError` (file size exceeds limit) and `AttachmentLimitReachedError`
+  (attachment count exceeds limit). [[#2476]](https://github.com/GetStream/stream-chat-flutter/issues/2476)
+
+🐞 Fixed
+
 - Fixed regression in `emoji_code` support for reactions.
 
 ## 10.0.0-beta.11


### PR DESCRIPTION
# Submit a pull request
Fixes: #2476 

## Description of the pull request
Replaced `ArgumentError` in `StreamAttachmentPickerController` with two new specific, typed errors:

- `AttachmentTooLargeError`: Thrown when an attachment's file size exceeds the `maxAttachmentSize` limit.
- `AttachmentLimitReachedError`: Thrown when the number of attachments exceeds the `maxAttachmentCount` limit.

This change makes error handling more robust and specific for developers.