### PR TITLE
fix(ui): fixes for deleted messagees

### DIFF
--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -585,11 +585,22 @@ class Message extends Equatable implements ComparableFieldProvider {
   Message syncWith(Message? other) {
     if (other == null) return this;
 
-    return copyWith(
+    var synced = copyWith(
       localCreatedAt: other.localCreatedAt,
       localUpdatedAt: other.localUpdatedAt,
       localDeletedAt: other.localDeletedAt,
     );
+
+    // The backend does not always enrich this deletedForMe field
+    if (other.deletedForMe == true && synced.deletedForMe != true) {
+      synced = synced.copyWith(
+        deletedForMe: true,
+        type: MessageType.deleted,
+        state: MessageState.deletedForMe,
+      );
+    }
+
+    return synced;
   }
 
   @override

--- a/packages/stream_chat/test/src/core/models/message_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:stream_chat/src/core/models/attachment.dart';
 import 'package:stream_chat/src/core/models/message.dart';
+import 'package:stream_chat/src/core/models/message_state.dart';
 import 'package:stream_chat/src/core/models/moderation.dart';
 import 'package:stream_chat/src/core/models/reaction.dart';
 import 'package:stream_chat/src/core/models/reaction_group.dart';
@@ -534,6 +535,94 @@ void main() {
       expect(message.moderation?.originalText, 'original message text');
       expect(message.isFlagged, isTrue);
     });
+  });
+
+  group('syncWith', () {
+    test('should preserve local timestamps from the other message', () {
+      final localCreatedAt = DateTime(2024, 1, 1);
+      final localUpdatedAt = DateTime(2024, 1, 2);
+      final localDeletedAt = DateTime(2024, 1, 3);
+
+      final serverMessage = Message(id: 'msg-1', text: 'Hello');
+      final localMessage = Message(
+        id: 'msg-1',
+        text: 'Hello',
+        localCreatedAt: localCreatedAt,
+        localUpdatedAt: localUpdatedAt,
+        localDeletedAt: localDeletedAt,
+      );
+
+      final synced = serverMessage.syncWith(localMessage);
+      expect(synced.localCreatedAt, localCreatedAt);
+      expect(synced.localUpdatedAt, localUpdatedAt);
+      expect(synced.localDeletedAt, localDeletedAt);
+    });
+
+    test('should return this if other is null', () {
+      final message = Message(id: 'msg-1', text: 'Hello');
+      final synced = message.syncWith(null);
+      expect(identical(synced, message), isTrue);
+    });
+
+    test(
+      'should preserve deletedForMe from local when server does not have it',
+      () {
+        final serverMessage = Message(
+          id: 'msg-1',
+          text: 'Hello',
+        );
+        final localMessage = Message(
+          id: 'msg-1',
+          text: 'Hello',
+          deletedForMe: true,
+          type: MessageType.deleted,
+          state: MessageState.deletedForMe,
+        );
+
+        final synced = serverMessage.syncWith(localMessage);
+        expect(synced.deletedForMe, isTrue);
+        expect(synced.type, MessageType.deleted);
+        expect(synced.state, MessageState.deletedForMe);
+        expect(synced.isDeleted, isTrue);
+      },
+    );
+
+    test(
+      'should keep server deletedForMe when both server and local have it',
+      () {
+        final serverMessage = Message(
+          id: 'msg-1',
+          text: 'Hello',
+          deletedForMe: true,
+          type: MessageType.deleted,
+          state: MessageState.deletedForMe,
+        );
+        final localMessage = Message(
+          id: 'msg-1',
+          text: 'Hello',
+          deletedForMe: true,
+          type: MessageType.deleted,
+          state: MessageState.deletedForMe,
+        );
+
+        final synced = serverMessage.syncWith(localMessage);
+        expect(synced.deletedForMe, isTrue);
+        expect(synced.type, MessageType.deleted);
+        expect(synced.state, MessageState.deletedForMe);
+      },
+    );
+
+    test(
+      'should not set deletedForMe when neither server nor local have it',
+      () {
+        final serverMessage = Message(id: 'msg-1', text: 'Hello');
+        final localMessage = Message(id: 'msg-1', text: 'Hello');
+
+        final synced = serverMessage.syncWith(localMessage);
+        expect(synced.deletedForMe, isNull);
+        expect(synced.type, isNot(MessageType.deleted));
+      },
+    );
   });
 }
 

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_item.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_item.dart
@@ -669,7 +669,7 @@ class _ChannelLastMessageWithStatusState extends State<_ChannelLastMessageWithSt
 
         return Row(
           children: [
-            deliveryPrefix,
+            if (!latestLastMessage.isDeleted) deliveryPrefix,
             Flexible(
               child: StreamMessagePreviewText(
                 message: latestLastMessage,


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-445

Fixes a blinking of the deleted for me message when the state is not enriched from the backend.
Fixes the own message prefix when previewing deleted message

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
<!-- 
Describe how these code changes fix the issue or how the feature works.
Also try to give instructions how this can be tested.
-->

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| img | img |
