### PR TITLE
fix(ui): guard MessageCard._updateWidthLimit against unlaid RenderBox

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -6,6 +6,9 @@
   until the server confirmed it.
 - Fixed a `FlutterError` ("A RenderViewport exceeded its maximum number of layout cycles") that
   could occur when fast-scrolling through the message list.
+- Fixed `RenderBox was not laid out` thrown by `MessageCard._updateWidthLimit` when the attachments
+  subtree was detached between scheduling the post-frame callback and it firing (e.g. the list was
+  rebuilt or the message removed). Added a `hasSize` guard before reading `RenderBox.size`.
 
 ## 9.24.0
 

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
@@ -133,15 +133,19 @@ class _MessageCardState extends State<MessageCard> {
   }
 
   void _updateWidthLimit() {
+    if (!mounted) return;
+
     final attachmentContext = attachmentsKey.currentContext;
     final renderBox = attachmentContext?.findRenderObject() as RenderBox?;
-    final attachmentsWidth = renderBox?.size.width;
+    // The attachments subtree may have been detached between scheduling this
+    // post-frame callback and it firing. Reading [RenderBox.size] without
+    // checking [RenderBox.hasSize] throws `RenderBox was not laid out`.
+    if (renderBox == null || !renderBox.hasSize) return;
+    final attachmentsWidth = renderBox.size.width;
 
-    if (attachmentsWidth == null || attachmentsWidth == 0) return;
+    if (attachmentsWidth == 0) return;
 
-    if (mounted) {
-      setState(() => widthLimit = attachmentsWidth);
-    }
+    setState(() => widthLimit = attachmentsWidth);
   }
 
   @override

