### PR TITLE
Fix(ui): dont start recording without permission

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -77,7 +77,7 @@ command:
       photo_view: ^0.15.0
       provider: ^6.0.5
       rate_limiter: ^1.0.0
-      record: ">=5.2.0 <7.0.0"
+      record: ^6.2.0
       responsive_builder: ^0.7.0
       rxdart: ^0.28.0
       sentry_flutter: ^8.3.0

--- a/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
@@ -61,8 +61,13 @@ class StreamAudioRecorderController extends ValueNotifier<AudioRecorderState> {
     // Only start the recorder if it is currently idle.
     if (value case RecordStateIdle()) {
       // Return if the recorder does not have permission to record audio.
-      final hasPermission = await _recorder.hasPermission();
-      if (!hasPermission) return;
+      final hasPermission = await _recorder.hasPermission(request: false);
+      if (!hasPermission) {
+        /// Request permission to record audio.
+        /// User has to start the recording session again to record audio.
+        await _recorder.hasPermission(request: true);
+        return;
+      }
 
       // Start the recording session.
       final tempPath = await _getOutputFilePath(config.encoder);

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   photo_manager: ^3.8.3
   photo_view: ^0.15.0
   rate_limiter: ^1.0.0
-  record: ">=5.2.0 <7.0.0"
+  record: ^6.2.0
   rxdart: ^0.28.0
   share_plus: ">=11.0.0 <13.0.0"
   shimmer: ^3.0.0

--- a/packages/stream_chat_flutter/test/src/message_input/audio_recorder/audio_recorder_controller_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/audio_recorder/audio_recorder_controller_test.dart
@@ -56,24 +56,38 @@ void main() {
     });
 
     test(
-      'starts recording when permission is granted',
+      'starts recording when permission is already granted',
       () async {
-        when(() => mockRecorder.hasPermission()).thenAnswer((_) async => true);
+        when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => true);
 
         await controller.startRecord();
 
         expect(controller.value, isA<RecordStateRecordingHold>());
         verify(() => mockRecorder.start(config, path: any(named: 'path')));
+        // Should not prompt for permission when already granted.
+        verifyNever(() => mockRecorder.hasPermission(request: true));
       },
     );
 
-    test('does not start recording when permission is denied', () async {
-      when(() => mockRecorder.hasPermission()).thenAnswer((_) async => false);
+    test('does not start recording when permission is not pre-granted', () async {
+      when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => false);
+      when(() => mockRecorder.hasPermission(request: true)).thenAnswer((_) async => false);
 
       await controller.startRecord();
 
       expect(controller.value, isA<RecordStateIdle>());
       verifyNever(() => mockRecorder.start(config, path: any(named: 'path')));
+    });
+
+    test('requests permission when not pre-granted', () async {
+      when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => false);
+      when(() => mockRecorder.hasPermission(request: true)).thenAnswer((_) async => false);
+
+      await controller.startRecord();
+
+      // Should first check without prompting, then prompt the user.
+      verify(() => mockRecorder.hasPermission(request: false)).called(1);
+      verify(() => mockRecorder.hasPermission(request: true)).called(1);
     });
   });
 
@@ -82,7 +96,7 @@ void main() {
     const testPath = '$pathPrefix/audio.m4a';
 
     setUp(() async {
-      when(() => mockRecorder.hasPermission()).thenAnswer((_) async => true);
+      when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => true);
       when(() => mockRecorder.stop()).thenAnswer((_) async => testPath);
       when(() => mockRecorder.start(config, path: any(named: 'path'))).thenAnswer((_) async {});
     });
@@ -117,7 +131,7 @@ void main() {
 
   group('cancelRecord', () {
     setUp(() {
-      when(() => mockRecorder.hasPermission()).thenAnswer((_) async => true);
+      when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => true);
       when(() => mockRecorder.cancel()).thenAnswer((_) async {});
       when(() => mockRecorder.start(config, path: any(named: 'path'))).thenAnswer((_) async {});
     });
@@ -203,7 +217,7 @@ void main() {
 
   group('amplitude changes', () {
     setUp(() {
-      when(() => mockRecorder.hasPermission()).thenAnswer((_) async => true);
+      when(() => mockRecorder.hasPermission(request: false)).thenAnswer((_) async => true);
       when(() => mockRecorder.start(config, path: any(named: 'path'))).thenAnswer((_) async {});
     });
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-417

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This change does not start the recording if permissions have to be granted, because the long press is no longer valid.
Fixes complaint from some customers.

## Screenshots / Videos



https://github.com/user-attachments/assets/4b50b5bf-dd65-4b3b-ae92-c3224aa7ac0a

