### PR TITLE
feat(ui): redesign image CDN handling and thumbnail resizing

### DIFF
--- a/migrations/redesign/README.md
+++ b/migrations/redesign/README.md
@@ -124,6 +124,7 @@ class MyCustomButton extends StatelessWidget {
 | Channel List Item | [channel_list_item.md](channel_list_item.md) |
 | Message Actions | [message_actions.md](message_actions.md) |
 | Reaction Picker / Reactions | [reaction_picker.md](reaction_picker.md) |
+| Image CDN & Thumbnails | [image_cdn.md](image_cdn.md) |
 
 ## Need Help?
 

--- a/migrations/redesign/image_cdn.md
+++ b/migrations/redesign/image_cdn.md
@@ -19,7 +19,7 @@ This guide covers the migration for the redesigned image CDN handling and thumbn
 
 | Component | Key Changes |
 |-----------|-------------|
-| [**StreamImageCDN**](#streamimagecdn) | New class replacing `getResizedImageUrl` and `stableCacheKey` String extensions |
+| [**StreamImageCDN**](#streamimagecdn) | New class replacing `getResizedImageUrl` String extension (stable cache keys now via `StreamImageCDN.cacheKey()`) |
 | [**StreamImageAttachmentThumbnail**](#streamimageattachmentthumbnail) | `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType` → single `resize` parameter |
 | [**StreamMediaAttachmentThumbnail**](#streammediaattachmentthumbnail) | `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType` → single `resize` parameter |
 | [**StreamImageAttachment**](#streamimageattachment) | `imageThumbnailSize`, `imageThumbnailResizeType`, `imageThumbnailCropType` → single `resize` parameter |

--- a/migrations/redesign/image_cdn.md
+++ b/migrations/redesign/image_cdn.md
@@ -1,0 +1,209 @@
+# Image CDN & Thumbnails Migration Guide
+
+This guide covers the migration for the redesigned image CDN handling and thumbnail resize parameters in Stream Chat Flutter SDK.
+
+---
+
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [StreamImageCDN](#streamimagecdn)
+- [StreamImageAttachmentThumbnail](#streamimageattachmentthumbnail)
+- [StreamMediaAttachmentThumbnail](#streammediaattachmentthumbnail)
+- [StreamImageAttachment](#streamimageattachment)
+- [Migration Checklist](#migration-checklist)
+
+---
+
+## Quick Reference
+
+| Component | Key Changes |
+|-----------|-------------|
+| [**StreamImageCDN**](#streamimagecdn) | New class replacing `getResizedImageUrl` and `stableCacheKey` String extensions |
+| [**StreamImageAttachmentThumbnail**](#streamimageattachmentthumbnail) | `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType` → single `resize` parameter |
+| [**StreamMediaAttachmentThumbnail**](#streammediaattachmentthumbnail) | `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType` → single `resize` parameter |
+| [**StreamImageAttachment**](#streamimageattachment) | `imageThumbnailSize`, `imageThumbnailResizeType`, `imageThumbnailCropType` → single `resize` parameter |
+
+---
+
+## StreamImageCDN
+
+### What Changed:
+
+The `getResizedImageUrl` String extension has been replaced with a dedicated `StreamImageCDN` class. This class handles CDN URL resolution and stable cache key generation, preventing image reloads caused by expiring signed URL tokens.
+
+### Key Changes:
+
+- `getResizedImageUrl` String extension removed — use `StreamImageCDN.resolveUrl` instead
+- New `StreamImageCDN.cacheKey` method generates stable cache keys that strip volatile signed URL tokens
+- Raw `String` resize/crop type parameters replaced with `ResizeMode` and `CropMode` enums
+- `StreamImageCDN` is injectable via `StreamChatConfigurationData` for custom CDN support
+
+### Migration:
+
+**Before:**
+```dart
+final resizedUrl = imageUrl.getResizedImageUrl(
+  width: 200,
+  height: 300,
+  resize: 'clip',
+  crop: 'center',
+);
+```
+
+**After:**
+```dart
+const imageCDN = StreamImageCDN();
+
+final resizedUrl = imageCDN.resolveUrl(
+  imageUrl,
+  resize: ImageResize(width: 200, height: 300),
+);
+
+final cacheKey = imageCDN.cacheKey(resizedUrl);
+```
+
+### Custom CDN Support:
+
+Extend `StreamImageCDN` and inject it via configuration:
+
+```dart
+class MyImageCDN extends StreamImageCDN {
+  @override
+  String cacheKey(String imageUrl) {
+    return Uri.parse(imageUrl).path;
+  }
+}
+
+StreamChat(
+  client: client,
+  config: StreamChatConfigurationData(
+    imageCDN: MyImageCDN(),
+  ),
+  child: ...,
+)
+```
+
+---
+
+## StreamImageAttachmentThumbnail
+
+### Breaking Changes:
+
+- `thumbnailSize` parameter removed
+- `thumbnailResizeType` parameter removed
+- `thumbnailCropType` parameter removed
+- New `resize` parameter (`ImageResize?`) replaces all three
+
+### Migration:
+
+**Before:**
+```dart
+StreamImageAttachmentThumbnail(
+  image: attachment,
+  thumbnailSize: const Size(200, 300),
+  thumbnailResizeType: 'clip',
+  thumbnailCropType: 'center',
+)
+```
+
+**After:**
+```dart
+StreamImageAttachmentThumbnail(
+  image: attachment,
+  resize: ImageResize(
+    width: 200,
+    height: 300,
+    mode: ResizeMode.clip,
+    crop: CropMode.center,
+  ),
+)
+```
+
+> **Note:** When `resize` is null, the size is auto-calculated from layout constraints and defaults to `ResizeMode.clip` and `CropMode.center`.
+
+---
+
+## StreamMediaAttachmentThumbnail
+
+### Breaking Changes:
+
+- `thumbnailSize` parameter removed
+- `thumbnailResizeType` parameter removed
+- `thumbnailCropType` parameter removed
+- New `resize` parameter (`ImageResize?`) replaces all three
+
+### Migration:
+
+**Before:**
+```dart
+StreamMediaAttachmentThumbnail(
+  media: attachment,
+  thumbnailSize: const Size(200, 300),
+  thumbnailResizeType: 'clip',
+  thumbnailCropType: 'center',
+)
+```
+
+**After:**
+```dart
+StreamMediaAttachmentThumbnail(
+  media: attachment,
+  resize: ImageResize(
+    width: 200,
+    height: 300,
+    mode: ResizeMode.clip,
+    crop: CropMode.center,
+  ),
+)
+```
+
+---
+
+## StreamImageAttachment
+
+### Breaking Changes:
+
+- `imageThumbnailSize` parameter removed
+- `imageThumbnailResizeType` parameter removed
+- `imageThumbnailCropType` parameter removed
+- New `resize` parameter (`ImageResize?`) replaces all three
+
+### Migration:
+
+**Before:**
+```dart
+StreamImageAttachment(
+  message: message,
+  image: attachment,
+  imageThumbnailSize: const Size(400, 600),
+  imageThumbnailResizeType: 'crop',
+  imageThumbnailCropType: 'center',
+)
+```
+
+**After:**
+```dart
+StreamImageAttachment(
+  message: message,
+  image: attachment,
+  resize: ImageResize(
+    width: 400,
+    height: 600,
+    mode: ResizeMode.crop,
+    crop: CropMode.center,
+  ),
+)
+```
+
+---
+
+## Migration Checklist
+
+- [ ] Replace `getResizedImageUrl` String extension calls with `StreamImageCDN.resolveUrl`
+- [ ] Use `StreamImageCDN.cacheKey` to generate stable cache keys for `CachedNetworkImage`
+- [ ] Replace raw `String` resize/crop values (`'clip'`, `'crop'`, etc.) with `ResizeMode` and `CropMode` enums
+- [ ] Update `StreamImageAttachmentThumbnail` to use `resize` parameter instead of `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType`
+- [ ] Update `StreamMediaAttachmentThumbnail` to use `resize` parameter instead of `thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType`
+- [ ] Update `StreamImageAttachment` to use `resize` parameter instead of `imageThumbnailSize`, `imageThumbnailResizeType`, `imageThumbnailCropType`
+- [ ] If using a custom CDN, extend `StreamImageCDN` and inject via `StreamChatConfigurationData`

--- a/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/image_attachment.dart
@@ -12,9 +12,7 @@ class StreamImageAttachment extends StatelessWidget {
     required this.image,
     this.shape,
     this.constraints = const BoxConstraints(),
-    this.imageThumbnailSize,
-    this.imageThumbnailResizeType = 'clip',
-    this.imageThumbnailCropType = 'center',
+    this.resize,
   });
 
   /// The [Message] that the image is attached to.
@@ -31,18 +29,14 @@ class StreamImageAttachment extends StatelessWidget {
   /// The constraints to use when displaying the image.
   final BoxConstraints constraints;
 
-  /// Size of the attachment image thumbnail.
-  final Size? imageThumbnailSize;
-
-  /// Resize type of the image attachment thumbnail.
+  /// The resize configuration for the image attachment thumbnail.
   ///
-  /// Defaults to [crop]
-  final String /*clip|crop|scale|fill*/ imageThumbnailResizeType;
-
-  /// Crop type of the image attachment thumbnail.
+  /// When provided, its [ImageResize.width] and [ImageResize.height] are used
+  /// directly as the CDN resize dimensions.
   ///
-  /// Defaults to [center]
-  final String /*center|top|bottom|left|right*/ imageThumbnailCropType;
+  /// When null, the size is auto-calculated from the layout constraints
+  /// and defaults to [ResizeMode.clip] and [CropMode.center].
+  final ImageResize? resize;
 
   @override
   Widget build(BuildContext context) {
@@ -86,9 +80,7 @@ class StreamImageAttachment extends StatelessWidget {
               fit: fit,
               width: double.infinity,
               height: double.infinity,
-              thumbnailSize: imageThumbnailSize,
-              thumbnailResizeType: imageThumbnailResizeType,
-              thumbnailCropType: imageThumbnailCropType,
+              resize: resize,
             ),
             Padding(
               padding: const EdgeInsets.all(8),

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/image_attachment_thumbnail.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/thumbnail_error.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/thumbnail_size_calculator.dart';
+import 'package:stream_chat_flutter/src/stream_chat_configuration.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
+import 'package:stream_chat_flutter/src/utils/stream_image_cdn.dart';
 import 'package:stream_chat_flutter/src/utils/utils.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 
@@ -22,9 +24,7 @@ class StreamImageAttachmentThumbnail extends StatelessWidget {
     this.width,
     this.height,
     this.fit,
-    this.thumbnailSize,
-    this.thumbnailResizeType = 'clip',
-    this.thumbnailCropType = 'center',
+    this.resize,
     this.errorBuilder = _defaultErrorBuilder,
   });
 
@@ -40,18 +40,14 @@ class StreamImageAttachmentThumbnail extends StatelessWidget {
   /// Fit of the attachment image thumbnail.
   final BoxFit? fit;
 
-  /// Size of the attachment image thumbnail.
-  final Size? thumbnailSize;
-
-  /// Resize type of the image attachment thumbnail.
+  /// The resize configuration for the image attachment thumbnail.
   ///
-  /// Defaults to [crop]
-  final String /*clip|crop|scale|fill*/ thumbnailResizeType;
-
-  /// Crop type of the image attachment thumbnail.
+  /// When provided, its [ImageResize.width] and [ImageResize.height] are used
+  /// directly as the CDN resize dimensions.
   ///
-  /// Defaults to [center]
-  final String /*center|top|bottom|left|right*/ thumbnailCropType;
+  /// When null, the size is auto-calculated from the layout constraints
+  /// and defaults to [ResizeMode.clip] and [CropMode.center].
+  final ImageResize? resize;
 
   /// Builder used when the thumbnail fails to load.
   final ThumbnailErrorBuilder errorBuilder;
@@ -75,35 +71,31 @@ class StreamImageAttachmentThumbnail extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Calculate optimal thumbnail size once for all paths
-        final effectiveThumbnailSize = switch (thumbnailSize) {
-          final thumbnailSize? => thumbnailSize,
-          _ => ThumbnailSizeCalculator.calculate(
+        var effectiveResize = resize;
+        if (effectiveResize == null) {
+          final size = ThumbnailSizeCalculator.calculate(
             targetSize: constraints.biggest,
             originalSize: image.originalSize,
             pixelRatio: MediaQuery.devicePixelRatioOf(context),
-          ),
-        };
+          );
 
-        final cacheWidth = effectiveThumbnailSize?.width.round();
-        final cacheHeight = effectiveThumbnailSize?.height.round();
+          if (size != null) effectiveResize = .new(width: size.width, height: size.height);
+        }
+
+        final cacheWidth = effectiveResize?.width.round();
+        final cacheHeight = effectiveResize?.height.round();
 
         // If the remote image URL is available, we can directly show it using
         // the _RemoteImageAttachment widget.
         final imageUrl = image.thumbUrl ?? image.imageUrl ?? image.assetUrl;
         if (imageUrl case final imageUrl?) {
-          var resizedImageUrl = imageUrl;
-          if (effectiveThumbnailSize case final thumbnailSize?) {
-            resizedImageUrl = imageUrl.getResizedImageUrl(
-              crop: thumbnailCropType,
-              resize: thumbnailResizeType,
-              width: thumbnailSize.width,
-              height: thumbnailSize.height,
-            );
-          }
+          final imageCDN = StreamChatConfiguration.maybeOf(context)?.imageCDN ?? const StreamImageCDN();
+          final resolvedUrl = imageCDN.resolveUrl(imageUrl, resize: effectiveResize);
+          final resolvedCacheKey = imageCDN.cacheKey(resolvedUrl);
 
           return _RemoteImageAttachment(
-            url: resizedImageUrl,
+            url: resolvedUrl,
+            cacheKey: resolvedCacheKey,
             width: width,
             height: height,
             fit: fit,
@@ -195,6 +187,7 @@ class _LocalImageAttachment extends StatelessWidget {
 class _RemoteImageAttachment extends StatelessWidget {
   const _RemoteImageAttachment({
     required this.url,
+    this.cacheKey,
     required this.errorBuilder,
     this.width,
     this.height,
@@ -204,6 +197,7 @@ class _RemoteImageAttachment extends StatelessWidget {
   });
 
   final String url;
+  final String? cacheKey;
   final double? width;
   final double? height;
   final int? cacheWidth;
@@ -215,6 +209,7 @@ class _RemoteImageAttachment extends StatelessWidget {
   Widget build(BuildContext context) {
     return CachedNetworkImage(
       imageUrl: url,
+      cacheKey: cacheKey,
       width: width,
       height: height,
       memCacheWidth: cacheWidth,

--- a/packages/stream_chat_flutter/lib/src/attachment/thumbnail/media_attachment_thumbnail.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/thumbnail/media_attachment_thumbnail.dart
@@ -3,6 +3,7 @@ import 'package:stream_chat_flutter/src/attachment/thumbnail/giphy_attachment_th
 import 'package:stream_chat_flutter/src/attachment/thumbnail/image_attachment_thumbnail.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/thumbnail_error.dart';
 import 'package:stream_chat_flutter/src/attachment/thumbnail/video_attachment_thumbnail.dart';
+import 'package:stream_chat_flutter/src/utils/stream_image_cdn.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 
 /// {@template mediaAttachmentThumbnail}
@@ -24,9 +25,7 @@ class StreamMediaAttachmentThumbnail extends StatelessWidget {
     this.width,
     this.height,
     this.fit,
-    this.thumbnailSize,
-    this.thumbnailResizeType = 'clip',
-    this.thumbnailCropType = 'center',
+    this.resize,
     this.gifInfoType = GiphyInfoType.original,
     this.errorBuilder = _defaultErrorBuilder,
   });
@@ -46,24 +45,16 @@ class StreamMediaAttachmentThumbnail extends StatelessWidget {
   /// Builder used when the thumbnail fails to load.
   final ThumbnailErrorBuilder errorBuilder;
 
-  /// Size of the attachment image thumbnail.
+  /// The resize configuration for the image attachment thumbnail.
+  ///
+  /// When provided, its [ImageResize.width] and [ImageResize.height] are used
+  /// directly as the CDN resize dimensions.
+  ///
+  /// When null, the size is auto-calculated from the layout constraints
+  /// and defaults to [ResizeMode.clip] and [CropMode.center].
   ///
   /// Ignored if the [Attachment.type] is not [AttachmentType.image].
-  final Size? thumbnailSize;
-
-  /// Resize type of the image attachment thumbnail.
-  ///
-  /// Defaults to [crop]
-  ///
-  /// Ignored if the [Attachment.type] is not [AttachmentType.image].
-  final String /*clip|crop|scale|fill*/ thumbnailResizeType;
-
-  /// Crop type of the image attachment thumbnail.
-  ///
-  /// Defaults to [center]
-  ///
-  /// Ignored if the [Attachment.type] is not [AttachmentType.image].
-  final String /*center|top|bottom|left|right*/ thumbnailCropType;
+  final ImageResize? resize;
 
   /// The type of giphy thumbnail to build.
   ///
@@ -94,9 +85,7 @@ class StreamMediaAttachmentThumbnail extends StatelessWidget {
         width: width,
         height: height,
         fit: fit,
-        thumbnailSize: thumbnailSize,
-        thumbnailResizeType: thumbnailResizeType,
-        thumbnailCropType: thumbnailCropType,
+        resize: resize,
         errorBuilder: errorBuilder,
       );
     }

--- a/packages/stream_chat_flutter/lib/src/stream_chat_configuration.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat_configuration.dart
@@ -165,6 +165,7 @@ class StreamChatConfigurationData {
     bool? enforceUniqueReactions,
     bool draftMessagesEnabled = false,
     MessagePreviewFormatter? messagePreviewFormatter,
+    StreamImageCDN imageCDN = const StreamImageCDN(),
   }) {
     return StreamChatConfigurationData._(
       loadingIndicator: loadingIndicator,
@@ -174,6 +175,7 @@ class StreamChatConfigurationData {
       enforceUniqueReactions: enforceUniqueReactions ?? true,
       draftMessagesEnabled: draftMessagesEnabled,
       messagePreviewFormatter: messagePreviewFormatter ?? MessagePreviewFormatter(),
+      imageCDN: imageCDN,
     );
   }
 
@@ -185,6 +187,7 @@ class StreamChatConfigurationData {
     required this.enforceUniqueReactions,
     required this.draftMessagesEnabled,
     required this.messagePreviewFormatter,
+    required this.imageCDN,
   });
 
   /// Copies the configuration options from one [StreamChatConfigurationData] to
@@ -197,6 +200,7 @@ class StreamChatConfigurationData {
     bool? enforceUniqueReactions,
     bool? draftMessagesEnabled,
     MessagePreviewFormatter? messagePreviewFormatter,
+    StreamImageCDN? imageCDN,
   }) {
     return StreamChatConfigurationData(
       reactionIconResolver: reactionIconResolver ?? this.reactionIconResolver,
@@ -206,6 +210,7 @@ class StreamChatConfigurationData {
       enforceUniqueReactions: enforceUniqueReactions ?? this.enforceUniqueReactions,
       draftMessagesEnabled: draftMessagesEnabled ?? this.draftMessagesEnabled,
       messagePreviewFormatter: messagePreviewFormatter ?? this.messagePreviewFormatter,
+      imageCDN: imageCDN ?? this.imageCDN,
     );
   }
 
@@ -236,6 +241,14 @@ class StreamChatConfigurationData {
   ///
   /// Defaults to [MessagePreviewFormatter].
   final MessagePreviewFormatter messagePreviewFormatter;
+
+  /// The image CDN used for generating resized image URLs and stable
+  /// cache keys.
+  ///
+  /// Defaults to [StreamImageCDN], which supports Stream's own CDN
+  /// and the Stream Dashboard CDN. Extend [StreamImageCDN] to customize
+  /// behavior for a custom CDN.
+  final StreamImageCDN imageCDN;
 
   static Widget _defaultUserImage(
     BuildContext context,

--- a/packages/stream_chat_flutter/lib/src/stream_chat_configuration.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat_configuration.dart
@@ -245,9 +245,8 @@ class StreamChatConfigurationData {
   /// The image CDN used for generating resized image URLs and stable
   /// cache keys.
   ///
-  /// Defaults to [StreamImageCDN], which supports Stream's own CDN
-  /// and the Stream Dashboard CDN. Extend [StreamImageCDN] to customize
-  /// behavior for a custom CDN.
+  /// Defaults to [StreamImageCDN], which supports Stream's own CDN.
+  /// Extend [StreamImageCDN] to customize behavior for a custom CDN.
   final StreamImageCDN imageCDN;
 
   static Widget _defaultUserImage(

--- a/packages/stream_chat_flutter/lib/src/utils/extensions.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/extensions.dart
@@ -101,7 +101,6 @@ extension StringExtension on String {
 
   /// Levenshtein distance between this and [t].
   int levenshteinDistance(String t) => levenshtein(this, t);
-
 }
 
 /// List extension

--- a/packages/stream_chat_flutter/lib/src/utils/extensions.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/extensions.dart
@@ -102,45 +102,6 @@ extension StringExtension on String {
   /// Levenshtein distance between this and [t].
   int levenshteinDistance(String t) => levenshtein(this, t);
 
-  /// Returns a resized imageUrl with the given [width], [height], [resize]
-  /// and [crop] if it is from Stream CDN or Dashboard.
-  ///
-  /// Read more at https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart#image-resizing
-  String getResizedImageUrl({
-    // TODO: Are these sizes optimal? Consider web/desktop
-    double width = 400,
-    double height = 400,
-    String /*clip|crop|scale|fill*/ resize = 'clip',
-    String /*center|top|bottom|left|right*/ crop = 'center',
-  }) {
-    final uri = Uri.parse(this);
-    final host = uri.host;
-
-    final fromStreamCDN = host.endsWith('stream-io-cdn.com');
-    final fromStreamDashboard = host.endsWith('stream-cloud-uploads.imgix.net');
-
-    if (!fromStreamCDN && !fromStreamDashboard) return this;
-
-    final queryParameters = {...uri.queryParameters};
-
-    if (fromStreamCDN) {
-      if (queryParameters['h'].isNullOrMatches('*') &&
-          queryParameters['w'].isNullOrMatches('*') &&
-          queryParameters['crop'].isNullOrMatches('*') &&
-          queryParameters['resize'].isNullOrMatches('*')) {
-        queryParameters['h'] = height.floor().toString();
-        queryParameters['w'] = width.floor().toString();
-        queryParameters['crop'] = crop;
-        queryParameters['resize'] = resize;
-      }
-    } else if (fromStreamDashboard) {
-      queryParameters['height'] = height.floor().toString();
-      queryParameters['width'] = width.floor().toString();
-      queryParameters['fit'] = crop;
-    }
-
-    return uri.replace(queryParameters: queryParameters).toString();
-  }
 }
 
 /// List extension

--- a/packages/stream_chat_flutter/lib/src/utils/stream_image_cdn.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/stream_image_cdn.dart
@@ -1,0 +1,175 @@
+/// Resize mode for CDN image transformations.
+///
+/// See the [Stream Image Resizing docs](https://getstream.io/chat/docs/flutter-dart/file_uploads/?language=dart#image-resizing)
+/// for more information.
+enum ResizeMode {
+  /// Resizes the image to fit within the given dimensions, preserving the
+  /// aspect ratio. The image may be smaller than the requested size.
+  clip('clip'),
+
+  /// Resizes and crops the image to exactly fill the given dimensions.
+  crop('crop'),
+
+  /// Stretches the image to exactly fill the given dimensions,
+  /// ignoring the aspect ratio.
+  scale('scale'),
+
+  /// Resizes the image to fill the given dimensions, preserving the
+  /// aspect ratio. Parts of the image may be cropped.
+  fill('fill')
+  ;
+
+  const ResizeMode(this.value);
+
+  /// The raw string value used as a CDN query parameter.
+  final String value;
+}
+
+/// Crop alignment for CDN image transformations.
+///
+/// This determines which part of the image is preserved when cropping.
+enum CropMode {
+  /// Crop from the center of the image.
+  center('center'),
+
+  /// Crop from the top of the image.
+  top('top'),
+
+  /// Crop from the bottom of the image.
+  bottom('bottom'),
+
+  /// Crop from the left of the image.
+  left('left'),
+
+  /// Crop from the right of the image.
+  right('right')
+  ;
+
+  const CropMode(this.value);
+
+  /// The raw string value used as a CDN query parameter.
+  final String value;
+}
+
+/// Configuration for resizing an image via a CDN.
+///
+/// When passed to [StreamImageCDN.resolveUrl], the CDN will resize the image
+/// to the given [width] and [height] using the specified [mode] and [crop].
+class ImageResize {
+  /// Creates a new [ImageResize] configuration.
+  const ImageResize({
+    required this.width,
+    required this.height,
+    this.mode = .clip,
+    this.crop = .center,
+  });
+
+  /// The target width in logical pixels.
+  final double width;
+
+  /// The target height in logical pixels.
+  final double height;
+
+  /// The resize mode to use.
+  ///
+  /// Defaults to [ResizeMode.clip].
+  final ResizeMode mode;
+
+  /// The crop alignment when the resize mode requires cropping.
+  ///
+  /// Defaults to [CropMode.center].
+  final CropMode crop;
+}
+
+/// Handles CDN URL resolution and cache key generation for Stream Chat images.
+///
+/// The default implementation supports Stream's own CDN
+/// (`stream-io-cdn.com`).
+///
+/// To customize behavior for a custom CDN, extend this class and override
+/// [resolveUrl] and/or [cacheKey]:
+///
+/// ```dart
+/// class MyImageCDN extends StreamImageCDN {
+///   @override
+///   String cacheKey(String imageUrl) {
+///     // Custom cache key logic for your CDN.
+///     return Uri.parse(imageUrl).path;
+///   }
+/// }
+/// ```
+///
+/// Then inject it via [StreamChatConfigurationData]:
+///
+/// ```dart
+/// StreamChat(
+///   client: client,
+///   config: StreamChatConfigurationData(
+///     imageCDN: MyImageCDN(),
+///   ),
+///   child: ...,
+/// )
+/// ```
+class StreamImageCDN {
+  /// Creates a new [StreamImageCDN] instance.
+  const StreamImageCDN();
+
+  // The host suffix for Stream's image CDN.
+  static const _streamCDNHost = 'stream-io-cdn.com';
+
+  // Query parameter names that are preserved in cache keys.
+  //
+  // These are the image-transformation parameters that affect
+  // which rendition of the image is returned. All other parameters
+  // (e.g. signed URL tokens) are stripped.
+  static const _persistedParameters = {'w', 'h', 'resize', 'crop'};
+
+  /// Resolves the [sourceUrl] by appending resize/transform parameters
+  /// appropriate for the CDN.
+  ///
+  /// When [resize] is null, no resizing parameters are added and the
+  /// [sourceUrl] is returned unchanged.
+  ///
+  /// For non-Stream CDN URLs, returns [sourceUrl] unchanged regardless
+  /// of [resize].
+  ///
+  /// Override this to customize URL rewriting for a custom CDN.
+  String resolveUrl(String sourceUrl, {ImageResize? resize}) {
+    final uri = Uri.tryParse(sourceUrl);
+    if (uri == null || !uri.host.contains(_streamCDNHost)) return sourceUrl;
+    if (resize == null) return sourceUrl;
+
+    final queryParameters = {
+      ...uri.queryParameters,
+      'w': resize.width == 0 ? '*' : resize.width.floor().toString(),
+      'h': resize.height == 0 ? '*' : resize.height.floor().toString(),
+      'resize': resize.mode.value,
+      'ro': '0',
+      if (resize.mode == ResizeMode.crop) 'crop': resize.crop.value,
+    };
+
+    return uri.replace(queryParameters: queryParameters).toString();
+  }
+
+  /// Returns a stable cache key for [imageUrl], stripping volatile
+  /// authentication parameters (e.g. CloudFront signed URL tokens)
+  /// while preserving those that identify distinct image renditions.
+  ///
+  /// This uses an allowlist approach, keeping only the parameters in
+  /// [_persistedParameters] for Stream CDN URLs.
+  ///
+  /// For non-Stream CDN URLs, returns the full URL string unchanged.
+  ///
+  /// Override this to customize cache key generation for a custom CDN.
+  String cacheKey(String imageUrl) {
+    final uri = Uri.tryParse(imageUrl);
+    if (uri == null || !uri.host.contains(_streamCDNHost)) return imageUrl;
+
+    final filteredParams = <String, String>{
+      for (final MapEntry(:key, :value) in uri.queryParameters.entries)
+        if (_persistedParameters.contains(key)) key: value,
+    };
+
+    return uri.replace(queryParameters: filteredParams).toString();
+  }
+}

--- a/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
+++ b/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
@@ -1,7 +1,6 @@
 export 'package:jiffy/jiffy.dart';
 export 'package:photo_manager/photo_manager.dart' show ThumbnailSize, ThumbnailFormat;
 export 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
-
 export 'package:stream_core_flutter/stream_core_flutter.dart'
     show
         StreamAvatarGroupSize,
@@ -172,4 +171,5 @@ export 'src/utils/device_segmentation.dart';
 export 'src/utils/extensions.dart';
 export 'src/utils/helpers.dart';
 export 'src/utils/message_preview_formatter.dart';
+export 'src/utils/stream_image_cdn.dart';
 export 'src/utils/typedefs.dart';

--- a/packages/stream_chat_flutter/test/src/utils/stream_image_cdn_test.dart
+++ b/packages/stream_chat_flutter/test/src/utils/stream_image_cdn_test.dart
@@ -1,0 +1,237 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/src/utils/stream_image_cdn.dart';
+
+void main() {
+  const cdn = StreamImageCDN();
+
+  group('StreamImageCDN.resolveUrl', () {
+    group('Stream CDN URLs', () {
+      test('returns unchanged URL when resize is null', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Policy=abc&Signature=xyz&Key-Pair-Id=123';
+
+        expect(cdn.resolveUrl(url), equals(url));
+      });
+
+      test('adds resize params when none exist', () {
+        const url = 'https://us-east.stream-io-cdn.com/102400/images/photo.jpg';
+        const resize = ImageResize(width: 200, height: 300);
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('w=200'));
+        expect(result, contains('h=300'));
+        expect(result, contains('resize=clip'));
+        expect(result, contains('ro=0'));
+        expect(result, isNot(contains('crop=')));
+      });
+
+      test('includes crop param only when mode is crop', () {
+        const url = 'https://us-east.stream-io-cdn.com/102400/images/photo.jpg';
+        const resize = ImageResize(
+          width: 400,
+          height: 400,
+          mode: ResizeMode.crop,
+          crop: CropMode.top,
+        );
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('resize=crop'));
+        expect(result, contains('crop=top'));
+        expect(result, contains('ro=0'));
+      });
+
+      test('does not include crop param when mode is not crop', () {
+        const url = 'https://us-east.stream-io-cdn.com/102400/images/photo.jpg';
+
+        for (final mode in [
+          ResizeMode.clip,
+          ResizeMode.scale,
+          ResizeMode.fill,
+        ]) {
+          final result = cdn.resolveUrl(
+            url,
+            resize: ImageResize(width: 200, height: 200, mode: mode),
+          );
+
+          expect(
+            result,
+            isNot(contains('crop=')),
+            reason: 'crop should not be present for mode ${mode.value}',
+          );
+        }
+      });
+
+      test('always overrides existing resize params', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?w=100&h=100&resize=fill';
+        const resize = ImageResize(
+          width: 200,
+          height: 300,
+          mode: ResizeMode.crop,
+          crop: CropMode.left,
+        );
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('w=200'));
+        expect(result, contains('h=300'));
+        expect(result, contains('resize=crop'));
+        expect(result, contains('crop=left'));
+      });
+
+      test('preserves existing non-resize query parameters', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Policy=abc&Signature=xyz&Key-Pair-Id=123';
+        const resize = ImageResize(width: 200, height: 300);
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('Policy=abc'));
+        expect(result, contains('Signature=xyz'));
+        expect(result, contains('Key-Pair-Id=123'));
+        expect(result, contains('w=200'));
+      });
+
+      test('floors fractional dimensions', () {
+        const url = 'https://us-east.stream-io-cdn.com/102400/images/photo.jpg';
+        const resize = ImageResize(width: 199.7, height: 300.3);
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('w=199'));
+        expect(result, contains('h=300'));
+      });
+
+      test('uses wildcard for zero dimensions', () {
+        const url = 'https://us-east.stream-io-cdn.com/102400/images/photo.jpg';
+        const resize = ImageResize(width: 0, height: 300);
+
+        final result = cdn.resolveUrl(url, resize: resize);
+
+        expect(result, contains('w=%2A'));
+        expect(result, contains('h=300'));
+      });
+    });
+
+    group('non-Stream URLs', () {
+      test('returns URL unchanged regardless of resize', () {
+        const url = 'https://example.com/photo.jpg';
+        const resize = ImageResize(width: 200, height: 300);
+
+        expect(cdn.resolveUrl(url, resize: resize), equals(url));
+      });
+
+      test('returns URL unchanged when resize is null', () {
+        const url = 'https://example.com/photo.jpg?token=abc';
+
+        expect(cdn.resolveUrl(url), equals(url));
+      });
+    });
+  });
+
+  group('StreamImageCDN.cacheKey', () {
+    group('Stream CDN URLs', () {
+      test('strips signing parameters', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Key-Pair-Id=APKAIHG&Policy=eyJTdGF0&Signature=OeMK5'
+            '&w=200&h=300&resize=clip&crop=center';
+
+        final key = cdn.cacheKey(url);
+
+        expect(key, contains('w=200'));
+        expect(key, contains('h=300'));
+        expect(key, contains('resize=clip'));
+        expect(key, contains('crop=center'));
+        expect(key, isNot(contains('Key-Pair-Id')));
+        expect(key, isNot(contains('Policy')));
+        expect(key, isNot(contains('Signature')));
+      });
+
+      test('returns URL path only when no resize params exist', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Key-Pair-Id=APKAIHG&Policy=eyJTdGF0&Signature=OeMK5';
+
+        final key = cdn.cacheKey(url);
+
+        expect(key, isNot(contains('Key-Pair-Id')));
+        expect(key, isNot(contains('Policy')));
+        expect(key, isNot(contains('Signature')));
+        expect(
+          key,
+          'https://us-east.stream-io-cdn.com/102400/images/photo.jpg?',
+        );
+      });
+
+      test('produces same key for same image with different signatures', () {
+        const url1 =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Key-Pair-Id=APKAIHG&Policy=policy1&Signature=sig1'
+            '&w=200&h=300';
+        const url2 =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?Key-Pair-Id=APKAIHG&Policy=policy2&Signature=sig2'
+            '&w=200&h=300';
+
+        expect(cdn.cacheKey(url1), equals(cdn.cacheKey(url2)));
+      });
+
+      test('produces different keys for different resize dimensions', () {
+        const url1 =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?w=200&h=300';
+        const url2 =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?w=400&h=600';
+
+        expect(cdn.cacheKey(url1), isNot(equals(cdn.cacheKey(url2))));
+      });
+
+      test('strips oh and ow parameters', () {
+        const url =
+            'https://us-east.stream-io-cdn.com/102400/images/photo.jpg'
+            '?oh=4032&ow=3024&w=200&h=300';
+
+        final key = cdn.cacheKey(url);
+
+        expect(key, isNot(contains('oh=')));
+        expect(key, isNot(contains('ow=')));
+        expect(key, contains('w=200'));
+        expect(key, contains('h=300'));
+      });
+    });
+
+    group('non-Stream URLs', () {
+      test('returns full URL string unchanged', () {
+        const url = 'https://example.com/photo.jpg?token=abc';
+
+        expect(cdn.cacheKey(url), equals(url));
+      });
+    });
+  });
+
+  group('ResizeMode', () {
+    test('all modes have correct string values', () {
+      expect(ResizeMode.clip.value, 'clip');
+      expect(ResizeMode.crop.value, 'crop');
+      expect(ResizeMode.scale.value, 'scale');
+      expect(ResizeMode.fill.value, 'fill');
+    });
+  });
+
+  group('CropMode', () {
+    test('all modes have correct string values', () {
+      expect(CropMode.center.value, 'center');
+      expect(CropMode.top.value, 'top');
+      expect(CropMode.bottom.value, 'bottom');
+      expect(CropMode.left.value, 'left');
+      expect(CropMode.right.value, 'right');
+    });
+  });
+}


### PR DESCRIPTION
## Description of the pull request
* Introduce `StreamImageCDN` for centralized URL resolution and stable cache key generation
* Replace raw string-based thumbnail parameters (`thumbnailSize`, `thumbnailResizeType`, `thumbnailCropType`) with a structured `ImageResize` object across `ImageAttachment`, `MediaAttachmentThumbnail`, and `ImageAttachmentThumbnail`
* Add `imageCDN` to `StreamChatConfigurationData` to allow custom CDN implementations
* Remove `getResizedImageUrl` extension on `String` in favor of `StreamImageCDN.resolveUrl`
* Improve image caching by using `StreamImageCDN.cacheKey` to strip volatile query parameters (e.g., signed tokens) from `CachedNetworkImage`
* Add comprehensive migration guide for the redesign and breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced redesigned image CDN system with configurable resize and crop modes
  * Added support for custom CDN implementations via configuration

* **Documentation**
  * Added comprehensive migration guide for image CDN updates

* **Refactor**
  * Simplified image attachment configuration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->