### PR TITLE
chore(persistence): Remove unused DAO methods

### DIFF
--- a/packages/stream_chat_persistence/lib/src/dao/member_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/member_dao.dart
@@ -55,10 +55,6 @@ class MemberDao extends DatabaseAccessor<DriftChatDatabase>
     };
   }
 
-  /// Updates all the members using the new [memberList] data
-  Future<void> updateMembers(String cid, List<Member> memberList) =>
-      bulkUpdateMembers({cid: memberList});
-
   /// Bulk updates the members data of multiple channels
   Future<void> bulkUpdateMembers(
     Map<String, List<Member>?> channelWithMembers,

--- a/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
@@ -220,11 +220,6 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase>
     return msgList;
   }
 
-  /// Updates the message data of a particular channel with
-  /// the new [messageList] data
-  Future<void> updateMessages(String cid, List<Message> messageList) =>
-      bulkUpdateMessages({cid: messageList});
-
   /// Bulk updates the message data of multiple channels
   Future<void> bulkUpdateMessages(
     Map<String, List<Message>?> channelWithMessages,

--- a/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/pinned_message_dao.dart
@@ -79,7 +79,7 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
     );
   }
 
-  /// Returns a single message by matching the [PinnedMessages.id] with [id]
+  /// Returns a single message by matching the [PinnedMessages.id] with [id].
   Future<Message?> getMessageById(
     String id, {
     bool fetchDraft = true,
@@ -100,65 +100,6 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
       result,
       fetchDraft: fetchDraft,
     );
-  }
-
-  /// Returns all the messages of a particular thread by matching
-  /// [PinnedMessages.channelCid] with [cid]
-  Future<List<Message>> getThreadMessages(String cid) async =>
-      Future.wait(await (select(pinnedMessages).join([
-        leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
-        leftOuterJoin(
-          _pinnedByUsers,
-          pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
-        ),
-      ])
-            ..where(pinnedMessages.channelCid.equals(cid))
-            ..where(pinnedMessages.parentId.isNotNull())
-            ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]))
-          .map(_messageFromJoinRow)
-          .get());
-
-  /// Returns all the messages of a particular thread by matching
-  /// [PinnedMessages.parentId] with [parentId]
-  Future<List<Message>> getThreadMessagesByParentId(
-    String parentId, {
-    PaginationParams? options,
-  }) async {
-    final msgList = await Future.wait(await (select(pinnedMessages).join([
-      leftOuterJoin(_users, pinnedMessages.userId.equalsExp(_users.id)),
-      leftOuterJoin(
-        _pinnedByUsers,
-        pinnedMessages.pinnedByUserId.equalsExp(_pinnedByUsers.id),
-      ),
-    ])
-          ..where(pinnedMessages.parentId.isNotNull())
-          ..where(pinnedMessages.parentId.equals(parentId))
-          ..orderBy([OrderingTerm.asc(pinnedMessages.createdAt)]))
-        .map(_messageFromJoinRow)
-        .get());
-
-    if (msgList.isNotEmpty) {
-      if (options?.lessThan != null) {
-        final lessThanIndex = msgList.indexWhere(
-          (m) => m.id == options!.lessThan,
-        );
-        if (lessThanIndex != -1) {
-          msgList.removeRange(lessThanIndex, msgList.length);
-        }
-      }
-      if (options?.greaterThan != null) {
-        final greaterThanIndex = msgList.indexWhere(
-          (m) => m.id == options!.greaterThan,
-        );
-        if (greaterThanIndex != -1) {
-          msgList.removeRange(0, greaterThanIndex);
-        }
-      }
-      if (options?.limit != null) {
-        return msgList.take(options!.limit).toList();
-      }
-    }
-    return msgList;
   }
 
   /// Returns all the messages of a channel by matching
@@ -215,11 +156,6 @@ class PinnedMessageDao extends DatabaseAccessor<DriftChatDatabase>
     }
     return msgList;
   }
-
-  /// Updates the message data of a particular channel with
-  /// the new [messageList] data
-  Future<void> updateMessages(String cid, List<Message> messageList) =>
-      bulkUpdateMessages({cid: messageList});
 
   /// Bulk updates the message data of multiple channels
   Future<void> bulkUpdateMessages(

--- a/packages/stream_chat_persistence/lib/src/dao/poll_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/poll_dao.dart
@@ -59,13 +59,6 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
         ),
       );
 
