### PR TITLE
fix(ui): auto-scroll on optimistic local messages

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming Changes
+
+🐞 Fixed
+
+- Fixed `StreamMessageListView` not auto-scrolling to the bottom on the user's own outgoing message
+  until the server confirmed it.
+
 ## 9.24.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -416,7 +416,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
   MessageListController get _messageListController =>
       widget.messageListController ?? _defaultController;
 
-  StreamSubscription? _messageNewListener;
+  StreamSubscription<Message>? _messageNewListener;
   StreamSubscription? _userReadListener;
 
   @override
@@ -444,17 +444,16 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
       debouncedMarkRead.cancel();
       debouncedMarkThreadRead.cancel();
 
-      _messageNewListener?.cancel();
-      _userReadListener?.cancel();
-
       _unreadState.value = _readUnreadSnapshot();
 
-      _messageNewListener =
-          streamChannel!.channel.on(EventType.messageNew).listen((event) {
-        final message = event.message;
-        if (message == null) return;
-        if (message.parentId != widget.parentMessage?.id) return;
+      final state = streamChannel?.channel.state;
+      final newMessageStream = switch (widget.parentMessage?.id) {
+        final parentId? => state?.newThreadMessageStream(parentId),
+        _ => state?.newMessageStream,
+      };
 
+      _messageNewListener?.cancel();
+      _messageNewListener = newMessageStream?.listen((message) {
         // Don't fight a scroll already in motion (drag, fling, or
         // still-running animated scrollTo).
         if (_scrollController?.isScrolling == true) return;
@@ -479,8 +478,8 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
         }
       });
 
-      _userReadListener =
-          streamChannel!.channel.state?.currentUserReadStream.listen((_) {
+      _userReadListener?.cancel();
+      _userReadListener = state?.currentUserReadStream.listen((_) {
         _unreadState.value = _readUnreadSnapshot();
       });
     }

--- a/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/mlv_utils.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat_flutter/scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
@@ -100,4 +101,101 @@ bool isElementAtIndexVisible(
 /// Returns true if the message is the initial message.
 bool isInitialMessage(String id, StreamChannelState? channelState) {
   return channelState!.initialMessageId == id;
+}
+
+/// Stream helpers for observing newly arrived messages on a channel,
+/// either in the main message list or scoped to a thread.
+extension NewMessageStreamX on ChannelClientState {
+  // True when [candidate] represents a newer tail message than
+  // [previous].
+  //
+  // A new arrival requires both a different id *and* a strictly later
+  // [Message.createdAt], so edits, reactions, and reorderings are
+  // ignored.
+  bool _isNewTailArrival(Message candidate, Message? previous) {
+    if (previous == null) return true;
+    return candidate.id != previous.id &&
+        candidate.createdAt.isAfter(previous.createdAt);
+  }
+
+  /// A stream that emits each newly arrived bottom message in
+  /// [messages].
+  ///
+  /// Fires for every upstream that grows the list, including
+  /// server-confirmed `message.new` events, optimistic local sends,
+  /// and any other update that appends to the tail.
+  ///
+  /// A new arrival is detected when the bottom message's id changes
+  /// **and** its [Message.createdAt] is strictly after the previously
+  /// observed tail. Edits, reactions, tail deletions, and pruning are
+  /// therefore ignored.
+  ///
+  /// Gated on [isUpToDate]: while the channel is loaded around a
+  /// historic message the stream stays silent, and the first emission
+  /// after the gate re-opens re-seeds the baseline without yielding.
+  Stream<Message> get newMessageStream async* {
+    var wasUpToDate = isUpToDate;
+    var lastSeen = wasUpToDate ? messages.lastOrNull : null;
+
+    await for (final updated in messagesStream) {
+      if (!isUpToDate) {
+        wasUpToDate = false;
+        lastSeen = null;
+        continue;
+      }
+
+      // Re-seed without yielding: the gate just re-opened, the next
+      // emission is a wholesale window replacement, not an arrival.
+      if (!wasUpToDate) {
+        wasUpToDate = true;
+        lastSeen = updated.lastOrNull;
+        continue;
+      }
+
+      final newLast = updated.lastOrNull;
+      if (newLast == null) {
+        lastSeen = null;
+        continue;
+      }
+
+      final isNewArrival = _isNewTailArrival(newLast, lastSeen);
+      lastSeen = newLast;
+      if (!isNewArrival) continue;
+      yield newLast;
+    }
+  }
+
+  /// A stream that emits each newly arrived reply at the bottom of
+  /// the thread identified by [parentMessageId].
+  ///
+  /// Fires for every upstream that grows the thread, including
+  /// server-confirmed replies, optimistic local sends, and any other
+  /// update that appends to the tail of [threads].
+  ///
+  /// A new arrival is detected when the bottom reply's id changes
+  /// **and** its [Message.createdAt] is strictly after the previously
+  /// observed tail. Edits, reactions, tail deletions, and pruning are
+  /// therefore ignored.
+  ///
+  /// Threads load lazily, so the stream stays silent until [threads]
+  /// carries replies for [parentMessageId]; that first snapshot seeds
+  /// the baseline without yielding.
+  Stream<Message> newThreadMessageStream(String parentMessageId) async* {
+    final threadMessages =
+        threadsStream.mapNotNull((it) => it[parentMessageId]);
+
+    var lastSeen = threads[parentMessageId]?.lastOrNull;
+    await for (final updated in threadMessages) {
+      final newLast = updated.lastOrNull;
+      if (newLast == null) {
+        lastSeen = null;
+        continue;
+      }
+
+      final isNewArrival = _isNewTailArrival(newLast, lastSeen);
+      lastSeen = newLast;
+      if (!isNewArrival) continue;
+      yield newLast;
+    }
+  }
 }

--- a/packages/stream_chat_flutter/test/src/message_list_view/auto_scroll_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/auto_scroll_test.dart
@@ -1,0 +1,351 @@
+// Pins `StreamMessageListView`'s auto-scroll-on-new-message behaviour:
+// the listener subscribes to `channel.state.messagesStream` so it
+// triggers on optimistic local sends too (not just server-confirmed
+// `messageNew` events), and the SPL scroll math + listener timing must
+// not race with anchor preservation.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../../test_utils/data_generator.dart';
+import '../mocks.dart';
+
+void main() {
+  late StreamChatClient client;
+  late Channel channel;
+  late ChannelClientState channelClientState;
+  late ClientState clientState;
+  late OwnUser ownUser;
+
+  late StreamController<bool> isUpToDateController;
+  late StreamController<int> unreadCountController;
+  late StreamController<List<Message>> messagesController;
+
+  setUp(() {
+    client = MockClient();
+    clientState = MockClientState();
+    when(() => client.state).thenAnswer((_) => clientState);
+    ownUser = OwnUser(id: 'ownid');
+    when(() => clientState.currentUser).thenReturn(ownUser);
+    when(() => clientState.currentUserStream)
+        .thenAnswer((_) => Stream.value(ownUser));
+
+    isUpToDateController = StreamController<bool>.broadcast();
+    unreadCountController = StreamController<int>.broadcast();
+    messagesController = StreamController<List<Message>>.broadcast();
+    addTearDown(isUpToDateController.close);
+    addTearDown(unreadCountController.close);
+    addTearDown(messagesController.close);
+
+    channel = MockChannel();
+    channelClientState = MockChannelState();
+    when(() => channel.client).thenReturn(client);
+    when(() => channel.state).thenReturn(channelClientState);
+
+    when(() => channelClientState.threadsStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => channelClientState.isUpToDateStream)
+        .thenAnswer((_) => isUpToDateController.stream);
+    when(() => channelClientState.unreadCountStream)
+        .thenAnswer((_) => unreadCountController.stream);
+    when(() => channelClientState.readStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => channelClientState.read).thenReturn([]);
+    when(() => channelClientState.membersStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => channelClientState.members).thenReturn([]);
+    when(() => channelClientState.currentUserRead).thenReturn(null);
+    when(() => channelClientState.currentUserReadStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => channelClientState.messagesStream)
+        .thenAnswer((_) => messagesController.stream);
+
+    when(() => channel.markRead(messageId: any(named: 'messageId')))
+        .thenAnswer((_) async => EmptyResponse());
+  });
+
+  Future<void> pumpMessageList(
+    WidgetTester tester, {
+    required List<Message> messages,
+    bool isUpToDate = true,
+    int unreadCount = 0,
+  }) async {
+    when(() => channelClientState.isUpToDate).thenReturn(isUpToDate);
+    when(() => channelClientState.unreadCount).thenReturn(unreadCount);
+    when(() => channelClientState.messages).thenReturn(messages);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultAssetBundle(
+            bundle: rootBundle,
+            child: StreamChat(
+              client: client,
+              streamChatThemeData: StreamChatThemeData.light(),
+              child: StreamChannel(
+                channel: channel,
+                child: const StreamMessageListView(),
+              ),
+            ),
+          ),
+        ),
+      );
+      isUpToDateController.add(isUpToDate);
+      unreadCountController.add(unreadCount);
+      messagesController.add(messages);
+      await tester.pumpAndSettle();
+    });
+  }
+
+  // Appends to the end because production state.messages is oldest-first.
+  // Mirrors what `state.updateMessage(...)` does for both optimistic local
+  // sends and server-confirmed `messageNew` events: it updates
+  // `channel.state.messages` and the stream emits the new list.
+  Future<void> deliverNewMessage(
+    WidgetTester tester, {
+    required Message newMessage,
+    required List<Message> existing,
+  }) async {
+    final updated = [...existing, newMessage];
+    when(() => channelClientState.messages).thenReturn(updated);
+    await tester.runAsync(() async {
+      messagesController.add(updated);
+      await tester.pumpAndSettle();
+    });
+  }
+
+  group('auto-scroll on new message', () {
+    testWidgets(
+      'new message from another user while at bottom → renders at the bottom',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(20, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+        expect(find.byType(FloatingActionButton), findsNothing);
+
+        final newMessage = Message(
+          id: 'new-msg-other',
+          text: 'A fresh incoming message',
+          user: other,
+          createdAt: DateTime.now(),
+        );
+        await deliverNewMessage(tester,
+            newMessage: newMessage, existing: messages);
+
+        expect(find.text(newMessage.text!), findsOneWidget);
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'new message from another user while scrolled up → does NOT auto-scroll',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(40, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+
+        await tester.drag(
+            find.byType(StreamMessageListView), const Offset(0, 400));
+        await tester.pumpAndSettle();
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+
+        final newMessage = Message(
+          id: 'new-msg-other-while-scrolled-up',
+          text: 'Should NOT pull the user back',
+          user: other,
+          createdAt: DateTime.now(),
+        );
+        await deliverNewMessage(tester,
+            newMessage: newMessage, existing: messages);
+
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+        expect(find.text(newMessage.text!), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'own message while scrolled up → DOES auto-scroll to bottom',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(40, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+
+        await tester.drag(
+            find.byType(StreamMessageListView), const Offset(0, 400));
+        await tester.pumpAndSettle();
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+
+        final ownMessage = Message(
+          id: 'new-msg-own',
+          text: 'My own outgoing message',
+          user: ownUser,
+          createdAt: DateTime.now(),
+        );
+        await deliverNewMessage(tester,
+            newMessage: ownMessage, existing: messages);
+
+        expect(find.text(ownMessage.text!), findsOneWidget);
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+
+    // The whole point of this listener change: the user's outgoing
+    // message hits state via `state.updateMessage(...)` before the
+    // server confirms (no `messageNew` event yet). Subscribing to the
+    // messages stream covers that path.
+    testWidgets(
+      'optimistic local message → auto-scrolls before server confirmation',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(20, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+        expect(find.byType(FloatingActionButton), findsNothing);
+
+        final ownLocalMessage = Message(
+          id: 'optimistic-local',
+          text: 'Sending…',
+          user: ownUser,
+          localCreatedAt: DateTime.now(),
+          state: MessageState.sending,
+        );
+        await deliverNewMessage(tester,
+            newMessage: ownLocalMessage, existing: messages);
+
+        expect(find.text(ownLocalMessage.text!), findsOneWidget);
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+
+    // Same message id with different createdAt (local→server confirm,
+    // failed→retry, edit, reaction…) must NOT re-trigger auto-scroll.
+    // After the first fire we scroll up, then the server confirms the
+    // same id with a different createdAt — the user must stay scrolled
+    // up.
+    testWidgets(
+      'server confirmation of optimistic message → does NOT scroll twice',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(40, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+
+        final localCreatedAt = DateTime.now();
+        final ownLocalMessage = Message(
+          id: 'optimistic-confirm-probe',
+          text: 'Hello',
+          user: ownUser,
+          localCreatedAt: localCreatedAt,
+          state: MessageState.sending,
+        );
+        await deliverNewMessage(tester,
+            newMessage: ownLocalMessage, existing: messages);
+        expect(find.text(ownLocalMessage.text!), findsOneWidget);
+
+        // User scrolls away from the bottom while the server is round-tripping.
+        await tester.drag(
+            find.byType(StreamMessageListView), const Offset(0, 400));
+        await tester.pumpAndSettle();
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+
+        // Server confirms: same id, different createdAt (server clock).
+        final confirmedMessage = ownLocalMessage.copyWith(
+          createdAt: localCreatedAt.add(const Duration(milliseconds: 250)),
+          state: MessageState.sent,
+        );
+        final updated = [...messages, confirmedMessage];
+        when(() => channelClientState.messages).thenReturn(updated);
+        await tester.runAsync(() async {
+          messagesController.add(updated);
+          await tester.pumpAndSettle();
+        });
+
+        // Listener must NOT fire on the confirmation: user stays scrolled up.
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+      },
+    );
+
+    // Pins listener teardown on dispose: cancelling subscriptions in
+    // dispose() must not throw, and a delivery after dispose must be a
+    // no-op (no exceptions on a stale subscription).
+    testWidgets(
+      'listener is torn down on widget dispose',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(20, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+
+        // Replace with an empty widget tree — disposes the message list.
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        // Pushing after dispose must not throw.
+        final stale = Message(
+          id: 'after-dispose',
+          text: 'late arrival',
+          user: other,
+          createdAt: DateTime.now(),
+        );
+        final updated = [...messages, stale];
+        when(() => channelClientState.messages).thenReturn(updated);
+        await tester.runAsync(() async {
+          messagesController.add(updated);
+          await tester.pumpAndSettle();
+        });
+
+        // No widget to render the new message; just ensure no exception.
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    // Real burst: emit 5 messages back-to-back in the same microtask
+    // cycle, settle once at the end. The previous version awaited
+    // `pumpAndSettle` between each emit, which means no two messages
+    // were ever in flight together — that's not a burst.
+    testWidgets(
+      'rapid burst of messages while at bottom → final layout shows newest',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages =
+            generateConversation(20, users: [other]).reversed.toList();
+
+        await pumpMessageList(tester, messages: messages);
+        expect(find.byType(FloatingActionButton), findsNothing);
+
+        var existing = messages;
+        late Message latest;
+        await tester.runAsync(() async {
+          for (var i = 0; i < 5; i++) {
+            latest = Message(
+              id: 'burst-$i',
+              text: 'Burst message $i',
+              user: other,
+              createdAt: DateTime.now().add(Duration(milliseconds: i)),
+            );
+            existing = [...existing, latest];
+            when(() => channelClientState.messages).thenReturn(existing);
+            messagesController.add(existing);
+          }
+          await tester.pumpAndSettle();
+        });
+
+        expect(find.text(latest.text!), findsOneWidget);
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes [FLU-499](https://linear.app/stream/issue/FLU-499/auto-scroll-on-optimistic-local-messages) (QA item #97 from [Flutter QA — New Design](https://www.notion.so/stream-wiki/Flutter-QA-New-Design-3296a5d7f9f680c4b592c4b677dd5a78)).

## Summary

- `StreamMessageListView`'s auto-scroll-to-bottom listener now subscribes to `channel.state.newMessageStream` (or `newThreadMessageStream(parentId)` in thread mode), exposed via a new `NewMessageStreamX` extension on `ChannelClientState` (in `mlv_utils.dart`, not exported). Diffs `messagesStream` / `threadsStream` for "a new message landed at the bottom" — covering both server-confirmed `message.new` events AND optimistic local sends. The previous `channel.on(EventType.messageNew)` path missed local sends because no WS event fires for them.
- Gated on `isUpToDate`: no auto-scroll while the channel is loaded around a historic message. The `false → true` flip is a wholesale replacement and is also suppressed.
- Detection uses `(newLast.id != lastSeen.id) && newLast.createdAt.isAfter(lastSeen.createdAt)` — handles tail deletion, optimistic→server confirm (same id, no double-scroll), and pruning + append in the same emission.

## Test plan

- [x] `flutter test test/src/message_list_view/auto_scroll_test.dart` — 7/7 pass (new file).
- [x] `flutter test test/src/message_list_view/` — full MLV suite passes.
- [x] `flutter analyze lib/src/message_list_view/` — clean.
- [x] Manual on Pixel 4 (profile mode): send while at bottom, send while scrolled up, receive while at bottom, receive while scrolled up.
- [x] Manual: send → server confirm doesn't double-scroll.
- [ ] Manual: send → fails → tap retry — no jump, message stays in place.
- [ ] Manual: open a thread, send in thread — thread auto-scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-scroll behavior when sending outgoing messages before server confirmation is received, ensuring the message list stays positioned at the latest message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-flutter/pull/2683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->