### PR TITLE
fix(ui): Don't count anchor corrections in ScrollablePositionedList

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed `StreamMessageListView` not auto-scrolling to the bottom on the user's own outgoing message
   until the server confirmed it.
+- Fixed a `FlutterError` ("A RenderViewport exceeded its maximum number of layout cycles") that
+  could occur when fast-scrolling through the message list.
 
 ## 9.24.0
 

--- a/packages/stream_chat_flutter/lib/scrollable_positioned_list/src/viewport.dart
+++ b/packages/stream_chat_flutter/lib/scrollable_positioned_list/src/viewport.dart
@@ -219,7 +219,9 @@ class UnboundedRenderViewport extends RenderViewport {
             final fitAnchor = _minScrollExtent.abs() / mainAxisExtent;
             if (fitAnchor != effectiveAnchor) {
               effectiveAnchor = fitAnchor;
-              count += 1;
+              // Do not increment `count` here. This is a deliberate one-time
+              // anchor correction (not an oscillation), so it must not consume
+              // a slot from the sliver-correction budget.
               continue;
             }
           }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
<!-- 
Describe how these code changes fix the issue or how the feature works.
Also try to give instructions how this can be tested.
-->

## Screenshots / Videos

What was happening:

The performLayout loop has a budget of 10 cycles (_maxLayoutCycles = 10). Each non-converging iteration increments count. With our custom fitAnchor logic, the lifecycle during fast scrolling was:

1. N cycles consumed by sliver corrections — when fast-scrolling loads new messages, SliverList children get laid out with new sizes and may request scrollOffsetCorrection to keep the viewport stable.
2. +1 cycle consumed by the fitAnchor branch (count += 1 before continue) — our custom code that overrides the anchor when content fits in the viewport.
3. +1 cycle consumed when applyContentDimensions returns false (pixel position clamped).
4. = N+2 total. When N ≥ 8 (which can happen during a fast fling through many messages), that exceeds 10.
The fix:

The fitAnchor pass is a deliberate one-time correction, not an oscillation. The upstream library's UnboundedRenderViewport doesn't have this pass at all — it was our addition to handle the edge case where a short list would appear centered instead of bottom-pinned. This pass must not consume a slot from the oscillation budget. Removing count += 1 gives back that cycle, meaning you now get the full 10 cycles for actual sliver oscillations before the assert fires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewport layout behavior in scrollable positioned lists: one-time anchor adjustments no longer consume layout-cycle budget. This improves stability and smoothness during rapid scrolling, reducing the chance of layout cycle errors and ensuring more reliable re-layouts of message lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-flutter/pull/2693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->