### PR TITLE
fix(ci): disable SPM at CI level instead of via pubspec flag

### DIFF
--- a/.github/workflows/distribute_external.yml
+++ b/.github/workflows/distribute_external.yml
@@ -114,6 +114,9 @@ jobs:
           channel: stable
           cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
 
+      - name: "Disable Swift Package Manager"
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/distribute_internal.yml
+++ b/.github/workflows/distribute_internal.yml
@@ -124,6 +124,9 @@ jobs:
           channel: stable
           cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
 
+      - name: "Disable Swift Package Manager"
+        run: flutter config --no-enable-swift-package-manager
+
       - name: "Install Tools"
         run: flutter pub global activate melos
 

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -50,8 +50,6 @@ flutter:
   assets:
     - assets/
     - pubspec.lock
-  config:
-    enable-swift-package-manager: false
 
 flutter_icons:
   image_path: "assets/ic_launcher.png"


### PR DESCRIPTION
## Summary
- Drop the `flutter > config > enable-swift-package-manager: false` key added to `sample_app/pubspec.yaml` in #2672. That key was introduced in Flutter ~3.38, so it fails to parse under our legacy floor (Flutter 3.27.4 pinned by `legacy_version_analyze.yml`), breaking master right after #2672 merged with:

  > Unexpected child "config" found under "flutter".

- Instead, run `flutter config --no-enable-swift-package-manager` in the two workflows that actually produce codesigned IPAs (`distribute_internal`, `distribute_external`) — the only place SPM signing errors bite. The PR-validation `build (ios) no_codesign:true` path in `stream_flutter_workflow.yml` doesn't need it (no signing → no SPM signing failures).

Failing master run for context: https://github.com/GetStream/stream-chat-flutter/actions/runs/26162346822

## Test plan
- [x] `legacy_version_analyze` passes on this PR (sample_app's pubspec is parseable on Flutter 3.27.4 again).
- [x] Dispatched `distribute_internal` (ios) on this branch succeeds end-to-end, with the new `Disable Swift Package Manager` step taking effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated iOS build configuration to ensure consistent behavior across development and distribution workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-flutter/pull/2675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->