### PR TITLE
fix(deps): bump jose minimum to ^0.3.5+1

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -56,7 +56,7 @@ command:
       image_picker: ^1.1.2
       image_size_getter: ^2.3.0
       jiffy: ^6.2.1
-      jose: ^0.3.5
+      jose: ^0.3.5+1
       json_annotation: ^4.9.0
       just_audio: ">=0.9.38 <0.11.0"
       logging: ^1.2.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -56,7 +56,7 @@ command:
       image_picker: ^1.1.2
       image_size_getter: ^2.3.0
       jiffy: ^6.2.1
-      jose: ^0.3.4
+      jose: ^0.3.5
       json_annotation: ^4.9.0
       just_audio: ">=0.9.38 <0.11.0"
       logging: ^1.2.0

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   equatable: ^2.0.5
   freezed_annotation: ">=2.4.1 <4.0.0"
   http_parser: ^4.0.2
-  jose: ^0.3.4
+  jose: ^0.3.5
   json_annotation: ^4.9.0
   logging: ^1.2.0
   meta: ^1.9.1

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   equatable: ^2.0.5
   freezed_annotation: ">=2.4.1 <4.0.0"
   http_parser: ^4.0.2
-  jose: ^0.3.5
+  jose: ^0.3.5+1
   json_annotation: ^4.9.0
   logging: ^1.2.0
   meta: ^1.9.1


### PR DESCRIPTION
# Submit a pull request

Linear: N/A
Github Issue: N/A

## CLA
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

jose 0.3.4 has a JWT signature bypass vulnerability tracked as [CVE-2026-34240](https://nvd.nist.gov/vuln/detail/CVE-2026-34240) / [GHSA-vm9r-h74p-hg97](https://github.com/advisories/GHSA-vm9r-h74p-hg97). The fix is available in jose 0.3.5+.

This PR bumps the lower bound from `^0.3.4` to `^0.3.5` in two files:
- `melos.yaml`
- `packages/stream_chat/pubspec.yaml`

No code changes — the jose API is unchanged. The `^` constraint still allows anything `>=0.3.5 <0.4.0`, so nothing else breaks. Only the vulnerable version is excluded from resolution.

**Testing:** Dependency-only change, no logic affected. Verified `pub get` resolves cleanly.

## Screenshots / Videos

N/A — dependency version bump only, no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency to a newer patch release to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->