-  /// Returns the list of all the polls stored in db
-  Future<List<Poll>> getPolls() async => Future.wait(await (select(polls)
-        ..orderBy([(it) => OrderingTerm.desc(it.createdAt)]))
-      .join([leftOuterJoin(users, polls.createdById.equalsExp(users.id))])
-      .map(_pollFromJoinRow)
-      .get());
-
   /// Deletes all the polls whose [Polls.id] is present in [pollIds]
   Future<void> deletePollsByIds(List<String> pollIds) =>
       (delete(polls)..where((tbl) => tbl.id.isIn(pollIds))).go();

--- a/packages/stream_chat_persistence/lib/src/dao/read_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/read_dao.dart
@@ -27,11 +27,6 @@ class ReadDao extends DatabaseAccessor<DriftChatDatabase> with _$ReadDaoMixin {
         return readEntity.toRead(user: userEntity.toUser());
       }).get();
 
-  /// Updates the read data of a particular channel with
-  /// the new [readList] data
-  Future<void> updateReads(String cid, List<Read> readList) =>
-      bulkUpdateReads({cid: readList});
-
   /// Bulk updates the reads data of multiple channels
   Future<void> bulkUpdateReads(Map<String, List<Read>?> channelWithReads) {
     final entities = channelWithReads.entries

--- a/packages/stream_chat_persistence/lib/src/dao/user_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/user_dao.dart
@@ -19,10 +19,4 @@ class UserDao extends DatabaseAccessor<DriftChatDatabase> with _$UserDaoMixin {
           userList.map((u) => u.toEntity()).toList(),
         ),
       );
-
-  /// Returns the list of all the users stored in db
-  Future<List<User>> getUsers() =>
-      (select(users)..orderBy([(u) => OrderingTerm.desc(u.createdAt)]))
-          .map((it) => it.toUser())
-          .get();
 }

