### PR TITLE
feat(ui): composer also send to channel

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -95,7 +95,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: aaa6209ee7e8f155b210a75d6c3828ac68b8d348
+          ref: 2959ed4323d189c1c43930964726f8d219e5dd94
           path: packages/stream_core_flutter
       synchronized: ^3.1.0+1
       thumblr: ^0.0.4

--- a/melos.yaml
+++ b/melos.yaml
@@ -95,7 +95,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: 213dfb64b1d0c22a668a4a0924503703ff9a33e9
+          ref: aaa6209ee7e8f155b210a75d6c3828ac68b8d348
           path: packages/stream_core_flutter
       synchronized: ^3.1.0+1
       thumblr: ^0.0.4

--- a/packages/stream_chat_flutter/lib/src/components/message_composer/stream_chat_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/components/message_composer/stream_chat_message_composer.dart
@@ -7,6 +7,7 @@ import 'package:stream_chat_flutter/src/components/message_composer/message_comp
 import 'package:stream_chat_flutter/src/components/message_composer/message_composer_recording_locked.dart';
 import 'package:stream_chat_flutter/src/components/message_composer/message_composer_recording_ongoing.dart';
 import 'package:stream_chat_flutter/src/components/message_composer/message_composer_trailing.dart';
+import 'package:stream_chat_flutter/src/message_input/dm_checkbox_list_tile.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import 'package:stream_core_flutter/stream_core_flutter.dart' as core;
 
@@ -33,6 +34,7 @@ class StreamChatMessageComposer extends StatefulWidget {
     StreamAudioRecorderController? audioRecorderController,
     bool sendVoiceRecordingAutomatically = false,
     AudioRecorderFeedback feedback = const AudioRecorderFeedback(),
+    bool canAlsoSendAsToChannel = false,
   }) : props = MessageComposerProps(
          controller: controller,
          isFloating: false,
@@ -46,6 +48,7 @@ class StreamChatMessageComposer extends StatefulWidget {
          audioRecorderController: audioRecorderController,
          sendVoiceRecordingAutomatically: sendVoiceRecordingAutomatically,
          feedback: feedback,
+         canAlsoSendAsToChannel: canAlsoSendAsToChannel,
        );
 
   /// The controller for the message composer.
@@ -176,6 +179,7 @@ class MessageComposerProps {
     this.audioRecorderController,
     this.sendVoiceRecordingAutomatically = false,
     this.feedback = const AudioRecorderFeedback(),
+    this.canAlsoSendAsToChannel = false,
   });
 
   /// The controller for the message composer.
@@ -216,6 +220,10 @@ class MessageComposerProps {
 
   /// The feedback for the audio recorder.
   final AudioRecorderFeedback feedback;
+
+  /// Whether the user can also send the message as a direct message.
+  /// Usually used in threads.
+  final bool canAlsoSendAsToChannel;
 }
 
 extension on StreamAudioRecorderController {
@@ -290,7 +298,29 @@ class DefaultStreamChatMessageComposer extends StatelessWidget {
       inputLeading: StreamMessageComposerInputLeading(
         props: componentProps,
       ),
-      inputBody: body,
+      inputBody:
+          body ??
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              core.StreamMessageComposerInputField(
+                controller: inputController.textFieldController,
+                placeholder: props.placeholder,
+                focusNode: props.focusNode,
+              ),
+              if (props.canAlsoSendAsToChannel)
+                DmCheckboxListTile(
+                  value: props.controller?.showInChannel ?? false,
+                  // height of list tile is 34px, height of checkbox is 16px, so we need to subtract 8px to make the spacing correct.
+                  contentPadding: EdgeInsets.only(
+                    right: context.streamSpacing.md,
+                    left: context.streamSpacing.md,
+                    bottom: context.streamSpacing.md - 8,
+                  ),
+                  onChanged: (value) => props.controller?.showInChannel = value,
+                ),
+            ],
+          ),
     );
   }
 

