### PR TITLE
fix(llc)!: prevent external mutation of ClientState collections

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Tightened `Channel.isGroup` from `memberCount != 2` to `memberCount > 2 || !isDistinct`. Two-member non-distinct channels now correctly report as groups, and 1-member distinct channels no longer do. Migrate via `!channel.isOneToOne` or `channel.memberCount != 2`.
 - Tightened `Channel.isDistinct` to require the `!members-` prefix (with trailing dash), matching the backend's `DistinctChannelPrefix` constant. Real server-generated ids always include the dash; only malformed/test ids that previously matched the looser `!members` check are affected.
 - Renamed `SortedListX.merge` (added in 9.24.0) → `SortedListX.mergeSorted` and moved the unsorted/iterable variant to `IterableMergeX.merge`. Callers on `List<T>` that want sorted output should switch to `mergeSorted`; callers on `Iterable<T>` keep using `merge`.
+- Made the collection getters on `ClientState` (`channels`, `users`, `activeLiveLocations`) unmodifiable. Direct mutation used to silently bypass their streams; update them via `addChannels` / `removeChannel`, `updateUser` / `updateUsers`.
+- Marked the cache-mutation surface on `ClientState` (`channels=`, `currentUser=`, `activeLiveLocations=`, `totalUnreadCount=`, `blockedUserIds=`, `updateUsers`, `updateUser`, `addChannels`, `removeChannel`) as `@internal`. App flows (`connectUser`, etc.) are unaffected.
 
 🔒 Security
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -42,6 +42,7 @@ import 'package:stream_chat/src/core/models/reaction.dart';
 import 'package:stream_chat/src/core/models/thread.dart';
 import 'package:stream_chat/src/core/models/user.dart';
 import 'package:stream_chat/src/core/util/event_controller.dart';
+import 'package:stream_chat/src/core/util/extension.dart';
 import 'package:stream_chat/src/core/util/in_flight_cache.dart';
 import 'package:stream_chat/src/core/util/list_extensions.dart';
 import 'package:stream_chat/src/core/util/utils.dart';
@@ -2320,7 +2321,7 @@ class ClientState {
       _client.on(EventType.channelHidden).listen((event) async {
         final eventChannel = event.channel!;
         await _client.chatPersistenceClient?.deleteChannels([eventChannel.cid]);
-        channels.remove(eventChannel.cid)?.dispose();
+        channels[eventChannel.cid]?.dispose();
       }),
     );
   }
@@ -2376,7 +2377,7 @@ class ClientState {
             if (isCurrentUser && event.channel != null) {
               final eventChannel = event.channel!;
               await _client.chatPersistenceClient?.deleteChannels([eventChannel.cid]);
-              channels.remove(eventChannel.cid)?.dispose();
+              channels[eventChannel.cid]?.dispose();
             }
           }),
     );
@@ -2392,7 +2393,7 @@ class ClientState {
           .listen((Event event) async {
             final eventChannel = event.channel!;
             await _client.chatPersistenceClient?.deleteChannels([eventChannel.cid]);
-            channels.remove(eventChannel.cid)?.dispose();
+            channels[eventChannel.cid]?.dispose();
           }),
     );
   }
