### PR TITLE
fix(llc): bump jose floor to 0.3.5+1 for CVE-2026-34240

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -56,7 +56,7 @@ command:
       image_picker: ^1.1.2
       image_size_getter: ^2.3.0
       jiffy: ^6.2.1
-      jose: ^0.3.4
+      jose: ^0.3.5+1
       json_annotation: ^4.9.0
       just_audio: ">=0.9.38 <0.11.0"
       logging: ^1.2.0

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Upcoming Changes
 
+🔒 Security
+
+- Bumped `jose` floor to `0.3.5+1` to address [CVE-2026-34240](https://github.com/advisories/GHSA-vm9r-h74p-hg97)
+  (untrusted JWK header accepted during signature verification). The SDK only uses `JsonWebToken.unverified` and
+  is not directly exploitable, but the floor bump ensures consumers resolve to a patched version.
+
 🐞 Fixed
 
 - Fixed `StreamChatClient.queryDrafts` not forwarding the `filter` argument to the API.

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   equatable: ^2.0.5
   freezed_annotation: ">=2.4.1 <4.0.0"
   http_parser: ^4.0.2
-  jose: ^0.3.4
+  jose: ^0.3.5+1
   json_annotation: ^4.9.0
   logging: ^1.2.0
   meta: ^1.9.1


### PR DESCRIPTION
Fixes: #2589

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (existing test suite — no behavior change)

## Description of the pull request

Bumps the `jose` dependency floor from `^0.3.4` to `^0.3.5+1` in `stream_chat` to address [GHSA-vm9r-h74p-hg97](https://github.com/advisories/GHSA-vm9r-h74p-hg97) (CVE-2026-34240): an untrusted JWK header accepted during signature verification.

The SDK only uses `JsonWebToken.unverified` so it's not directly exploitable — but the floor bump ensures consumers resolve to a patched version of `jose` and SCA scanners (Dependabot, Snyk, etc.) stop flagging the dependency.

### Diff

- `packages/stream_chat/pubspec.yaml`: `jose: ^0.3.4` → `^0.3.5+1`
- `melos.yaml`: same bump in the workspace deps block
- `packages/stream_chat/CHANGELOG.md`: `🔒 Security` entry in Upcoming Changes

### Why a separate PR from #2644

The v10 PR (#2644) bumped `jose` as part of a broader sweep that also raised the SDK floor to Dart `^3.10.0` / Flutter `>=3.38.1` and migrated to `file_picker 11.x`. v9 is on Dart `^3.6.2` / Flutter `>=3.27.4`, so those broader changes can't be ported as-is without bumping the SDK floor — which is out of scope for a v9 security patch. This PR is the surgical port: just `jose`.

The remaining surface from issue #2599 (file_picker / plus-plugin widenings) is intentionally deferred — it would require raising v9's SDK floor.

Closes #2589.

## Test plan

- [x] `flutter analyze` clean in `stream_chat`.
- [x] `flutter test` in `stream_chat` — 1226 tests pass.
- [x] `melos bs` resolves `jose` to `0.3.5+2` (latest patch in the `^0.3.5+1` range).
