### PR TITLE
refactor(ui): attachment upload and gallery improvements

### DIFF
--- a/packages/stream_chat/lib/src/core/models/attachment_file.dart
+++ b/packages/stream_chat/lib/src/core/models/attachment_file.dart
@@ -68,20 +68,34 @@ class AttachmentFile {
   /// Serialize to json
   Map<String, dynamic> toJson() => _$AttachmentFileToJson(this);
 
-  /// Converts this into a [MultipartFile]
+  /// Converts this [AttachmentFile] to a [MultipartFile].
+  ///
+  /// Tries path-based creation first, which is more efficient for large files.
+  /// Falls back to byte-based creation when the path is inaccessible
+  /// (e.g. web platforms, or short-lived iOS photo library exports).
   Future<MultipartFile> toMultipartFile() async {
-    return switch (CurrentPlatform.type) {
-      PlatformType.web => MultipartFile.fromBytes(
-        bytes!,
+    if (path case final path?) {
+      try {
+        return await MultipartFile.fromFile(
+          path,
+          filename: name,
+          contentType: mediaType,
+        );
+      } catch (_) {} // Path may no longer exist
+    }
+
+    if (bytes case final bytes?) {
+      return MultipartFile.fromBytes(
+        bytes,
         filename: name,
         contentType: mediaType,
-      ),
-      _ => await MultipartFile.fromFile(
-        path!,
-        filename: name,
-        contentType: mediaType,
-      ),
-    };
+      );
+    }
+
+    throw StateError(
+      'Cannot create MultipartFile: both path and bytes are unavailable. '
+      'path: $path, bytes: $bytes',
+    );
   }
 
   /// Creates a copy of this [AttachmentFile] but with the given fields

--- a/packages/stream_chat_flutter/lib/src/attachment/gallery_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/gallery_attachment.dart
@@ -186,43 +186,15 @@ class DefaultStreamGalleryAttachment extends StatelessWidget {
       );
     }
 
-    // Both the images are portrait.
+    // Portrait, mixed, or unknown — strict 50/50 width split with cover crop.
     // -----------
     // |    |    |
     // |    |    |
     // |    |    |