@@ -2516,22 +2517,25 @@ class ClientState {
 
   /// Sets the user currently interacting with the client
   /// note: this fully overrides the [currentUser]
+  @internal
   set currentUser(OwnUser? user) {
     _computeUnreadCounts(user);
-    _currentUserController.add(user);
+    _currentUserController.safeAdd(user);
   }
 
   /// Update all the [users] with the provided [userList]
+  @internal
   void updateUsers(List<User?> userList) {
     final newUsers = {
       ...users,
       for (final user in userList)
         if (user != null) user.id: user,
     };
-    _usersController.add(newUsers);
+    _usersController.safeAdd(.unmodifiable(newUsers));
   }
 
   /// Update the passed [user] in state
+  @internal
   void updateUser(User? user) => updateUsers([user]);
 
   /// The current user
@@ -2547,20 +2551,17 @@ class ClientState {
   Stream<Map<String, User>> get usersStream => _usersController.stream;
 
   /// The current active live locations shared by the user.
-  List<Location> get activeLiveLocations {
-    return _activeLiveLocationsController.value;
-  }
+  List<Location> get activeLiveLocations => _activeLiveLocationsController.value;
 
   /// The current active live locations shared by the user as a stream.
-  Stream<List<Location>> get activeLiveLocationsStream {
-    return _activeLiveLocationsController.stream;
-  }
+  Stream<List<Location>> get activeLiveLocationsStream => _activeLiveLocationsController.stream;
 
   /// Sets the active live locations.
+  @internal
   set activeLiveLocations(List<Location> locations) {
     // For safe-keeping, we filter out any inactive locations before update.
-    final activeLocations = [...locations.where((it) => it.isActive)];
-    _activeLiveLocationsController.add(activeLocations);
+    final activeLocations = locations.where((it) => it.isActive);
+    _activeLiveLocationsController.safeAdd(.unmodifiable(activeLocations));
   }
 
   /// The current unread channels count
@@ -2587,52 +2588,57 @@ class ClientState {
   /// The current list of channels in memory
   Map<String, Channel> get channels => _channelsController.value;
 
+  @internal
   set channels(Map<String, Channel> newChannels) {
-    _channelsController.add(newChannels);
+    _channelsController.safeAdd(.unmodifiable(newChannels));
   }
 
   /// Adds a list of channels to the current list of cached channels
+  @internal
   void addChannels(Map<String, Channel> channelMap) {
     final newChannels = {...channels, ...channelMap};
     channels = newChannels;
   }
 
   /// Removes the channel from the cached list of [channels]
+  @internal
   void removeChannel(String channelCid) {
-    channels = channels..remove(channelCid);
+    if (!channels.containsKey(channelCid)) return;
+    channels = {...channels}..remove(channelCid);
   }
 
-  @visibleForTesting
+  @internal
   set blockedUserIds(List<String> blockedUserIds) {
     currentUser = currentUser?.copyWith(blockedUserIds: blockedUserIds);
   }
 
   /// Used internally for optimistic update of unread count
+  @internal
   set totalUnreadCount(int unreadCount) {
-    _totalUnreadCountController.add(unreadCount);
+    _totalUnreadCountController.safeAdd(unreadCount);
   }
 
   void _computeUnreadCounts(OwnUser? user) {
     if (user?.totalUnreadCount case final count?) {
-      _totalUnreadCountController.add(count);
+      _totalUnreadCountController.safeAdd(count);
     }
 
     if (user?.unreadChannels case final count?) {
-      _unreadChannelsController.add(count);
+      _unreadChannelsController.safeAdd(count);
     }
 
     if (user?.unreadThreads case final count?) {
-      _unreadThreadsController.add(count);
+      _unreadThreadsController.safeAdd(count);
     }
   }
 
-  final _channelsController = BehaviorSubject<Map<String, Channel>>.seeded({});
+  final _channelsController = BehaviorSubject<Map<String, Channel>>.seeded(.unmodifiable(const {}));
   final _currentUserController = BehaviorSubject<OwnUser?>();
-  final _usersController = BehaviorSubject<Map<String, User>>.seeded({});
+  final _usersController = BehaviorSubject<Map<String, User>>.seeded(.unmodifiable(const {}));
   final _unreadChannelsController = BehaviorSubject<int>.seeded(0);
   final _unreadThreadsController = BehaviorSubject<int>.seeded(0);
   final _totalUnreadCountController = BehaviorSubject<int>.seeded(0);
-  final _activeLiveLocationsController = BehaviorSubject.seeded(<Location>[]);
+  final _activeLiveLocationsController = BehaviorSubject<List<Location>>.seeded(.unmodifiable(const []));
 
   /// Call this method to dispose this object
   void dispose() {
@@ -2645,10 +2651,9 @@ class ClientState {
     _activeLiveLocationsController.close();
     _staleLiveLocationsCleanerTimer?.cancel();
 
-    final channels = [...this.channels.keys];
-    for (final channel in channels) {
-      this.channels.remove(channel)?.dispose();
-    }
     _channelsController.close();
+    for (final channel in channels.values) {
+      channel.dispose(); // Dispose any remaining channels in memory.
+    }
   }
 }

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -43,6 +43,7 @@ import 'package:stream_chat/src/core/models/thread.dart';
 import 'package:stream_chat/src/core/models/user.dart';
 import 'package:stream_chat/src/core/util/event_controller.dart';
 import 'package:stream_chat/src/core/util/extension.dart';
+import 'package:stream_chat/src/core/util/immutable_collection_subjects.dart';
 import 'package:stream_chat/src/core/util/in_flight_cache.dart';
 import 'package:stream_chat/src/core/util/list_extensions.dart';
 import 'package:stream_chat/src/core/util/utils.dart';
@@ -2531,7 +2532,7 @@ class ClientState {
       for (final user in userList)
         if (user != null) user.id: user,
     };
-    _usersController.safeAdd(.unmodifiable(newUsers));
+    _usersController.safeAdd(newUsers);
   }
 
   /// Update the passed [user] in state
@@ -2561,7 +2562,7 @@ class ClientState {
   set activeLiveLocations(List<Location> locations) {
     // For safe-keeping, we filter out any inactive locations before update.
     final activeLocations = locations.where((it) => it.isActive);
-    _activeLiveLocationsController.safeAdd(.unmodifiable(activeLocations));
+    _activeLiveLocationsController.safeAdd(activeLocations.toList());
   }
 
   /// The current unread channels count
@@ -2590,7 +2591,7 @@ class ClientState {
 
   @internal
   set channels(Map<String, Channel> newChannels) {
-    _channelsController.safeAdd(.unmodifiable(newChannels));
+    _channelsController.safeAdd(newChannels);
   }
 
   /// Adds a list of channels to the current list of cached channels
@@ -2632,13 +2633,13 @@ class ClientState {
     }
   }
 
-  final _channelsController = BehaviorSubject<Map<String, Channel>>.seeded(.unmodifiable(const {}));
+  final _channelsController = ImmutableMapBehaviorSubject<String, Channel>.seeded(const {});
   final _currentUserController = BehaviorSubject<OwnUser?>();
-  final _usersController = BehaviorSubject<Map<String, User>>.seeded(.unmodifiable(const {}));
+  final _usersController = ImmutableMapBehaviorSubject<String, User>.seeded(const {});
   final _unreadChannelsController = BehaviorSubject<int>.seeded(0);
   final _unreadThreadsController = BehaviorSubject<int>.seeded(0);
   final _totalUnreadCountController = BehaviorSubject<int>.seeded(0);
-  final _activeLiveLocationsController = BehaviorSubject<List<Location>>.seeded(.unmodifiable(const []));
+  final _activeLiveLocationsController = ImmutableListBehaviorSubject<Location>.seeded(const []);
 
   /// Call this method to dispose this object
   void dispose() {

--- a/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
+++ b/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
@@ -5,6 +5,14 @@ import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/core/util/extension.dart';
 
+/// A map view that throws `UnsupportedError` on any mutating operation.
+@internal
+typedef ImmutableMap<K, V> = UnmodifiableMapView<K, V>;
+
+/// A list view that throws `UnsupportedError` on any mutating operation.
+@internal
+typedef ImmutableList<E> = UnmodifiableListView<E>;
+
 /// A [Stream] of maps that guarantees every emitted value is immutable.
 ///
 /// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
@@ -28,7 +36,7 @@ import 'package:stream_chat/src/core/util/extension.dart';
 ///
 ///  * [ImmutableListBehaviorSubject], the list counterpart.
 @internal
-class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements Sink<Map<K, V>> {
+class ImmutableMapBehaviorSubject<K, V> extends StreamView<ImmutableMap<K, V>> implements Sink<Map<K, V>> {
   /// Creates an [ImmutableMapBehaviorSubject] with no initial value.
   ///
   /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
@@ -37,7 +45,7 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements
     void Function()? onCancel,
     bool sync = false,
   }) => ImmutableMapBehaviorSubject._(
-    BehaviorSubject<UnmodifiableMapView<K, V>>(
+    BehaviorSubject<ImmutableMap<K, V>>(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
@@ -55,8 +63,8 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements
     void Function()? onCancel,
     bool sync = false,
   }) => ImmutableMapBehaviorSubject._(
-    BehaviorSubject<UnmodifiableMapView<K, V>>.seeded(
-      UnmodifiableMapView(seed),
+    BehaviorSubject<ImmutableMap<K, V>>.seeded(
+      ImmutableMap(seed),
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
@@ -65,22 +73,22 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements
 
   ImmutableMapBehaviorSubject._(this._subject) : super(_subject);
 
-  final BehaviorSubject<UnmodifiableMapView<K, V>> _subject;
+  final BehaviorSubject<ImmutableMap<K, V>> _subject;
 
   /// A read-only view of the underlying stream.
-  Stream<Map<K, V>> get stream => _subject.stream;
+  Stream<ImmutableMap<K, V>> get stream => _subject.stream;
 
   /// The most recently emitted value.
-  Map<K, V> get value => _subject.value;
+  ImmutableMap<K, V> get value => _subject.value;
 
   /// Sets and emits the new [value].
   set value(Map<K, V> value) => add(value);
 
   @override
-  void add(Map<K, V> value) => _subject.add(UnmodifiableMapView(value));
+  void add(Map<K, V> value) => _subject.add(ImmutableMap(value));
 
   /// Adds [value] to the subject. Does nothing if the subject is closed.
-  void safeAdd(Map<K, V> value) => _subject.safeAdd(UnmodifiableMapView(value));
+  void safeAdd(Map<K, V> value) => _subject.safeAdd(ImmutableMap(value));
 
   @override
   Future<void> close() => _subject.close();
@@ -109,7 +117,7 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements
 ///
 ///  * [ImmutableMapBehaviorSubject], the map counterpart.
 @internal
-class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Sink<List<E>> {
+class ImmutableListBehaviorSubject<E> extends StreamView<ImmutableList<E>> implements Sink<List<E>> {
   /// Creates an [ImmutableListBehaviorSubject] with no initial value.
   ///
   /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
@@ -118,7 +126,7 @@ class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Sin
     void Function()? onCancel,
     bool sync = false,
   }) => ImmutableListBehaviorSubject._(
-    BehaviorSubject<UnmodifiableListView<E>>(
+    BehaviorSubject<ImmutableList<E>>(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
@@ -136,8 +144,8 @@ class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Sin
     void Function()? onCancel,
     bool sync = false,
   }) => ImmutableListBehaviorSubject._(
-    BehaviorSubject<UnmodifiableListView<E>>.seeded(
-      UnmodifiableListView(seed),
+    BehaviorSubject<ImmutableList<E>>.seeded(
+      ImmutableList(seed),
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
@@ -146,22 +154,22 @@ class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Sin
 
   ImmutableListBehaviorSubject._(this._subject) : super(_subject);
 
-  final BehaviorSubject<UnmodifiableListView<E>> _subject;
+  final BehaviorSubject<ImmutableList<E>> _subject;
 
   /// A read-only view of the underlying stream.
-  Stream<List<E>> get stream => _subject.stream;
+  Stream<ImmutableList<E>> get stream => _subject.stream;
 
   /// The most recently emitted value.
-  List<E> get value => _subject.value;
+  ImmutableList<E> get value => _subject.value;
 
   /// Sets and emits the new [value].
   set value(List<E> value) => add(value);
 
   @override
-  void add(List<E> value) => _subject.add(UnmodifiableListView(value));
+  void add(List<E> value) => _subject.add(ImmutableList(value));
 
   /// Adds [value] to the subject. Does nothing if the subject is closed.
-  void safeAdd(List<E> value) => _subject.safeAdd(UnmodifiableListView(value));
+  void safeAdd(List<E> value) => _subject.safeAdd(ImmutableList(value));
 
   @override
   Future<void> close() => _subject.close();

--- a/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
+++ b/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/core/util/extension.dart';
 
-/// A [ValueStream] of maps that guarantees every emitted value is immutable.
+/// A [Stream] of maps that guarantees every emitted value is immutable.
 ///
 /// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
 /// Callers pass plain maps to [add] / [safeAdd] — the wrap is handled here
@@ -28,8 +28,7 @@ import 'package:stream_chat/src/core/util/extension.dart';
 ///
 ///  * [ImmutableListBehaviorSubject], the list counterpart.
 @internal
-class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>>
-    implements ValueStream<Map<K, V>>, Sink<Map<K, V>> {
+class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>> implements Sink<Map<K, V>> {
   /// Creates an [ImmutableMapBehaviorSubject] with no initial value.
   ///
   /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
@@ -69,34 +68,13 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>>
   final BehaviorSubject<UnmodifiableMapView<K, V>> _subject;
 
   /// A read-only view of the underlying stream.
-  ValueStream<Map<K, V>> get stream => _subject.stream;
+  Stream<Map<K, V>> get stream => _subject.stream;
 
-  @override
+  /// The most recently emitted value.
   Map<K, V> get value => _subject.value;
 
   /// Sets and emits the new [value].
   set value(Map<K, V> value) => add(value);
-
-  @override
-  Map<K, V>? get valueOrNull => _subject.valueOrNull;
-
-  @override
-  bool get hasValue => _subject.hasValue;
-
-  @override
-  Object get error => _subject.error;
-
-  @override
-  Object? get errorOrNull => _subject.errorOrNull;
-
-  @override
-  bool get hasError => _subject.hasError;
-
-  @override
-  StackTrace? get stackTrace => _subject.stackTrace;
-
-  @override
-  StreamNotification<Map<K, V>>? get lastEventOrNull => _subject.lastEventOrNull;
 
   @override
   void add(Map<K, V> value) => _subject.add(UnmodifiableMapView(value));
@@ -108,7 +86,7 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>>
   Future<void> close() => _subject.close();
 }
 
-/// A [ValueStream] of lists that guarantees every emitted value is immutable.
+/// A [Stream] of lists that guarantees every emitted value is immutable.
 ///
 /// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
 /// Callers pass plain lists to [add] / [safeAdd] — the wrap is handled here
@@ -131,7 +109,7 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>>
 ///
 ///  * [ImmutableMapBehaviorSubject], the map counterpart.
 @internal
-class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements ValueStream<List<E>>, Sink<List<E>> {
+class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Sink<List<E>> {
   /// Creates an [ImmutableListBehaviorSubject] with no initial value.
   ///
   /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
@@ -171,34 +149,13 @@ class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements Val
   final BehaviorSubject<UnmodifiableListView<E>> _subject;
 
   /// A read-only view of the underlying stream.
-  ValueStream<List<E>> get stream => _subject.stream;
+  Stream<List<E>> get stream => _subject.stream;
 
-  @override
+  /// The most recently emitted value.
   List<E> get value => _subject.value;
 
   /// Sets and emits the new [value].
   set value(List<E> value) => add(value);
-
-  @override
-  List<E>? get valueOrNull => _subject.valueOrNull;
-
-  @override
-  bool get hasValue => _subject.hasValue;
-
-  @override
-  Object get error => _subject.error;
-
-  @override
-  Object? get errorOrNull => _subject.errorOrNull;
-
-  @override
-  bool get hasError => _subject.hasError;
-
-  @override
-  StackTrace? get stackTrace => _subject.stackTrace;
-
-  @override
-  StreamNotification<List<E>>? get lastEventOrNull => _subject.lastEventOrNull;
 
   @override
   void add(List<E> value) => _subject.add(UnmodifiableListView(value));

--- a/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
+++ b/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
@@ -5,19 +5,18 @@ import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/core/util/extension.dart';
 
-/// A map view that throws `UnsupportedError` on any mutating operation.
-@internal
+/// A map that throws `UnsupportedError` on any mutating operation.
 typedef ImmutableMap<K, V> = UnmodifiableMapView<K, V>;
 
-/// A list view that throws `UnsupportedError` on any mutating operation.
-@internal
+/// A list that throws `UnsupportedError` on any mutating operation.
 typedef ImmutableList<E> = UnmodifiableListView<E>;
 
 /// A [Stream] of maps that guarantees every emitted value is immutable.
 ///
-/// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
-/// Callers pass plain maps to [add] / [safeAdd] — the wrap is handled here
-/// so it cannot be forgotten or bypassed.
+/// The stream is a broadcast stream — multiple subscribers can listen at
+/// once. Subscribers receive snapshots that throw `UnsupportedError` on
+/// mutation. Callers pass plain maps to [add] / [safeAdd] — wrapping is
+/// automatic and unbypassable.
 ///
 /// ```dart
 /// final controller = ImmutableMapBehaviorSubject<String, Channel>.seeded(const {});
@@ -37,9 +36,10 @@ typedef ImmutableList<E> = UnmodifiableListView<E>;
 ///  * [ImmutableListBehaviorSubject], the list counterpart.
 @internal
 class ImmutableMapBehaviorSubject<K, V> extends StreamView<ImmutableMap<K, V>> implements Sink<Map<K, V>> {
-  /// Creates an [ImmutableMapBehaviorSubject] with no initial value.
+  /// Creates a subject with no initial value.
   ///
-  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  /// [onListen], [onCancel] and [sync] follow [StreamController.broadcast]
+  /// semantics.
   factory ImmutableMapBehaviorSubject({
     void Function()? onListen,
     void Function()? onCancel,
@@ -52,11 +52,12 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<ImmutableMap<K, V>> i
     ),
   );
 
-  /// Creates the subject with [seed] as the initial value.
+  /// Creates a subject with [seed] as the initial value.
   ///
   /// Subscribers connecting before the first [add] also receive [seed].
   ///
-  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  /// [onListen], [onCancel] and [sync] follow [StreamController.broadcast]
+  /// semantics.
   factory ImmutableMapBehaviorSubject.seeded(
     Map<K, V> seed, {
     void Function()? onListen,
@@ -96,9 +97,10 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<ImmutableMap<K, V>> i
 
 /// A [Stream] of lists that guarantees every emitted value is immutable.
 ///
-/// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
-/// Callers pass plain lists to [add] / [safeAdd] — the wrap is handled here
-/// so it cannot be forgotten or bypassed.
+/// The stream is a broadcast stream — multiple subscribers can listen at
+/// once. Subscribers receive snapshots that throw `UnsupportedError` on
+/// mutation. Callers pass plain lists to [add] / [safeAdd] — wrapping is
+/// automatic and unbypassable.
 ///
 /// ```dart
 /// final controller = ImmutableListBehaviorSubject<Location>.seeded(const []);
@@ -118,9 +120,10 @@ class ImmutableMapBehaviorSubject<K, V> extends StreamView<ImmutableMap<K, V>> i
 ///  * [ImmutableMapBehaviorSubject], the map counterpart.
 @internal
 class ImmutableListBehaviorSubject<E> extends StreamView<ImmutableList<E>> implements Sink<List<E>> {
-  /// Creates an [ImmutableListBehaviorSubject] with no initial value.
+  /// Creates a subject with no initial value.
   ///
-  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  /// [onListen], [onCancel] and [sync] follow [StreamController.broadcast]
+  /// semantics.
   factory ImmutableListBehaviorSubject({
     void Function()? onListen,
     void Function()? onCancel,
@@ -133,11 +136,12 @@ class ImmutableListBehaviorSubject<E> extends StreamView<ImmutableList<E>> imple
     ),
   );
 
-  /// Creates the subject with [seed] as the initial value.
+  /// Creates a subject with [seed] as the initial value.
   ///
   /// Subscribers connecting before the first [add] also receive [seed].
   ///
-  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  /// [onListen], [onCancel] and [sync] follow [StreamController.broadcast]
+  /// semantics.
   factory ImmutableListBehaviorSubject.seeded(
     List<E> seed, {
     void Function()? onListen,

--- a/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
+++ b/packages/stream_chat/lib/src/core/util/immutable_collection_subjects.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:meta/meta.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:stream_chat/src/core/util/extension.dart';
+
+/// A [ValueStream] of maps that guarantees every emitted value is immutable.
+///
+/// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
+/// Callers pass plain maps to [add] / [safeAdd] — the wrap is handled here
+/// so it cannot be forgotten or bypassed.
+///
+/// ```dart
+/// final controller = ImmutableMapBehaviorSubject<String, Channel>.seeded(const {});
+///
+/// controller.listen(print);
+/// controller.safeAdd({'general': generalChannel});
+///
+/// // Reads succeed.
+/// final cached = controller.value['general'];
+///
+/// // Writes throw `UnsupportedError`.
+/// controller.value['general'] = otherChannel;
+/// ```
+///
+/// See also:
+///
+///  * [ImmutableListBehaviorSubject], the list counterpart.
+@internal
+class ImmutableMapBehaviorSubject<K, V> extends StreamView<Map<K, V>>
+    implements ValueStream<Map<K, V>>, Sink<Map<K, V>> {
+  /// Creates an [ImmutableMapBehaviorSubject] with no initial value.
+  ///
+  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  factory ImmutableMapBehaviorSubject({
+    void Function()? onListen,
+    void Function()? onCancel,
+    bool sync = false,
+  }) => ImmutableMapBehaviorSubject._(
+    BehaviorSubject<UnmodifiableMapView<K, V>>(
+      onListen: onListen,
+      onCancel: onCancel,
+      sync: sync,
+    ),
+  );
+
+  /// Creates the subject with [seed] as the initial value.
+  ///
+  /// Subscribers connecting before the first [add] also receive [seed].
+  ///
+  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  factory ImmutableMapBehaviorSubject.seeded(
+    Map<K, V> seed, {
+    void Function()? onListen,
+    void Function()? onCancel,
+    bool sync = false,
+  }) => ImmutableMapBehaviorSubject._(
+    BehaviorSubject<UnmodifiableMapView<K, V>>.seeded(
+      UnmodifiableMapView(seed),
+      onListen: onListen,
+      onCancel: onCancel,
+      sync: sync,
+    ),
+  );
+
+  ImmutableMapBehaviorSubject._(this._subject) : super(_subject);
+
+  final BehaviorSubject<UnmodifiableMapView<K, V>> _subject;
+
+  /// A read-only view of the underlying stream.
+  ValueStream<Map<K, V>> get stream => _subject.stream;
+
+  @override
+  Map<K, V> get value => _subject.value;
+
+  /// Sets and emits the new [value].
+  set value(Map<K, V> value) => add(value);
+
+  @override
+  Map<K, V>? get valueOrNull => _subject.valueOrNull;
+
+  @override
+  bool get hasValue => _subject.hasValue;
+
+  @override
+  Object get error => _subject.error;
+
+  @override
+  Object? get errorOrNull => _subject.errorOrNull;
+
+  @override
+  bool get hasError => _subject.hasError;
+
+  @override
+  StackTrace? get stackTrace => _subject.stackTrace;
+
+  @override
+  StreamNotification<Map<K, V>>? get lastEventOrNull => _subject.lastEventOrNull;
+
+  @override
+  void add(Map<K, V> value) => _subject.add(UnmodifiableMapView(value));
+
+  /// Adds [value] to the subject. Does nothing if the subject is closed.
+  void safeAdd(Map<K, V> value) => _subject.safeAdd(UnmodifiableMapView(value));
+
+  @override
+  Future<void> close() => _subject.close();
+}
+
+/// A [ValueStream] of lists that guarantees every emitted value is immutable.
+///
+/// Subscribers receive snapshots that throw `UnsupportedError` on mutation.
+/// Callers pass plain lists to [add] / [safeAdd] — the wrap is handled here
+/// so it cannot be forgotten or bypassed.
+///
+/// ```dart
+/// final controller = ImmutableListBehaviorSubject<Location>.seeded(const []);
+///
+/// controller.listen(print);
+/// controller.safeAdd([userLocation]);
+///
+/// // Reads succeed.
+/// final first = controller.value.first;
+///
+/// // Writes throw `UnsupportedError`.
+/// controller.value.add(otherLocation);
+/// ```
+///
+/// See also:
+///
+///  * [ImmutableMapBehaviorSubject], the map counterpart.
+@internal
+class ImmutableListBehaviorSubject<E> extends StreamView<List<E>> implements ValueStream<List<E>>, Sink<List<E>> {
+  /// Creates an [ImmutableListBehaviorSubject] with no initial value.
+  ///
+  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  factory ImmutableListBehaviorSubject({
+    void Function()? onListen,
+    void Function()? onCancel,
+    bool sync = false,
+  }) => ImmutableListBehaviorSubject._(
+    BehaviorSubject<UnmodifiableListView<E>>(
+      onListen: onListen,
+      onCancel: onCancel,
+      sync: sync,
+    ),
+  );
+
+  /// Creates the subject with [seed] as the initial value.
+  ///
+  /// Subscribers connecting before the first [add] also receive [seed].
+  ///
+  /// See [StreamController.broadcast] for [onListen], [onCancel] and [sync].
+  factory ImmutableListBehaviorSubject.seeded(
+    List<E> seed, {
+    void Function()? onListen,
+    void Function()? onCancel,
+    bool sync = false,
+  }) => ImmutableListBehaviorSubject._(
+    BehaviorSubject<UnmodifiableListView<E>>.seeded(
+      UnmodifiableListView(seed),
+      onListen: onListen,
+      onCancel: onCancel,
+      sync: sync,
+    ),
+  );
+
+  ImmutableListBehaviorSubject._(this._subject) : super(_subject);
+
+  final BehaviorSubject<UnmodifiableListView<E>> _subject;
+
+  /// A read-only view of the underlying stream.
+  ValueStream<List<E>> get stream => _subject.stream;
+
+  @override
+  List<E> get value => _subject.value;
+
+  /// Sets and emits the new [value].
+  set value(List<E> value) => add(value);
+
+  @override
+  List<E>? get valueOrNull => _subject.valueOrNull;
+
+  @override
+  bool get hasValue => _subject.hasValue;
+
+  @override
+  Object get error => _subject.error;
+
+  @override
+  Object? get errorOrNull => _subject.errorOrNull;
+
+  @override
+  bool get hasError => _subject.hasError;
+
+  @override
+  StackTrace? get stackTrace => _subject.stackTrace;
+
+  @override
+  StreamNotification<List<E>>? get lastEventOrNull => _subject.lastEventOrNull;
+
+  @override
+  void add(List<E> value) => _subject.add(UnmodifiableListView(value));
+
+  /// Adds [value] to the subject. Does nothing if the subject is closed.
+  void safeAdd(List<E> value) => _subject.safeAdd(UnmodifiableListView(value));
+
+  @override
+  Future<void> close() => _subject.close();
+}

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -4870,4 +4870,122 @@ void main() {
       );
     });
   });
+
+  group('ClientState mutation guards', () {
+    const apiKey = 'test-api-key';
+    late final api = FakeChatApi();
+    late StreamChatClient client;
+
+    setUp(() {
+      final ws = FakeWebSocket();
+      client = StreamChatClient(apiKey, ws: ws, chatApi: api);
+    });
+
+    tearDown(() {
+      client.dispose();
+    });
+
+    test('`state.channels` returns an unmodifiable view', () {
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+
+      expect(client.state.channels, hasLength(1));
+      expect(() => client.state.channels.remove('messaging:c1'), throwsUnsupportedError);
+      expect(() => client.state.channels.clear(), throwsUnsupportedError);
+      expect(() => client.state.channels['messaging:c2'] = channel, throwsUnsupportedError);
+    });
+
+    test('`state.users` returns an unmodifiable view', () {
+      client.state.updateUser(User(id: 'u1'));
+
+      expect(client.state.users.containsKey('u1'), isTrue);
+      expect(() => client.state.users.remove('u1'), throwsUnsupportedError);
+      expect(() => client.state.users.clear(), throwsUnsupportedError);
+    });
+
+    test('`state.activeLiveLocations` returns an unmodifiable view', () {
+      expect(() => client.state.activeLiveLocations.clear(), throwsUnsupportedError);
+    });
+
+    test('`removeChannel` emits a fresh map so distinct subscribers see the change', () async {
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+
+      final received = <Map<String, Channel>>[];
+      // Skip the BehaviorSubject's replay of the current value to new subscribers.
+      final sub = client.state.channelsStream.distinct().skip(1).listen(received.add);
+
+      client.state.removeChannel('messaging:c1');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single, isEmpty);
+
+      await sub.cancel();
+    });
+
+    test('initial seeded values are unmodifiable (before any write)', () {
+      // Fresh client, no mutations yet — subscribers connecting at this point
+      // still see unmodifiable seeds.
+      expect(() => client.state.channels.clear(), throwsUnsupportedError);
+      expect(() => client.state.users.clear(), throwsUnsupportedError);
+      expect(() => client.state.activeLiveLocations.clear(), throwsUnsupportedError);
+    });
+
+    test('`channelsStream` emits unmodifiable maps', () async {
+      final received = <Map<String, Channel>>[];
+      final sub = client.state.channelsStream.listen(received.add);
+
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+      await Future<void>.delayed(Duration.zero);
+
+      // Both the initial seed and the post-write emission must be unmodifiable.
+      expect(received, hasLength(greaterThanOrEqualTo(2)));
+      for (final emitted in received) {
+        expect(emitted.clear, throwsUnsupportedError);
+      }
+
+      await sub.cancel();
+    });
+
+    test('`usersStream` emits unmodifiable maps', () async {
+      final received = <Map<String, User>>[];
+      final sub = client.state.usersStream.listen(received.add);
+
+      client.state.updateUser(User(id: 'u1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(greaterThanOrEqualTo(2)));
+      for (final emitted in received) {
+        expect(emitted.clear, throwsUnsupportedError);
+      }
+
+      await sub.cancel();
+    });
+
+    test('`activeLiveLocationsStream` emits unmodifiable lists', () async {
+      final received = <List<Location>>[];
+      final sub = client.state.activeLiveLocationsStream.listen(received.add);
+
+      client.state.activeLiveLocations = const [];
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, isNotEmpty);
+      for (final emitted in received) {
+        expect(emitted.clear, throwsUnsupportedError);
+      }
+
+      await sub.cancel();
+    });
+  });
 }

--- a/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
+++ b/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:stream_chat/src/core/util/immutable_collection_subjects.dart';
 import 'package:test/test.dart';
@@ -20,7 +19,7 @@ void main() {
       controller.add({'a': 1});
 
       expect(controller.value, equals({'a': 1}));
-      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(controller.value, isA<ImmutableMap<String, int>>());
     });
 
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
@@ -28,7 +27,7 @@ void main() {
       addTearDown(controller.close);
 
       expect(controller.value, equals({'a': 1}));
-      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(controller.value, isA<ImmutableMap<String, int>>());
       expect(() => controller.value['b'] = 2, throwsUnsupportedError);
     });
 
@@ -39,7 +38,7 @@ void main() {
       controller.add({'a': 1});
 
       expect(controller.value, equals({'a': 1}));
-      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(controller.value, isA<ImmutableMap<String, int>>());
       expect(() => controller.value['b'] = 2, throwsUnsupportedError);
     });
 
@@ -57,7 +56,7 @@ void main() {
       controller.safeAdd({'a': 1});
 
       expect(controller.value, equals({'a': 1}));
-      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(controller.value, isA<ImmutableMap<String, int>>());
     });
 
     test('`safeAdd` is a no-op after close', () async {
@@ -83,7 +82,7 @@ void main() {
 
       expect(received, hasLength(3));
       for (final map in received) {
-        expect(map, isA<UnmodifiableMapView<String, int>>());
+        expect(map, isA<ImmutableMap<String, int>>());
         expect(() => map['x'] = 9, throwsUnsupportedError);
       }
     });
@@ -112,7 +111,7 @@ void main() {
       controller.add([1, 2, 3]);
 
       expect(controller.value, equals([1, 2, 3]));
-      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(controller.value, isA<ImmutableList<int>>());
     });
 
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
@@ -120,7 +119,7 @@ void main() {
       addTearDown(controller.close);
 
       expect(controller.value, equals([1, 2, 3]));
-      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(controller.value, isA<ImmutableList<int>>());
       expect(() => controller.value.add(4), throwsUnsupportedError);
     });
 
@@ -131,7 +130,7 @@ void main() {
       controller.add([1, 2, 3]);
 
       expect(controller.value, equals([1, 2, 3]));
-      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(controller.value, isA<ImmutableList<int>>());
       expect(() => controller.value.add(4), throwsUnsupportedError);
     });
 
@@ -149,7 +148,7 @@ void main() {
       controller.safeAdd([1, 2, 3]);
 
       expect(controller.value, equals([1, 2, 3]));
-      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(controller.value, isA<ImmutableList<int>>());
     });
 
     test('`safeAdd` is a no-op after close', () async {
@@ -175,7 +174,7 @@ void main() {
 
       expect(received, hasLength(3));
       for (final list in received) {
-        expect(list, isA<UnmodifiableListView<int>>());
+        expect(list, isA<ImmutableList<int>>());
         expect(() => list.add(99), throwsUnsupportedError);
       }
     });

--- a/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
+++ b/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
@@ -6,6 +6,23 @@ import 'package:test/test.dart';
 
 void main() {
   group('ImmutableMapBehaviorSubject', () {
+    test('non-seeded constructor throws when reading `value` before any add', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>();
+      addTearDown(controller.close);
+
+      expect(() => controller.value, throwsA(isA<Error>()));
+    });
+
+    test('non-seeded constructor surfaces the first add as `value`', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>();
+      addTearDown(controller.close);
+
+      controller.add({'a': 1});
+
+      expect(controller.value, equals({'a': 1}));
+      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+    });
+
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
       final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
       addTearDown(controller.close);
@@ -81,6 +98,23 @@ void main() {
   });
 
   group('ImmutableListBehaviorSubject', () {
+    test('non-seeded constructor throws when reading `value` before any add', () {
+      final controller = ImmutableListBehaviorSubject<int>();
+      addTearDown(controller.close);
+
+      expect(() => controller.value, throwsA(isA<Error>()));
+    });
+
+    test('non-seeded constructor surfaces the first add as `value`', () {
+      final controller = ImmutableListBehaviorSubject<int>();
+      addTearDown(controller.close);
+
+      controller.add([1, 2, 3]);
+
+      expect(controller.value, equals([1, 2, 3]));
+      expect(controller.value, isA<UnmodifiableListView<int>>());
+    });
+
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
       final controller = ImmutableListBehaviorSubject<int>.seeded(const [1, 2, 3]);
       addTearDown(controller.close);

--- a/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
+++ b/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
@@ -1,32 +1,22 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:rxdart/rxdart.dart';
 import 'package:stream_chat/src/core/util/immutable_collection_subjects.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('ImmutableMapBehaviorSubject', () {
-    test('non-seeded constructor has no initial value', () {
-      final controller = ImmutableMapBehaviorSubject<String, int>();
-      addTearDown(controller.close);
-
-      expect(controller.hasValue, isFalse);
-      expect(controller.valueOrNull, isNull);
-    });
-
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
       final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
       addTearDown(controller.close);
 
-      expect(controller.hasValue, isTrue);
       expect(controller.value, equals({'a': 1}));
       expect(controller.value, isA<UnmodifiableMapView<String, int>>());
       expect(() => controller.value['b'] = 2, throwsUnsupportedError);
     });
 
     test('`add` wraps plain maps as unmodifiable', () {
-      final controller = ImmutableMapBehaviorSubject<String, int>();
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({});
       addTearDown(controller.close);
 
       controller.add({'a': 1});
@@ -44,7 +34,7 @@ void main() {
     });
 
     test('`safeAdd` wraps plain maps as unmodifiable', () {
-      final controller = ImmutableMapBehaviorSubject<String, int>();
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({});
       addTearDown(controller.close);
 
       controller.safeAdd({'a': 1});
@@ -81,37 +71,27 @@ void main() {
       }
     });
 
-    test('IS-A Stream / ValueStream / Sink', () {
+    test('IS-A Stream / Sink', () {
       final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
       addTearDown(controller.close);
 
       expect(controller, isA<Stream<Map<String, int>>>());
-      expect(controller, isA<ValueStream<Map<String, int>>>());
       expect(controller, isA<Sink<Map<String, int>>>());
     });
   });
 
   group('ImmutableListBehaviorSubject', () {
-    test('non-seeded constructor has no initial value', () {
-      final controller = ImmutableListBehaviorSubject<int>();
-      addTearDown(controller.close);
-
-      expect(controller.hasValue, isFalse);
-      expect(controller.valueOrNull, isNull);
-    });
-
     test('seeded constructor exposes the seed wrapped as unmodifiable', () {
       final controller = ImmutableListBehaviorSubject<int>.seeded(const [1, 2, 3]);
       addTearDown(controller.close);
 
-      expect(controller.hasValue, isTrue);
       expect(controller.value, equals([1, 2, 3]));
       expect(controller.value, isA<UnmodifiableListView<int>>());
       expect(() => controller.value.add(4), throwsUnsupportedError);
     });
 
     test('`add` wraps plain lists as unmodifiable', () {
-      final controller = ImmutableListBehaviorSubject<int>();
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const []);
       addTearDown(controller.close);
 
       controller.add([1, 2, 3]);
@@ -129,7 +109,7 @@ void main() {
     });
 
     test('`safeAdd` wraps plain lists as unmodifiable', () {
-      final controller = ImmutableListBehaviorSubject<int>();
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const []);
       addTearDown(controller.close);
 
       controller.safeAdd([1, 2, 3]);
@@ -166,12 +146,11 @@ void main() {
       }
     });
 
-    test('IS-A Stream / ValueStream / Sink', () {
+    test('IS-A Stream / Sink', () {
       final controller = ImmutableListBehaviorSubject<int>.seeded(const [1]);
       addTearDown(controller.close);
 
       expect(controller, isA<Stream<List<int>>>());
-      expect(controller, isA<ValueStream<List<int>>>());
       expect(controller, isA<Sink<List<int>>>());
     });
   });

--- a/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
+++ b/packages/stream_chat/test/src/core/util/immutable_collection_subjects_test.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:stream_chat/src/core/util/immutable_collection_subjects.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ImmutableMapBehaviorSubject', () {
+    test('non-seeded constructor has no initial value', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>();
+      addTearDown(controller.close);
+
+      expect(controller.hasValue, isFalse);
+      expect(controller.valueOrNull, isNull);
+    });
+
+    test('seeded constructor exposes the seed wrapped as unmodifiable', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
+      addTearDown(controller.close);
+
+      expect(controller.hasValue, isTrue);
+      expect(controller.value, equals({'a': 1}));
+      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(() => controller.value['b'] = 2, throwsUnsupportedError);
+    });
+
+    test('`add` wraps plain maps as unmodifiable', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>();
+      addTearDown(controller.close);
+
+      controller.add({'a': 1});
+
+      expect(controller.value, equals({'a': 1}));
+      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+      expect(() => controller.value['b'] = 2, throwsUnsupportedError);
+    });
+
+    test('`add` throws after close', () async {
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
+      await controller.close();
+
+      expect(() => controller.add({'b': 2}), throwsStateError);
+    });
+
+    test('`safeAdd` wraps plain maps as unmodifiable', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>();
+      addTearDown(controller.close);
+
+      controller.safeAdd({'a': 1});
+
+      expect(controller.value, equals({'a': 1}));
+      expect(controller.value, isA<UnmodifiableMapView<String, int>>());
+    });
+
+    test('`safeAdd` is a no-op after close', () async {
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
+      await controller.close();
+
+      // Should not throw.
+      controller.safeAdd({'b': 2});
+    });
+
+    test('subscribers receive unmodifiable maps', () async {
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'seed': 0});
+      addTearDown(controller.close);
+
+      final received = <Map<String, int>>[];
+      final sub = controller.listen(received.add);
+      addTearDown(sub.cancel);
+
+      controller
+        ..add({'a': 1})
+        ..safeAdd({'b': 2});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(3));
+      for (final map in received) {
+        expect(map, isA<UnmodifiableMapView<String, int>>());
+        expect(() => map['x'] = 9, throwsUnsupportedError);
+      }
+    });
+
+    test('IS-A Stream / ValueStream / Sink', () {
+      final controller = ImmutableMapBehaviorSubject<String, int>.seeded({'a': 1});
+      addTearDown(controller.close);
+
+      expect(controller, isA<Stream<Map<String, int>>>());
+      expect(controller, isA<ValueStream<Map<String, int>>>());
+      expect(controller, isA<Sink<Map<String, int>>>());
+    });
+  });
+
+  group('ImmutableListBehaviorSubject', () {
+    test('non-seeded constructor has no initial value', () {
+      final controller = ImmutableListBehaviorSubject<int>();
+      addTearDown(controller.close);
+
+      expect(controller.hasValue, isFalse);
+      expect(controller.valueOrNull, isNull);
+    });
+
+    test('seeded constructor exposes the seed wrapped as unmodifiable', () {
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const [1, 2, 3]);
+      addTearDown(controller.close);
+
+      expect(controller.hasValue, isTrue);
+      expect(controller.value, equals([1, 2, 3]));
+      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(() => controller.value.add(4), throwsUnsupportedError);
+    });
+
+    test('`add` wraps plain lists as unmodifiable', () {
+      final controller = ImmutableListBehaviorSubject<int>();
+      addTearDown(controller.close);
+
+      controller.add([1, 2, 3]);
+
+      expect(controller.value, equals([1, 2, 3]));
+      expect(controller.value, isA<UnmodifiableListView<int>>());
+      expect(() => controller.value.add(4), throwsUnsupportedError);
+    });
+
+    test('`add` throws after close', () async {
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const [1]);
+      await controller.close();
+
+      expect(() => controller.add([2]), throwsStateError);
+    });
+
+    test('`safeAdd` wraps plain lists as unmodifiable', () {
+      final controller = ImmutableListBehaviorSubject<int>();
+      addTearDown(controller.close);
+
+      controller.safeAdd([1, 2, 3]);
+
+      expect(controller.value, equals([1, 2, 3]));
+      expect(controller.value, isA<UnmodifiableListView<int>>());
+    });
+
+    test('`safeAdd` is a no-op after close', () async {
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const [1]);
+      await controller.close();
+
+      // Should not throw.
+      controller.safeAdd([2]);
+    });
+
+    test('subscribers receive unmodifiable lists', () async {
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const [0]);
+      addTearDown(controller.close);
+
+      final received = <List<int>>[];
+      final sub = controller.listen(received.add);
+      addTearDown(sub.cancel);
+
+      controller
+        ..add([1])
+        ..safeAdd([1, 2]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(3));
+      for (final list in received) {
+        expect(list, isA<UnmodifiableListView<int>>());
+        expect(() => list.add(99), throwsUnsupportedError);
+      }
+    });
+
+    test('IS-A Stream / ValueStream / Sink', () {
+      final controller = ImmutableListBehaviorSubject<int>.seeded(const [1]);
+      addTearDown(controller.close);
+
+      expect(controller, isA<Stream<List<int>>>());
+      expect(controller, isA<ValueStream<List<int>>>());
+      expect(controller, isA<Sink<List<int>>>());
+    });
+  });
+}