--- a/packages/stream_chat_flutter/lib/src/components/message_composer/stream_chat_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/components/message_composer/stream_chat_message_composer.dart
@@ -34,7 +34,7 @@ class StreamChatMessageComposer extends StatefulWidget {
     StreamAudioRecorderController? audioRecorderController,
     bool sendVoiceRecordingAutomatically = false,
     AudioRecorderFeedback feedback = const AudioRecorderFeedback(),
-    bool canAlsoSendAsToChannel = false,
+    bool canAlsoSendToChannel = false,
   }) : props = MessageComposerProps(
          controller: controller,
          isFloating: false,
@@ -48,7 +48,7 @@ class StreamChatMessageComposer extends StatefulWidget {
          audioRecorderController: audioRecorderController,
          sendVoiceRecordingAutomatically: sendVoiceRecordingAutomatically,
          feedback: feedback,
-         canAlsoSendAsToChannel: canAlsoSendAsToChannel,
+         canAlsoSendToChannel: canAlsoSendToChannel,
        );
 
   /// The controller for the message composer.
@@ -179,7 +179,7 @@ class MessageComposerProps {
     this.audioRecorderController,
     this.sendVoiceRecordingAutomatically = false,
     this.feedback = const AudioRecorderFeedback(),
-    this.canAlsoSendAsToChannel = false,
+    this.canAlsoSendToChannel = false,
   });
 
   /// The controller for the message composer.
