### PR TITLE
feat(ui): fix duration on video attachments

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -95,7 +95,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: 28f914ddf41700c0ef14b132f6c284b986658db4
+          ref: 492f6f4ef8c73c64b3f399f92c5e508b7fb39e55
           path: packages/stream_core_flutter
       synchronized: ^3.1.0+1
       thumblr: ^0.0.4

--- a/melos.yaml
+++ b/melos.yaml
@@ -95,7 +95,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: 8057a775c2ed764dbd5cbabd2dd60d3cd68d2f08
+          ref: 28f914ddf41700c0ef14b132f6c284b986658db4
           path: packages/stream_core_flutter
       synchronized: ^3.1.0+1
       thumblr: ^0.0.4

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_gallery_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_gallery_picker.dart
@@ -271,6 +271,10 @@ extension StreamImagePickerX on StreamAttachmentPickerController {
 
     extraDataMap['file_size'] = file.size!;
 
+    if (type == AssetType.video) {
+      extraDataMap['duration'] = asset.videoDuration.inSeconds;
+    }
+
     final attachment = Attachment(
       id: asset.id,
       file: file,

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input_attachment_list.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input_attachment_list.dart
@@ -442,8 +442,11 @@ class StreamMediaAttachmentBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final durationSecs = attachment.extraData['duration'] as num?;
+    final videoDuration = durationSecs != null ? Duration(seconds: durationSecs.round()) : null;
+
     final mediaBadge = attachment.type == AttachmentType.video
-        ? const StreamMediaBadge(type: MediaBadgeType.video)
+        ? StreamMediaBadge(type: MediaBadgeType.video, duration: videoDuration)
         : null;
 
     return Container(

--- a/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery_tile.dart
@@ -116,23 +116,16 @@ class StreamPhotoGalleryTile extends StatelessWidget {
             child: _GallerySelectedIndicator(selected: selected),
           ),
         ),
-        if (media.type == AssetType.video) ...[
+        if (media.type == AssetType.video)
           Positioned(
             left: 8,
-            bottom: 10,
-            child: Icon(context.streamIcons.videoSolid),
-          ),
-          Positioned(
-            right: 4,
-            bottom: 10,
-            child: Text(
-              media.videoDuration.format(),
-              style: TextStyle(
-                color: chatThemeData.colorTheme.barsBg,
-              ),
+            bottom: 8,
+            child: StreamMediaBadge(
+              type: MediaBadgeType.video,
+              duration: media.videoDuration,
+              durationFormat: MediaBadgeDurationFormat.exact,
             ),
           ),
-        ],
         // https://stackoverflow.com/a/59317162/10036882
         Positioned.fill(
           child: Material(
@@ -173,17 +166,6 @@ class _GallerySelectedIndicator extends StatelessWidget {
             )
           : null,
     );
-  }
-}
-
-extension on Duration {
-  String format() {
-    final s = '$this'.split('.')[0].padLeft(8, '0');
-    if (s.startsWith('00:')) {
-      return s.replaceFirst('00:', '');
-    }
-
-    return s;
   }
 }
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 28f914ddf41700c0ef14b132f6c284b986658db4
+      ref: 492f6f4ef8c73c64b3f399f92c5e508b7fb39e55
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.1.0+1

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 8057a775c2ed764dbd5cbabd2dd60d3cd68d2f08
+      ref: 28f914ddf41700c0ef14b132f6c284b986658db4
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.1.0+1


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: fixes FLU-413

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Duration in extraData from iOS: https://github.com/GetStream/stream-chat-swiftui/blob/v5/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerItemView.swift#L83C67-L83C68

Needs: https://github.com/GetStream/stream-core-flutter/pull/80


## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/a44c8c95-e203-46f6-b7c9-2eed17fc6dc4" /> | <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/10a781f2-5be0-40c8-8106-b8ed9efaec44" /> |