### PR DESCRIPTION
Closes [FLU-500](https://linear.app/stream/issue/FLU-500/make-clientstatechannels-and-related-collection-getters-unmodifiable)

## Summary

The collection getters on `ClientState` — `channels`, `users`, `activeLiveLocations` — returned live internal references. Callers could mutate the cache directly and silently bypass `channelsStream` / `usersStream` / `activeLiveLocationsStream`. Wrap them in unmodifiable maps/lists at write time so both the synchronous getter and the stream emit immutable values, and lock down the cache-mutation surface with `@internal`.

## What changed

**Read-side**
- `state.channels`, `state.users`, `state.activeLiveLocations` now return unmodifiable maps/lists. Calling `.clear()`, `.remove(...)`, `[k] = v`, etc. throws `UnsupportedError`.
- The wrap happens once at write time inside the setter / cache-mutation method, so the getter is zero-allocation. Subscribers to `channelsStream` / `usersStream` / `activeLiveLocationsStream` also receive unmodifiable values.
- Initial seeds are unmodifiable too — subscribers connecting *before* any write still see immutable values.

**Write-side hardening**
- All write calls in `ClientState` go through `safeAdd(...)` (the existing close-safe extension). Emissions after close are no-ops instead of throwing.
- `removeChannel` early-returns when the channel isn't cached and emits a freshly-built map, so `.distinct()` subscribers correctly observe the change. Previously `channels = channels..remove(cid)` re-emitted the same reference and missed the change for `.distinct()`.
- `dispose()` closes `_channelsController` before iterating the cached channels and disposing them. Each `Channel.dispose()` calls `removeChannel(cid)` which `safeAdd`-no-ops on the closed controller, so teardown produces **zero** subscriber emissions (vs. N progressively-shrinking maps previously).

**`@internal` audit**
The cache-mutation API surface on `ClientState` is now marked `@internal`. App flows (`connectUser`, `client.queryChannels`, `client.startLiveLocationSharing`, etc.) populate the cache through these methods and are unaffected.

- Setters: `channels=`, `currentUser=`, `activeLiveLocations=`, `totalUnreadCount=`, `blockedUserIds=`
- Methods: `updateUsers`, `updateUser`, `addChannels`, `removeChannel`

`ChannelClientState` is left out of this PR — the same pattern can be applied later when threads/typing events become a priority.

## Extracted wrapper module (post-review)

The unmodifiable-wrap discipline lives in two `@internal` wrapper classes (in `lib/src/core/util/immutable_collection_subjects.dart`):

- `ImmutableMapBehaviorSubject<K, V>`
- `ImmutableListBehaviorSubject<E>`

Both wrap a `BehaviorSubject<UnmodifiableMapView/ListView>`, extend `StreamView<T>`, and implement `Sink<T>` — so they behave like a regular broadcast stream + sink. Callers pass plain `Map<K, V>` / `List<E>` to `add` / `safeAdd`; the unmodifiable wrap happens inside, structurally impossible to forget or bypass via the wrapper's public surface.

The file also exports two public typedefs to keep the "Immutable" naming consistent:

- `ImmutableMap<K, V>` = `UnmodifiableMapView<K, V>`
- `ImmutableList<E>` = `UnmodifiableListView<E>`

The three collection controllers in `ClientState` now use the wrappers instead of the inline `BehaviorSubject<...>.seeded(.unmodifiable(...))` pattern.

## Tests

8 tests under `ClientState mutation guards`:

- `state.channels` returns an unmodifiable view
- `state.users` returns an unmodifiable view
- `state.activeLiveLocations` returns an unmodifiable view
- `removeChannel` emits a fresh map so `.distinct()` subscribers see the change
- initial seeded values are unmodifiable (before any write)
- `channelsStream` emits unmodifiable maps
- `usersStream` emits unmodifiable maps
- `activeLiveLocationsStream` emits unmodifiable lists

Plus 18 unit tests for the wrappers in `immutable_collection_subjects_test.dart` — covering both factory constructors, `add`/`safeAdd` wrap behavior, `add` throws after close, `safeAdd` no-op after close, subscribers receive unmodifiable values, and IS-A `Stream`/`Sink`.

Full LLC suite passes (1407/1407) on the rebased branch.

## Breaking

`fix(llc)!` — code that was mutating these collections directly (`state.channels.remove(...)`, `state.users.clear()`, etc.) will now throw `UnsupportedError` at runtime. Migration: go through the existing `addChannels` / `removeChannel` / `updateUser` / `updateUsers` methods (now `@internal`, but callable by SDK code; apps populate the cache via API methods that hit these internally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
