### PR TITLE
fix(repo): release of stream_chat_flutter

### DIFF
--- a/.github/workflows/distribute_internal.yml
+++ b/.github/workflows/distribute_internal.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-      # TODO: Remove feat/design-refresh once merged to master
-      - feat/design-refresh
+      # TODO: Remove once merged to master
+      - v10.0.0
   workflow_dispatch:
     inputs:
       platform:

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -5,9 +5,6 @@ version: 10.0.0-beta.13
 repository: https://github.com/GetStream/stream-chat-flutter
 issue_tracker: https://github.com/GetStream/stream-chat-flutter/issues
 
-# TODO: Remove this once stream_core_flutter is published to pub.dev
-publish_to: none
-
 # Note: The environment configuration and dependency versions are managed by Melos.
 #
 # Do not edit them manually.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
stream_chat_flutter had release:none because it had a git dependency. This prevented it to be released on pub.dev.