### PR TITLE
fix(ui): show edited footer always

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_widget.dart
@@ -378,7 +378,12 @@ class DefaultStreamMessage extends StatelessWidget {
 
     final placement = StreamMessagePlacement.of(context);
     final theme = StreamMessageItemTheme.of(context);
-    final defaults = _StreamMessageWidgetDefaults(context, isPinned: message.pinned, state: message.state);
+    final defaults = _StreamMessageWidgetDefaults(
+      context,
+      isPinned: message.pinned,
+      isEdited: message.messageTextUpdatedAt != null,
+      state: message.state,
+    );
 
     final resolve = StreamMessageStyleResolver(placement, [theme, defaults]);
 
@@ -863,10 +868,12 @@ class _StreamMessageWidgetDefaults extends StreamMessageItemThemeData {
   _StreamMessageWidgetDefaults(
     this._context, {
     this.isPinned = false,
+    this.isEdited = false,
     required MessageState state,
   }) : _messageState = state;
 
   final bool isPinned;
+  final bool isEdited;
 
   final BuildContext _context;
   final MessageState _messageState;
@@ -902,10 +909,12 @@ class _StreamMessageWidgetDefaults extends StreamMessageItemThemeData {
   StreamMessageStyleVisibility get headerVisibility => .all(.visible);
 
   @override
-  StreamMessageStyleVisibility get footerVisibility => .resolveWith(
-    (placement) => switch (placement.stackPosition) {
-      .single || .bottom => .visible,
-      _ => .gone,
-    },
-  );
+  StreamMessageStyleVisibility get footerVisibility => isEdited
+      ? .all(.visible)
+      : .resolveWith(
+          (placement) => switch (placement.stackPosition) {
+            .single || .bottom => .visible,
+            _ => .gone,
+          },
+        );
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-450
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
<!-- 
Describe how these code changes fix the issue or how the feature works.
Also try to give instructions how this can be tested.
-->

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| <img width="590" height="1278" alt="edited-before" src="https://github.com/user-attachments/assets/f177279a-db3a-4a27-9a0e-b4cb3962cdc7" /> | <img width="590" height="1278" alt="editer-after" src="https://github.com/user-attachments/assets/bf4b5a80-b155-4ee5-801c-d7e90f5176dc" /> |
