### PR TITLE
fix(ui): hide mark as unread for own messages

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
@@ -148,7 +148,7 @@ class StreamMessageActionsBuilder {
       );
     }
 
-    if (canReceiveReadEvents) {
+    if (canReceiveReadEvents && !isSentByCurrentUser) {
       StreamContextMenuAction<MessageAction> markUnreadAction() {
         return StreamContextMenuAction(
           value: MarkUnread(message: message),

--- a/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
@@ -164,7 +164,7 @@ class StreamMessageActionsBuilder {
       }
       // If the message is in the channel view, only other user messages can be
       // marked unread.
-      else if (!isSentByCurrentUser && (!isThreadMessage || canShowInChannel)) {
+      else if (!isThreadMessage || canShowInChannel) {
         messageActions.add(markUnreadAction());
       }
     }

--- a/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
+++ b/packages/stream_chat_flutter/lib/src/message_action/message_actions_builder.dart
@@ -148,6 +148,7 @@ class StreamMessageActionsBuilder {
       );
     }
 
+    // Mark unread action is only available for other users' messages.
     if (canReceiveReadEvents && !isSentByCurrentUser) {
       StreamContextMenuAction<MessageAction> markUnreadAction() {
         return StreamContextMenuAction(

--- a/packages/stream_chat_flutter/test/src/message_action/message_actions_builder_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_action/message_actions_builder_test.dart
@@ -488,6 +488,37 @@ void main() {
         reason: 'Mark unread unavailable without read events capability',
       );
     });
+
+    testWidgets(
+      'excludes mark unread action for own messages even if parent message',
+      (tester) async {
+        final context = await _getContext(tester);
+
+        final channelWithReadEvents = _getChannelWithCapabilities([
+          ChannelCapability.sendMessage,
+          ChannelCapability.sendReply,
+          ChannelCapability.readEvents,
+        ]);
+
+        final ownParentMessage = createTestMessage(
+          userId: currentUser.id,
+          replyCount: 5,
+        );
+
+        final actions = StreamMessageActionsBuilder.buildActions(
+          context: context,
+          message: ownParentMessage,
+          channel: channelWithReadEvents,
+          currentUser: currentUser,
+        );
+
+        actions.notExpects<MarkUnread>(
+          reason:
+              'Mark unread should not be available for own messages, '
+              'even if it is a parent message',
+        );
+      },
+    );
   });
 
   group('buildBouncedErrorActions', () {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-463

[in-depth Slack thread](https://getstream.slack.com/archives/C0A3JU6C6G3/p1774948953492979)

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
<!-- 
Describe how these code changes fix the issue or how the feature works.
Also try to give instructions how this can be tested.
-->

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| img | img |
