### PR TITLE
test(llc): de-flake queryChannels persistence verifies

### DIFF
--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -655,7 +655,13 @@ void main() {
                   clearQueryCache: any(named: 'clearQueryCache')))
               .thenAnswer((_) => Future.value());
 
-          expectLater(
+          // setUp's `connectUser` schedules debounced persistence writes
+          // (1s window) that would otherwise fire during this test's wait
+          // and pollute the call counts. Wait past the debounce, then clear.
+          await delay(1100);
+          clearInteractions(persistence);
+
+          await expectLater(
             client.queryChannels(),
             emitsInOrder([
               // emits persistent channels first
@@ -665,9 +671,10 @@ void main() {
             ]),
           );
 
-          // Hack as `teardown` gets called even
-          // before our stream starts emitting data
-          await delay(1050);
+          // Wait safely past the 1s debounce on persistence writes
+          // (updateChannelState, updateChannelThreads) so all trailing
+          // invocations have fired before we verify counts.
+          await delay(1500);
 
           verify(() => persistence.getChannelStates(
                 filter: any(named: 'filter'),
@@ -738,7 +745,13 @@ void main() {
           when(() => persistence.updateChannelThreads(any(), any()))
               .thenAnswer((_) async => {});
 
-          expectLater(
+          // setUp's `connectUser` schedules debounced persistence writes
+          // (1s window) that would otherwise fire during this test's wait
+          // and pollute the call counts. Wait past the debounce, then clear.
+          await delay(1100);
+          clearInteractions(persistence);
+
+          await expectLater(
             client.queryChannels(),
             emitsInOrder([
               // emits persistent channels
@@ -746,9 +759,10 @@ void main() {
             ]),
           );
 
-          // Hack as `teardown` gets called even
-          // before our stream starts emitting data
-          await delay(1050);
+          // Wait safely past the 1s debounce on persistence writes
+          // (updateChannelState, updateChannelThreads) so all trailing
+          // invocations have fired before we verify counts.
+          await delay(1500);
 
           verify(() => persistence.getChannelStates(
                 filter: any(named: 'filter'),


### PR DESCRIPTION
## Summary

The two `Client with connected user with persistence`.`.queryChannels` tests in `client_test.dart` waited only 50&nbsp;ms past the 1&nbsp;s debounce on `ChannelClientState`'s persistence writes. The margin worked locally but raced the wall clock on the `legacy_version_analyze` CI runner — those tests have failed on every master commit since #2652.

#2652 wrapped `queryChannelsOnline` in `InFlightCache.run`, which adds a couple of microtasks of `Future.sync` + `whenComplete` overhead. Enough to shift the trailing-edge debounced `updateChannelState` past the 1050&nbsp;ms window on slow CI — and to occasionally split a single channel's two rapid debounce triggers into two separate fires, depending on which side of the 1&nbsp;s boundary they land.

## Fix

- `await expectLater(...)` (was fire-and-forget) so stream emissions are observed before the timing wait starts.
- `clearInteractions(persistence)` after waiting past the setUp-induced debounce window, so calls scheduled by `connectUser` don't pollute the test's count.
- Bump the post-emit `delay` from 1050&nbsp;ms to 1500&nbsp;ms — generous margin past the 1&nbsp;s debounce on both `updateChannelState` and `updateChannelThreads`.

## Test plan

- [x] `flutter test packages/stream_chat/test/src/client/client_test.dart` — all 155 tests pass.
- [x] Loop ×5, same. No flakes.
- [x] `melos run analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of persistence-enabled channel query tests by refining debounce timing and clearing mock state between test phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-flutter/pull/2659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->