@@ -223,7 +223,7 @@ class MessageComposerProps {
 
   /// Whether the user can also send the message as a direct message.
   /// Usually used in threads.
-  final bool canAlsoSendAsToChannel;
+  final bool canAlsoSendToChannel;
 }
 
 extension on StreamAudioRecorderController {
@@ -308,7 +308,7 @@ class DefaultStreamChatMessageComposer extends StatelessWidget {
                 placeholder: props.placeholder,
                 focusNode: props.focusNode,
               ),
-              if (props.canAlsoSendAsToChannel)
+              if (props.canAlsoSendToChannel)
                 DmCheckboxListTile(
                   value: props.controller?.showInChannel ?? false,
                   // height of list tile is 34px, height of checkbox is 16px, so we need to subtract 8px to make the spacing correct.

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -670,7 +670,7 @@ class DefaultTranslations implements Translations {
   String get reconnectingLabel => 'Reconnecting...';
 
   @override
-  String get alsoSendAsDirectMessageLabel => 'Also send as direct message';
+  String get alsoSendAsDirectMessageLabel => 'Also send in Channel';
 
   @override
   String get addACommentOrSendLabel => 'Add a comment or send';

--- a/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
@@ -26,7 +26,6 @@ class DmCheckboxListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = context.streamTextTheme;
-    final colorScheme = context.streamColorScheme;
 
     const visualDensity = VisualDensity(
       vertical: VisualDensity.minimumDensity,
@@ -55,10 +54,7 @@ class DmCheckboxListTile extends StatelessWidget {
         contentPadding: contentPadding,
         title: Text(
           context.translations.alsoSendAsDirectMessageLabel,
-          style: textTheme.metadataDefault.copyWith(
-            // ignore: deprecated_member_use
-            color: colorScheme.textPrimary,
-          ),
+          style: textTheme.metadataDefault,
         ),
       ),
     );

--- a/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+import 'package:stream_core_flutter/stream_core_flutter.dart';
 
 /// {@template dmCheckboxListTile}
 /// A widget that represents a checkbox list tile for direct message input.
@@ -25,9 +27,8 @@ class DmCheckboxListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = StreamChatTheme.of(context);
-    final textTheme = theme.textTheme;
-    final colorTheme = theme.colorTheme;
+    final textTheme = context.streamTextTheme;
+    final colorScheme = context.streamColorScheme;
 
     const visualDensity = VisualDensity(
       vertical: VisualDensity.minimumDensity,
@@ -35,27 +36,13 @@ class DmCheckboxListTile extends StatelessWidget {
     );
 
     final checkbox = ExcludeFocus(
-      child: CheckboxTheme(
-        data: CheckboxThemeData(
-          overlayColor: WidgetStatePropertyAll(
-            colorTheme.accentPrimary.withAlpha(kRadialReactionAlpha),
-          ),
-        ),
-        child: Checkbox(
-          value: value,
-          visualDensity: visualDensity,
-          activeColor: colorTheme.accentPrimary,
-          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          side: BorderSide(width: 2, color: colorTheme.textLowEmphasis),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(3)),
-          onChanged: switch (onChanged) {
-            final onChanged? => (value) {
-              if (value == null) return;
-              return onChanged.call(value);
-            },
-            _ => null,
-          },
-        ),
+      child: StreamCheckbox(
+        value: value,
+        size: StreamCheckboxSize.sm,
+        onChanged: switch (onChanged) {
+          final onChanged? => onChanged.call,
+          _ => null,
+        },
       ),
     );
 
@@ -70,9 +57,9 @@ class DmCheckboxListTile extends StatelessWidget {
         contentPadding: contentPadding,
         title: Text(
           context.translations.alsoSendAsDirectMessageLabel,
-          style: textTheme.footnote.copyWith(
+          style: textTheme.metadataDefault.copyWith(
             // ignore: deprecated_member_use
-            color: colorTheme.textHighEmphasis.withOpacity(0.5),
+            color: colorScheme.textPrimary,
           ),
         ),
       ),

--- a/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/dm_checkbox_list_tile.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:stream_chat_flutter/src/theme/stream_chat_theme.dart';
-import 'package:stream_chat_flutter/src/utils/extensions.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import 'package:stream_core_flutter/stream_core_flutter.dart';
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -790,8 +790,8 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
             focusNode: focusNode,
             onSendPressed: sendMessage,
             audioRecorderController: _audioRecorderController,
+            canAlsoSendAsToChannel: _shouldShowDmCheckbox(),
           ),
-          _buildDmCheckbox(context),
           _buildInlineAttachmentPicker(context),
         ].nonNulls.toList(),
       ),
@@ -855,19 +855,11 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
     return null;
   }
 
-  Widget? _buildDmCheckbox(BuildContext context) {
-    if (widget.hideSendAsDm) return null;
+  bool _shouldShowDmCheckbox() {
+    if (widget.hideSendAsDm) return false;
 
     final insideThread = _effectiveController.message.parentId != null;
-    if (!insideThread) return null;
-
-    return DmCheckboxListTile(
-      value: _effectiveController.showInChannel,
-      contentPadding: EdgeInsets.symmetric(
-        horizontal: context.streamSpacing.md,
-      ),
-      onChanged: (value) => _effectiveController.showInChannel = value,
-    );
+    return insideThread;
   }
 
   Widget _buildNoPermissionMessage(BuildContext context) {

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -790,7 +790,7 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
             placeholder: _getHint(context) ?? '',
             focusNode: focusNode,
             onSendPressed: sendMessage,
-            canAlsoSendAsToChannel: _shouldShowDmCheckbox(),
+            canAlsoSendToChannel: _shouldShowSendToChannelCheckbox(),
             audioRecorderController: widget.enableVoiceRecording ? _audioRecorderController : null,
           ),
           _buildInlineAttachmentPicker(context),
@@ -856,7 +856,7 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
     return null;
   }
 
-  bool _shouldShowDmCheckbox() {
+  bool _shouldShowSendToChannelCheckbox() {
     if (!widget.canAlsoSendToChannelFromThread) return false;
 
     final insideThread = _effectiveController.message.parentId != null;

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -11,7 +11,6 @@ import 'package:flutter_portal/flutter_portal.dart';
 import 'package:stream_chat_flutter/platform_widget_builder/src/platform_widget_builder.dart';
 import 'package:stream_chat_flutter/src/message_input/attachment_button.dart';
 import 'package:stream_chat_flutter/src/message_input/command_button.dart';
-import 'package:stream_chat_flutter/src/message_input/dm_checkbox_list_tile.dart';
 import 'package:stream_chat_flutter/src/message_input/quoting_message_top_area.dart';
 import 'package:stream_chat_flutter/src/message_input/stream_message_input_icon_button.dart';
 import 'package:stream_chat_flutter/src/message_input/tld.dart';

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -126,7 +126,7 @@ class StreamMessageInput extends StatefulWidget {
     this.focusNode,
     this.sendButtonLocation = SendButtonLocation.outside,
     this.autofocus = false,
-    this.hideSendAsDm = false,
+    this.canAlsoSendToChannelFromThread = true,
     this.enableVoiceRecording = false,
     this.sendVoiceRecordingAutomatically = false,
     this.voiceRecordingFeedback = const AudioRecorderFeedback(),
@@ -218,8 +218,10 @@ class StreamMessageInput extends StatefulWidget {
   /// Use this property to hide/show the commands button.
   final bool showCommandsButton;
 
-  /// Hide send as dm checkbox.
-  final bool hideSendAsDm;
+  /// Show the checkbox to send the message as a direct message to the channel.
+  ///
+  /// Defaults to true.
+  final bool canAlsoSendToChannelFromThread;
 
   /// If true the voice recording button will be displayed.
   ///
@@ -788,8 +790,8 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
             placeholder: _getHint(context) ?? '',
             focusNode: focusNode,
             onSendPressed: sendMessage,
-            audioRecorderController: _audioRecorderController,
             canAlsoSendAsToChannel: _shouldShowDmCheckbox(),
+            audioRecorderController: widget.enableVoiceRecording ? _audioRecorderController : null,
           ),
           _buildInlineAttachmentPicker(context),
         ].nonNulls.toList(),
@@ -855,7 +857,7 @@ class StreamMessageInputState extends State<StreamMessageInput> with Restoration
   }
 
   bool _shouldShowDmCheckbox() {
-    if (widget.hideSendAsDm) return false;
+    if (!widget.canAlsoSendToChannelFromThread) return false;
 
     final insideThread = _effectiveController.message.parentId != null;
     return insideThread;

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 213dfb64b1d0c22a668a4a0924503703ff9a33e9
+      ref: aaa6209ee7e8f155b210a75d6c3828ac68b8d348
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.1.0+1

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: aaa6209ee7e8f155b210a75d6c3828ac68b8d348
+      ref: 2959ed4323d189c1c43930964726f8d219e5dd94
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.1.0+1

--- a/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_input_test.dart
@@ -539,7 +539,7 @@ void main() {
                 channel: channel,
                 child: const Scaffold(
                   bottomNavigationBar: StreamMessageInput(
-                    hideSendAsDm: true,
+                    canAlsoSendToChannelFromThread: false,
                   ),
                 ),
               ),

--- a/packages/stream_chat_localizations/example/lib/add_new_lang.dart
+++ b/packages/stream_chat_localizations/example/lib/add_new_lang.dart
@@ -132,7 +132,7 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   String get reconnectingLabel => 'Reconnecting...';
 
   @override
-  String get alsoSendAsDirectMessageLabel => 'Also send as direct message';
+  String get alsoSendAsDirectMessageLabel => 'Also send in Channel';
 
   @override
   String get addACommentOrSendLabel => 'Add a comment or send';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -112,7 +112,7 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get reconnectingLabel => 'Reconnecting...';
 
   @override
-  String get alsoSendAsDirectMessageLabel => 'Also send as direct message';
+  String get alsoSendAsDirectMessageLabel => 'Also send in Channel';
 
   @override
   String get addACommentOrSendLabel => 'Add a comment or send';


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-410

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This updates the UI so there can be a checkbox for 'send to channel' in the thread composer.

Required from core: https://github.com/GetStream/stream-core-flutter/pull/72

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

https://github.com/user-attachments/assets/84eba338-665b-45bb-982e-144de404fc61


| Before | After |
| --- | --- |
| <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/cc653397-b400-473a-b98b-f416d12d16fe" /> | <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/261e3141-7e2d-46d5-bcbd-ede45ff17d28" /> |