--- a/packages/stream_chat_flutter/test/src/message_widget/message_card_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_widget/message_card_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../mocks.dart';
+
+/// Always-handles attachment builder used to inject a known-size widget into
+/// the attachments slot of [MessageCard]. Lets each test control the size that
+/// `_updateWidthLimit` will read off the rendered RenderBox.
+class _FixedSizeAttachmentBuilder extends StreamAttachmentWidgetBuilder {
+  const _FixedSizeAttachmentBuilder({required this.size});
+
+  final Size size;
+
+  @override
+  bool canHandle(Message message, Map<String, List<Attachment>> attachments) =>
+      true;
+
+  @override
+  Widget build(
+    BuildContext context,
+    Message message,
+    Map<String, List<Attachment>> attachments,
+  ) {
+    return SizedBox.fromSize(size: size);
+  }
+}
+
+MessageCard _buildCard({
+  required bool hasNonUrlAttachments,
+  StreamAttachmentWidgetBuilder? attachmentBuilder,
+}) {
+  return MessageCard(
+    message: Message(
+      id: 'm1',
+      text: 'hi',
+      attachments: [Attachment(type: AttachmentType.file)],
+    ),
+    isFailedState: false,
+    showUserAvatar: DisplayWidget.show,
+    messageTheme: const StreamMessageThemeData(),
+    hasQuotedMessage: false,
+    hasUrlAttachments: false,
+    hasNonUrlAttachments: hasNonUrlAttachments,
+    hasPoll: false,
+    isOnlyEmoji: false,
+    isGiphy: false,
+    attachmentBuilders: attachmentBuilder == null ? null : [attachmentBuilder],
+    attachmentPadding: const EdgeInsets.all(4),
+    attachmentShape: null,
+    onAttachmentTap: (_, __) {},
+    onShowMessage: (_, __) {},
+    onReplyTap: (_) {},
+    attachmentActionsModalBuilder: null,
+    textPadding: const EdgeInsets.all(8),
+    reverse: false,
+  );
+}
+
+/// Wraps [child] in a minimal [StreamChat] + [MaterialApp] so descendant
+/// widgets like [StreamMessageText] can resolve `StreamChat.of(context)`.
+Widget _wrap(Widget child) {
+  final client = MockClient();
+  final clientState = MockClientState();
+  final user = OwnUser(id: 'user-id');
+  when(() => client.state).thenReturn(clientState);
+  when(() => clientState.currentUser).thenReturn(user);
+  when(() => clientState.currentUserStream)
+      .thenAnswer((_) => Stream.value(user));
+
+  return MaterialApp(
+    home: StreamChat(
+      client: client,
+      child: Scaffold(body: Center(child: child)),
+    ),
+  );
+}
+
+void main() {
+  group('MessageCard._updateWidthLimit', () {
+    testWidgets(
+      'applies width limit from laid-out attachments render box',
+      (tester) async {
+        const attachmentSize = Size(220, 80);
+
+        await tester.pumpWidget(
+          _wrap(
+            _buildCard(
+              hasNonUrlAttachments: true,
+              attachmentBuilder:
+                  const _FixedSizeAttachmentBuilder(size: attachmentSize),
+            ),
+          ),
+        );
+        // Allow the post-frame callback scheduled in didChangeDependencies to
+        // fire and apply the width limit via setState.
+        await tester.pump();
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(MessageCard),
+            matching: find.byType(Container),
+          ),
+        );
+        expect(container.constraints?.maxWidth, attachmentSize.width);
+      },
+    );
+
+    testWidgets(
+      'does not throw when the message card is unmounted before '
+      'the post-frame callback fires',
+      (tester) async {
+        const attachmentSize = Size(120, 60);
+
+        await tester.pumpWidget(
+          _wrap(
+            _buildCard(
+              hasNonUrlAttachments: true,
+              attachmentBuilder:
+                  const _FixedSizeAttachmentBuilder(size: attachmentSize),
+            ),
+          ),
+        );
+        // Replace the MessageCard with an empty tree BEFORE pumping the next
+        // frame. The post-frame callback queued in didChangeDependencies will
+        // fire against an unmounted state — the new `if (!mounted) return;`
+        // guard must keep it from throwing.
+        await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'leaves width limit unset when attachment reports zero width',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            _buildCard(
+              hasNonUrlAttachments: true,
+              attachmentBuilder:
+                  const _FixedSizeAttachmentBuilder(size: Size.zero),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(MessageCard),
+            matching: find.byType(Container),
+          ),
+        );
+        // The early-return on `attachmentsWidth == 0` means widthLimit stays
+        // null and the constraints stay unconstrained on the width axis.
+        expect(container.constraints?.maxWidth, double.infinity);
+      },
+    );
+
+    testWidgets(
+      'skips width measurement entirely when there are no attachments',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(_buildCard(hasNonUrlAttachments: false)),
+        );
+        await tester.pump();
+
+        // No exception — the post-frame callback is not scheduled at all when
+        // hasAttachments is false.
+        expect(tester.takeException(), isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

### Bug

`_MessageCardState._updateWidthLimit` is scheduled via `WidgetsBinding.instance.addPostFrameCallback` from `didChangeDependencies`, and reads `renderBox.size.width` when it fires:

```dart
void _updateWidthLimit() {
  final attachmentContext = attachmentsKey.currentContext;
  final renderBox = attachmentContext?.findRenderObject() as RenderBox?;
  final attachmentsWidth = renderBox?.size.width;          // <-- throws
  ...
}
```

If the attachments subtree has been detached from the tree between scheduling and firing (e.g. the parent rebuilt the list, the chat was disposed, the attachment was deleted, the user navigated away), then per Flutter's contract `RenderBox.size` throws `StateError: RenderBox was not laid out`:

> A RenderBox object must be laid out before any method that reads its size or position is called.

The throw is caught by `FlutterError.onError`, so the user sees a dropped frame rather than a crash. But it surfaces as a fatal error in crash reporters like Sentry. In a production Flutter app pinned to `stream_chat_flutter: ^9.24.0`, the two Sentry issues corresponding to this code path have generated **over 1500 events across 1100+ unique users in a single 2-week release** — the loudest non-network issue in the audit.

Sample symbolicated stack:
```
at _MessageCardState.didChangeDependencies.<T> (message_card.dart:155)
at _MessageCardState._updateWidthLimit (message_card.dart:138)
at RenderBox.size (box.dart:2304)
    (throw StateError('RenderBox was not laid out: $runtimeType#${shortHash(this)}'));
```

### Fix

1. Add a `hasSize` guard before reading `renderBox.size` — exactly what the framework docs recommend for the "read size after a frame" pattern.
2. Move the existing `mounted` check from "before `setState`" to the top of the function. Previously, on an unmounted widget we still touched the (possibly unlaid) render object — only the `setState` was skipped. The earlier check is symmetrical and slightly cheaper.

Diff:
```dart
void _updateWidthLimit() {
  if (!mounted) return;

  final attachmentContext = attachmentsKey.currentContext;
  final renderBox = attachmentContext?.findRenderObject() as RenderBox?;
  // The attachments subtree may have been detached between scheduling this
  // post-frame callback and it firing. Reading [RenderBox.size] without
  // checking [RenderBox.hasSize] throws `RenderBox was not laid out`.
  if (renderBox == null || !renderBox.hasSize) return;
  final attachmentsWidth = renderBox.size.width;

  if (attachmentsWidth == 0) return;

  setState(() => widthLimit = attachmentsWidth);
}
```

### Testing

This is a defensive guard against a framework-level race that fires intermittently on real user devices and is hard to reproduce locally. The guard preserves the existing happy-path behavior (when the render object is laid out, width is read and applied identically to before) and short-circuits cleanly when it's not.

## Screenshots / Videos

Not applicable — this fix removes a race-condition error log, no visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when measuring attachment widths if attachments are removed before a post-frame update; width checks now avoid invalid reads and skip updates when not applicable.
* **Tests**
  * Added widget tests verifying width measurement behavior, unmount safety, zero-width handling, and no-op when no attachments exist.
* **Documentation**
  * Updated changelog with the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->