### PR TITLE
fix(ui): dont start play after track seek

### DIFF
--- a/packages/stream_chat_flutter/lib/src/attachment/voice_recording_attachment_playlist.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/voice_recording_attachment_playlist.dart
@@ -147,10 +147,6 @@ class _StreamVoiceRecordingAttachmentPlaylistState extends State<StreamVoiceReco
                   if (state.currentIndex != index) return;
                   return _controller.pause();
                 },
-                onTrackSeekEnd: (_) async {
-                  if (state.currentIndex != index) return;
-                  return _controller.play();
-                },
                 onTrackSeekChanged: (progress) async {
                   if (state.currentIndex != index) return;
 
@@ -158,7 +154,7 @@ class _StreamVoiceRecordingAttachmentPlaylistState extends State<StreamVoiceReco
                   final seekPosition = (duration * progress).toInt();
                   final seekDuration = Duration(microseconds: seekPosition);
 
-                  return _controller.seek(seekDuration);
+                  await _controller.seek(seekDuration);
                 },
               );
             },

--- a/packages/stream_chat_flutter/test/src/attachment/voice_recording_attachment_playlist_test.dart
+++ b/packages/stream_chat_flutter/test/src/attachment/voice_recording_attachment_playlist_test.dart
@@ -1,6 +1,7 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/src/audio/audio_playlist_state.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 import '../mocks.dart';
@@ -171,6 +172,63 @@ void main() {
         );
 
         expect(playlist.padding, padding);
+      },
+    );
+
+    testWidgets(
+      'does not play audio when track seek changes',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamVoiceRecordingAttachmentPlaylist(
+              message: MockMessage(),
+              voiceRecordings: [fakeAudioRecording1],
+            ),
+          ),
+        );
+
+        final attachment = tester.widget<StreamVoiceRecordingAttachment>(
+          find.byType(StreamVoiceRecordingAttachment),
+        );
+
+        // onTrackSeekEnd must be null so that play() is never called
+        // when the user lifts their finger after scrubbing.
+        expect(attachment.onTrackSeekEnd, isNull);
+      },
+    );
+
+    testWidgets(
+      'seek callback does not resume playback',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          _wrapWithStreamChatApp(
+            StreamVoiceRecordingAttachmentPlaylist(
+              message: MockMessage(),
+              voiceRecordings: [fakeAudioRecording1],
+            ),
+          ),
+        );
+
+        final attachmentFinder = find.byType(StreamVoiceRecordingAttachment);
+        final attachment = tester.widget<StreamVoiceRecordingAttachment>(
+          attachmentFinder,
+        );
+
+        // Invoking onTrackSeekChanged should not throw and should not change
+        // the track to a playing state (track is idle, no AudioPlayer action
+        // is triggered because there is no active audio source).
+        expect(
+          () => attachment.onTrackSeekChanged?.call(0.5),
+          returnsNormally,
+        );
+
+        await tester.pump();
+
+        // The track should still not be in a playing state.
+        final updatedAttachment = tester.widget<StreamVoiceRecordingAttachment>(
+          attachmentFinder,
+        );
+        expect(updatedAttachment.track.state, isNot(TrackState.playing));
       },
     );
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: fixes FLU-449

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Currently the sdk always starts playing after seek. The native iOS sdk always goes to paused state, also when it was playing. 
