### PR TITLE
expose default buttons of composer

### DIFF
--- a/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer.dart
@@ -1,2 +1,4 @@
 export 'message_composer_component_props.dart';
+export 'message_composer_input_trailing.dart' show DefaultStreamMessageComposerInputTrailing;
+export 'message_composer_leading.dart' show DefaultStreamMessageComposerLeading;
 export 'stream_chat_message_composer.dart';

--- a/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer_leading.dart
+++ b/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer_leading.dart
@@ -19,13 +19,19 @@ class StreamMessageComposerLeading extends StatelessWidget {
           context,
           MessageComposerLeadingProps.from(props),
         ) ??
-        _DefaultStreamMessageComposerLeading(props: props);
+        DefaultStreamMessageComposerLeading(props: props);
   }
 }
 
-class _DefaultStreamMessageComposerLeading extends StatelessWidget {
-  const _DefaultStreamMessageComposerLeading({required this.props});
+/// Default implementation of the leading of the message composer.
+/// Shows the attachment button when the message composer is not in audio recording flow and no command is selected.
+class DefaultStreamMessageComposerLeading extends StatelessWidget {
+  
+  /// Creates a new instance of [DefaultStreamMessageComposerLeading].
+  /// [props] contains the properties for the message composer component.
+  const DefaultStreamMessageComposerLeading({super.key, required this.props});
 
+  /// The properties for the message composer component.
   final MessageComposerComponentProps props;
 
   @override

--- a/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer_leading.dart
+++ b/packages/stream_chat_flutter/lib/src/components/message_composer/message_composer_leading.dart
@@ -26,7 +26,6 @@ class StreamMessageComposerLeading extends StatelessWidget {
 /// Default implementation of the leading of the message composer.
 /// Shows the attachment button when the message composer is not in audio recording flow and no command is selected.
 class DefaultStreamMessageComposerLeading extends StatelessWidget {
-  
   /// Creates a new instance of [DefaultStreamMessageComposerLeading].
   /// [props] contains the properties for the message composer component.
   const DefaultStreamMessageComposerLeading({super.key, required this.props});

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_command_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/options/stream_command_picker.dart
@@ -35,7 +35,7 @@ class StreamCommandPicker extends StatelessWidget {
               child: Text(context.translations.instantCommandsLabel, style: textTheme.headlineBold),
             );
           }
-          
+
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 4),
             child: InkWell(


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Small cherry pick of this commit: https://github.com/GetStream/stream-chat-flutter/commit/49bf2a11e2ef8592f5ad29b3d10d3c74a4a9b0d9

This allows the default buttons to be placed on other places.


## Screenshots / Videos

<img width="1022" height="234" alt="image" src="https://github.com/user-attachments/assets/746b6657-303c-46f7-ba93-8b108dd74c13" />