--- a/packages/stream_chat_persistence/test/src/dao/channel_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/channel_dao_test.dart
@@ -68,7 +68,9 @@ void main() {
 
     // Saving a dummy member
     final dummyMember = Member(userId: userId, user: dummyUser);
-    await database.memberDao.updateMembers(cid, [dummyMember]);
+    await database.memberDao.bulkUpdateMembers({
+      cid: [dummyMember]
+    });
 
     // Should match the dummy member
     final updatedMembers = await database.memberDao.getMembersByCid(cid);
@@ -78,7 +80,9 @@ void main() {
     // Saving a dummy message
     const messageId = 'messageId';
     final dummyMessage = Message(id: messageId, user: dummyUser);
-    await database.messageDao.updateMessages(cid, [dummyMessage]);
+    await database.messageDao.bulkUpdateMessages({
+      cid: [dummyMessage]
+    });
 
     // Should match the dummy message
     final updatedMessages = await database.messageDao.getMessagesByCid(cid);
@@ -91,7 +95,9 @@ void main() {
       user: dummyUser,
       lastReadMessageId: messageId,
     );
-    await database.readDao.updateReads(cid, [dummyRead]);
+    await database.readDao.bulkUpdateReads({
+      cid: [dummyRead]
+    });
 
     // Should match the dummy read
     final updatedReads = await database.readDao.getReadsByCid(cid);

--- a/packages/stream_chat_persistence/test/src/dao/draft_message_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/draft_message_dao_test.dart
@@ -102,7 +102,7 @@ void main() {
     await database.channelDao.updateChannels(allChannels);
 
     if (withParentMessage || withQuotedMessage) {
-      await database.messageDao.updateMessages(cid, messages);
+      await database.messageDao.bulkUpdateMessages({cid: messages});
     }
 
     if (withPoll && polls != null) {
@@ -287,7 +287,9 @@ void main() {
 
         await database.userDao.updateUsers([user]);
         await database.channelDao.updateChannels([ChannelModel(cid: cid)]);
-        await database.messageDao.updateMessages(cid, [parentMessage]);
+        await database.messageDao.bulkUpdateMessages({
+          cid: [parentMessage],
+        });
 
         // Create first thread draft
         final firstDraft = Draft(
@@ -421,7 +423,7 @@ void main() {
 
         await database.userDao.updateUsers([user]);
         await database.channelDao.updateChannels([ChannelModel(cid: cid)]);
-        await database.messageDao.updateMessages(cid, messages);
+        await database.messageDao.bulkUpdateMessages({cid: messages});
 
         // Create a channel draft (no parent message)
         final channelDraft = Draft(

--- a/packages/stream_chat_persistence/test/src/dao/member_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/member_dao_test.dart
@@ -39,7 +39,7 @@ void main() {
     );
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await memberDao.updateMembers(cid, memberList);
+    await memberDao.bulkUpdateMembers({cid: memberList});
     return memberList;
   }
 
@@ -112,9 +112,11 @@ void main() {
       ChannelModel(cid: cid2),
       ChannelModel(cid: cid3),
     ]);
-    await memberDao.updateMembers(cid1, [memberFor(targetUser)]);
-    await memberDao.updateMembers(cid2, [memberFor(targetUser)]);
-    await memberDao.updateMembers(cid3, [memberFor(otherUser)]);
+    await memberDao.bulkUpdateMembers({
+      cid1: [memberFor(targetUser)],
+      cid2: [memberFor(targetUser)],
+      cid3: [memberFor(otherUser)],
+    });
 
     // Should return memberships only for channels where target user
     // is a member, keyed by channelCid.
@@ -130,7 +132,7 @@ void main() {
     expect(memberships[cid2]!.user!.id, targetUserId);
   });
 
-  test('updateMembers', () async {
+  test('bulkUpdateMembers', () async {
     const cid = 'test:Cid';
 
     // Preparing test data
@@ -174,7 +176,9 @@ void main() {
       updatedAt: DateTime.now(),
     );
     await database.userDao.updateUsers([newUser]);
-    await memberDao.updateMembers(cid, [copyMember, newMember]);
+    await memberDao.bulkUpdateMembers({
+      cid: [copyMember, newMember],
+    });
 
     // Fetched member length should be one more than inserted members.
     // copyMember `banned` modified field should be true.

--- a/packages/stream_chat_persistence/test/src/dao/message_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/message_dao_test.dart
@@ -113,7 +113,7 @@ void main() {
     );
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await messageDao.updateMessages(cid, allMessages);
+    await messageDao.bulkUpdateMessages({cid: allMessages});
     await database.reactionDao.updateReactions([reaction]);
     return allMessages;
   }
@@ -393,7 +393,7 @@ void main() {
     expect(fetchedMessages.first.id != lessThan, true);
   });
 
-  test('updateMessages', () async {
+  test('bulkUpdateMessages', () async {
     const cid = 'test:Cid';
 
     // Preparing test data
@@ -418,7 +418,9 @@ void main() {
       pinnedBy: User(id: 'testUserId4'),
     );
 
-    await messageDao.updateMessages(cid, [copyMessage, newMessage]);
+    await messageDao.bulkUpdateMessages({
+      cid: [copyMessage, newMessage],
+    });
 
     // Fetched messages length should be one more than inserted message.
     // copyMessage `showInChannel` modified field should be false.

--- a/packages/stream_chat_persistence/test/src/dao/pinned_message_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/pinned_message_dao_test.dart
@@ -98,7 +98,7 @@ void main() {
     );
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await pinnedMessageDao.updateMessages(cid, allMessages);
+    await pinnedMessageDao.bulkUpdateMessages({cid: allMessages});
     await database.pinnedMessageReactionDao.updateReactions([reaction]);
     return allMessages;
   }
@@ -222,97 +222,6 @@ void main() {
     );
   });
 
-  test('getMessageById', () async {
-    const cid = 'test:Cid';
-    const id = 'testMessageId${cid}0';
-
-    // Should be null initially
-    final message = await pinnedMessageDao.getMessageById(id);
-    expect(message, isNull);
-
-    // Adding test message with the cid and id
-    final insertedMessages = await _prepareTestData(cid, count: 1);
-    expect(insertedMessages.first.id, id);
-
-    // Fetched message id should match the inserted message id
-    final fetchedMessage = await pinnedMessageDao.getMessageById(id);
-    expect(fetchedMessage, isNotNull);
-    expect(fetchedMessage!.id, insertedMessages.first.id);
-  });
-
-  test('getThreadMessages', () async {
-    const cid = 'test:Cid';
-
-    // Messages should be empty initially
-    final messages = await pinnedMessageDao.getThreadMessages(cid);
-    expect(messages, isEmpty);
-
-    // Preparing test data
-    final insertedMessages = await _prepareTestData(cid, threads: true);
-    expect(insertedMessages, isNotEmpty);
-
-    // Should fetch all the thread messages of cid
-    final threadMessages = await pinnedMessageDao.getThreadMessages(cid);
-    expect(threadMessages, isNotEmpty);
-    for (final message in threadMessages) {
-      expect(message.parentId, isNotNull);
-    }
-  });
-
-  test('getThreadMessagesByParentId', () async {
-    const cid = 'test:Cid';
-    const parentId = 'testMessageId${cid}0';
-
-    // Messages should be empty initially
-    final messages =
-        await pinnedMessageDao.getThreadMessagesByParentId(parentId);
-    expect(messages, isEmpty);
-
-    // Preparing test data
-    final insertedMessages = await _prepareTestData(cid, threads: true);
-    expect(insertedMessages, isNotEmpty);
-
-    // Should fetch all the thread messages of parentId
-    final threadMessages =
-        await pinnedMessageDao.getThreadMessagesByParentId(parentId);
-    expect(threadMessages.length, 1);
-    expect(threadMessages.first.parentId, parentId);
-  });
-
-  test('getThreadMessagesByParentId along with pagination', () async {
-    const cid = 'test:Cid';
-    const parentId = 'testMessageId${cid}0';
-    const options = PaginationParams(
-      limit: 15,
-      lessThan: 'testThreadMessageId${cid}25',
-      greaterThanOrEqual: 'testThreadMessageId${cid}5',
-    );
-
-    // Messages should be empty initially
-    final messages = await pinnedMessageDao.getThreadMessagesByParentId(
-      parentId,
-      options: options,
-    );
-    expect(messages, isEmpty);
-
-    // Preparing test data
-    final insertedMessages = await _prepareTestData(
-      cid,
-      threads: true,
-      mapAllThreadToFirstMessage: true,
-      count: 30,
-    );
-    expect(insertedMessages, isNotEmpty);
-
-    // Should fetch all the thread messages of parentId and apply the pagination
-    final threadMessages = await pinnedMessageDao.getThreadMessagesByParentId(
-      parentId,
-      options: options,
-    );
-    expect(threadMessages.length, 15);
-    expect(threadMessages.first.parentId, parentId);
-  });
-
   test('getMessagesByCid', () async {
     const cid = 'test:Cid';
 
@@ -384,7 +293,7 @@ void main() {
     expect(fetchedMessages.last.id != lessThan, true);
   });
 
-  test('updateMessages', () async {
+  test('bulkUpdateMessages', () async {
     const cid = 'test:Cid';
 
     // Preparing test data
@@ -409,7 +318,9 @@ void main() {
       pinnedBy: User(id: 'testUserId4'),
     );
 
-    await pinnedMessageDao.updateMessages(cid, [copyMessage, newMessage]);
+    await pinnedMessageDao.bulkUpdateMessages({
+      cid: [copyMessage, newMessage],
+    });
 
     // Fetched messages length should be one more than inserted message.
     // copyMessage `showInChannel` modified field should be false.

--- a/packages/stream_chat_persistence/test/src/dao/pinned_message_reaction_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/pinned_message_reaction_dao_test.dart
@@ -53,7 +53,9 @@ void main() {
 
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await database.pinnedMessageDao.updateMessages(cid, [message]);
+    await database.pinnedMessageDao.bulkUpdateMessages({
+      cid: [message],
+    });
     await pinnedMessageReactionDao.updateReactions(reactions);
 
     return reactions;

--- a/packages/stream_chat_persistence/test/src/dao/poll_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/poll_dao_test.dart
@@ -86,20 +86,6 @@ void main() {
     return polls;
   }
 
-  test('getPolls', () async {
-    // Should be empty initially
-    final polls = await pollDao.getPolls();
-    expect(polls, isEmpty);
-
-    // Adding sample polls
-    final insertedPolls = await _preparePollData();
-    expect(insertedPolls, isNotEmpty);
-
-    // Fetched polls length should match inserted polls length.
-    final fetchedPollVotes = await pollDao.getPolls();
-    expect(fetchedPollVotes.length, insertedPolls.length);
-  });
-
   test('updatePolls', () async {
     // Preparing test data
     final insertedPolls = await _preparePollData();
@@ -109,11 +95,10 @@ void main() {
 
     await pollDao.updatePolls([newPoll]);
 
-    // Fetched users length should be one more than inserted users.
-    // Fetched users should contain the newUser.
-    final fetchedPolls = await pollDao.getPolls();
-    expect(fetchedPolls.length, insertedPolls.length + 1);
-    expect(fetchedPolls.any((it) => it.id == newPoll.id), isTrue);
+    // Fetched poll should match the newly inserted poll.
+    final fetchedPoll = await pollDao.getPollById(newPoll.id);
+    expect(fetchedPoll, isNotNull);
+    expect(fetchedPoll!.id, newPoll.id);
   });
 
   test('getPollById', () async {
@@ -134,10 +119,9 @@ void main() {
     final pollToDelete = insertedPolls.first;
     await pollDao.deletePollsByIds([pollToDelete.id]);
 
-    // Fetched poll list should be one less than inserted polls.
-    final fetchedPolls = await pollDao.getPolls();
-    expect(fetchedPolls.length, insertedPolls.length - 1);
-    expect(fetchedPolls.any((it) => it.id == pollToDelete.id), isFalse);
+    // Fetched poll should be null.
+    final fetchedPoll = await pollDao.getPollById(pollToDelete.id);
+    expect(fetchedPoll, isNull);
   });
 
   test('deleting a poll should also delete its votes', () async {
@@ -152,10 +136,9 @@ void main() {
     // Delete the poll
     await pollDao.deletePollsByIds([pollToDelete.id]);
 
-    // Fetched poll list should be one less than inserted polls.
-    final fetchedPolls = await pollDao.getPolls();
-    expect(fetchedPolls.length, insertedPolls.length - 1);
-    expect(fetchedPolls.any((it) => it.id == pollToDelete.id), isFalse);
+    // Fetched poll should be null.
+    final fetchedPoll = await pollDao.getPollById(pollToDelete.id);
+    expect(fetchedPoll, isNull);
 
     // Fetched poll votes should be empty
     final fetchedPollVotes = await database.pollVoteDao.getPollVotes(

--- a/packages/stream_chat_persistence/test/src/dao/reaction_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/reaction_dao_test.dart
@@ -53,7 +53,9 @@ void main() {
 
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await database.messageDao.updateMessages(cid, [message]);
+    await database.messageDao.bulkUpdateMessages({
+      cid: [message],
+    });
     await reactionDao.updateReactions(reactions);
 
     return reactions;

--- a/packages/stream_chat_persistence/test/src/dao/read_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/read_dao_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     await database.userDao.updateUsers(users);
     await database.channelDao.updateChannels(channels);
-    await readDao.updateReads(cid, reads);
+    await readDao.bulkUpdateReads({cid: reads});
     return reads;
   }
 
@@ -63,7 +63,7 @@ void main() {
     }
   });
 
-  test('updateReads', () async {
+  test('bulkUpdateReads', () async {
     const cid = 'test:Cid';
 
     // Preparing test data
@@ -81,7 +81,9 @@ void main() {
       lastDeliveredMessageId: 'lastDeliveredMessageId3',
     );
     await database.userDao.updateUsers([newUser]);
-    await readDao.updateReads(cid, [copyRead, newRead]);
+    await readDao.bulkUpdateReads({
+      cid: [copyRead, newRead],
+    });
 
     // Fetched reads length should be one more than inserted reads.
     // copyRead `unreadMessages` modified field should be 33.

--- a/packages/stream_chat_persistence/test/src/dao/user_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/user_dao_test.dart
@@ -59,7 +59,8 @@ void main() {
     final insertedUsers = await _prepareUserData();
 
     // Modifying one of the users and also adding one new
-    final copyUser = insertedUsers.first.copyWith(online: false);
+    final copyUser =
+        insertedUsers.first.copyWith(online: !insertedUsers.first.online);
     final newUser = User(
       id: 'testUserId3',
       role: 'testRole',
@@ -72,11 +73,14 @@ void main() {
     await userDao.updateUsers([copyUser, newUser]);
 
     // Fetched users length should be one more than inserted users.
-    // copyUser `online` modified field should be `false`.
+    // copyUser `online` should match the toggled value.
     // Fetched users should contain the newUser.
     final fetchedUsers = await _readPersistedUsers();
     expect(fetchedUsers.length, insertedUsers.length + 1);
-    expect(fetchedUsers.firstWhere((it) => it.id == copyUser.id).online, false);
+    expect(
+      fetchedUsers.firstWhere((it) => it.id == copyUser.id).online,
+      copyUser.online,
+    );
     expect(fetchedUsers.any((it) => it.id == newUser.id), isTrue);
   });
 

--- a/packages/stream_chat_persistence/test/src/dao/user_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/user_dao_test.dart
@@ -1,9 +1,11 @@
 import 'dart:math' as math;
 
+import 'package:drift/drift.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_chat/stream_chat.dart';
 import 'package:stream_chat_persistence/src/dao/dao.dart';
 import 'package:stream_chat_persistence/src/db/drift_chat_database.dart';
+import 'package:stream_chat_persistence/src/mapper/user_mapper.dart';
 
 import '../../stream_chat_persistence_client_test.dart';
 
@@ -35,11 +37,28 @@ void main() {
     return users;
   }
 
-  test('updateUsers', () async {
+  Future<List<User>> _readPersistedUsers() => (database.select(database.users)
+        ..orderBy([(u) => OrderingTerm(expression: u.createdAt)]))
+      .map((it) => it.toUser())
+      .get();
+
+  test('updateUsers persists new users', () async {
+    expect(await _readPersistedUsers(), isEmpty);
+
+    final insertedUsers = await _prepareUserData();
+
+    final fetchedUsers = await _readPersistedUsers();
+    expect(fetchedUsers.length, insertedUsers.length);
+    for (final user in insertedUsers) {
+      expect(fetchedUsers.any((it) => it.id == user.id), isTrue);
+    }
+  });
+
+  test('updateUsers upserts existing users and inserts new ones', () async {
     // Preparing test data
     final insertedUsers = await _prepareUserData();
 
-    // Modifying one of the user and also adding one new
+    // Modifying one of the users and also adding one new
     final copyUser = insertedUsers.first.copyWith(online: false);
     final newUser = User(
       id: 'testUserId3',
@@ -55,24 +74,10 @@ void main() {
     // Fetched users length should be one more than inserted users.
     // copyUser `online` modified field should be `false`.
     // Fetched users should contain the newUser.
-    final fetchedUsers = await userDao.getUsers();
+    final fetchedUsers = await _readPersistedUsers();
     expect(fetchedUsers.length, insertedUsers.length + 1);
     expect(fetchedUsers.firstWhere((it) => it.id == copyUser.id).online, false);
-    expect(fetchedUsers.contains(newUser), true);
-  });
-
-  test('getUsers', () async {
-    // Should be empty initially
-    final users = await userDao.getUsers();
-    expect(users, isEmpty);
-
-    // Preparing test data
-    final insertedUsers = await _prepareUserData();
-    expect(insertedUsers, isNotEmpty);
-
-    // Fetched user list should match inserted user list length
-    final fetchedUsers = await userDao.getUsers();
-    expect(fetchedUsers.length, insertedUsers.length);
+    expect(fetchedUsers.any((it) => it.id == newUser.id), isTrue);
   });
 
   tearDown(() async {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-501

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
- Removes all unused DAO methods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved persistence performance via multi-channel batch (bulk) update operations for members, messages, reads, and pinned messages
  * Simplified persistence surface by consolidating single-channel calls into standardized bulk-update calls
  * Removed a few legacy query helpers to streamline data access

* **Tests**
  * Updated tests to use the new bulk-update flows and validate behavior accordingly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-flutter/pull/2695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->