-    // -----------
-    if (!isLandscape1 && !isLandscape2) {
-      return FlexGrid(
-        pattern: const [
-          [1, 1],
-        ],
-        spacing: spacing,
-        runSpacing: runSpacing,
-        children: [
-          itemBuilder(context, 0),
-          itemBuilder(context, 1),
-        ],
-      );
-    }
-
-    // Layout on the basis of isLandscape1.
-    // 1. True
-    // -----------
-    // |      |  |
-    // |      |  |
-    // |      |  |
-    // -----------
-    //
-    // 2. False
-    // -----------
-    // |  |      |
-    // |  |      |
-    // |  |      |
     // -----------
     return FlexGrid(
-      pattern: [
-        if (isLandscape1) [2, 1] else [1, 2],
+      pattern: const [
+        [1, 1],
       ],
       spacing: spacing,
       runSpacing: runSpacing,

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_controller.dart
@@ -9,9 +9,6 @@ import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 /// The default maximum size for media attachments.
 const kDefaultMaxAttachmentSize = 100 * 1024 * 1024; // 100MB in Bytes
 
-/// The default maximum number of media attachments.
-const kDefaultMaxAttachmentCount = 10;
-
 /// Controller class for [StreamAttachmentPicker].
 class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerValue> {
   /// Creates a new instance of [StreamAttachmentPickerController].
@@ -20,7 +17,7 @@ class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerVal
     List<Attachment>? initialAttachments,
     Map<String, Object?>? initialExtraData,
     int maxAttachmentSize = kDefaultMaxAttachmentSize,
-    int maxAttachmentCount = kDefaultMaxAttachmentCount,
+    int? maxAttachmentCount,
   }) {
     return StreamAttachmentPickerController._fromValue(
       AttachmentPickerValue(
@@ -36,10 +33,10 @@ class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerVal
   StreamAttachmentPickerController._fromValue(
     this.initialValue, {
     this.maxAttachmentSize = kDefaultMaxAttachmentSize,
-    this.maxAttachmentCount = kDefaultMaxAttachmentCount,
+    this.maxAttachmentCount,
   }) : assert(
-         (initialValue.attachments.length) <= maxAttachmentCount,
-         '''The initial attachments count must be less than or equal to maxAttachmentCount''',
+         maxAttachmentCount == null || initialValue.attachments.length <= maxAttachmentCount,
+         'The initial attachments count must be less than or equal to maxAttachmentCount',
        ),
        super(initialValue);
 
@@ -51,13 +48,13 @@ class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerVal
   /// The max attachment size allowed in bytes.
   final int maxAttachmentSize;
 
-  /// The max attachment count allowed.
-  final int maxAttachmentCount;
+  /// The max attachment count allowed, or `null` for no limit.
+  final int? maxAttachmentCount;
 
   @override
   set value(AttachmentPickerValue newValue) {
-    if (newValue.attachments.length > maxAttachmentCount) {
-      throw AttachmentLimitReachedError(maxCount: maxAttachmentCount);
+    if (maxAttachmentCount case final maxCount? when newValue.attachments.length > maxCount) {
+      throw AttachmentLimitReachedError(maxCount: maxCount);
     }
     super.value = newValue;
   }

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_input.dart
@@ -837,42 +837,46 @@ class StreamMessageInputState extends State<StreamMessageInput>
     }
 
     setState(() {
-      final attachmentLimit = widget.attachmentLimit;
-      _pickerController = attachmentLimit != null
-          ? StreamAttachmentPickerController(
-              initialAttachments: _effectiveController.attachments,
-              initialPoll: _effectiveController.poll,
-              maxAttachmentCount: attachmentLimit,
-              maxAttachmentSize: widget.maxAttachmentSize,
-            )
-          : StreamAttachmentPickerController(
-              initialAttachments: _effectiveController.attachments,
-              initialPoll: _effectiveController.poll,
-              maxAttachmentSize: widget.maxAttachmentSize,
-            );
-      _pickerController!.addListener(_syncPickerToMessage);
-      _effectiveController.addListener(_syncMessageToPicker);
-      _customResultSubscription = _pickerController!.customResults.listen(_onCustomResult);
+      _pickerController = StreamAttachmentPickerController(
+        initialAttachments: _effectiveController.attachments,
+        initialPoll: _effectiveController.poll,
+        maxAttachmentCount: widget.attachmentLimit,
+        maxAttachmentSize: widget.maxAttachmentSize,
+      );
+
+      _startPickerSync();
 
       if (_effectiveFocusNode.hasFocus) {
         _effectiveFocusNode.unfocus();
       }
     });
+
     _pickerAnimationController.forward();
   }
 
   void _hidePicker() {
     if (!_isPickerVisible) return;
+
+    _stopPickerSync();
     _pickerAnimationController.reverse().then((_) {
-      if (mounted) setState(_disposePickerResources);
+      if (mounted) _disposePickerController();
     });
   }
 
-  void _disposePickerResources() {
+  void _startPickerSync() {
+    _pickerController?.addListener(_syncPickerToMessage);
+    _effectiveController.addListener(_syncMessageToPicker);
+    _customResultSubscription = _pickerController?.customResults.listen(_onCustomResult);
+  }
+
+  void _stopPickerSync() {
     _customResultSubscription?.cancel();
     _customResultSubscription = null;
     _pickerController?.removeListener(_syncPickerToMessage);
     _effectiveController.removeListener(_syncMessageToPicker);
+  }
+
+  void _disposePickerController() {
     _pickerController?.dispose();
     _pickerController = null;
   }
@@ -1230,7 +1234,8 @@ class StreamMessageInputState extends State<StreamMessageInput>
   void dispose() {
     _pickerAnimation.dispose();
     _pickerAnimationController.dispose();
-    _disposePickerResources();
+    _stopPickerSync();
+    _disposePickerController();
     _effectiveController
       ..removeListener(_onChangedThrottled)
       ..removeListener(_onChangedDebounced);


### PR DESCRIPTION
## Description of the pull request

- Fix attachment upload failure on iOS: The picker close animation (introduced in #2588) deferred listener cleanup by 200ms, causing _syncMessageToPicker to fire during controller.reset() in sendMessage(). This deleted cached attachment files from disk before the upload could read them, resulting in PathNotFoundException. Fixed by splitting picker lifecycle into _startPickerSync / _stopPickerSync / _disposePickerController and detaching sync listeners immediately in _hidePicker.

- Make toMultipartFile resilient to missing paths: Try path-based MultipartFile creation first, fall back to bytes when the path is inaccessible (e.g. short-lived iOS photo library exports). Throws a descriptive StateError if both are unavailable.

- Simplify gallery layout for two attachments: Use a strict 50/50 width split for mixed-orientation and both-portrait image pairs instead of the previous 2:1 ratio.

- Make maxAttachmentCount optional: A null value means no limit is enforced, removing the kDefaultMaxAttachmentCount constant and the ternary branch in _showPicker.
