### PR TITLE
fix(llc, core, ui): isolate channel state from sub-route wraps and smooth thread-open scroll

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 🐞 Fixed
 
+- Fixed `Channel.getMessagesById` mutating the loaded channel window as a side effect of fetching.
 - Fixed `StreamChatClient.queryDrafts` not forwarding the `filter` argument to the API.
 
 - Coalesced concurrent `queryChannels` calls with identical parameters via an in-flight cache.

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -1801,10 +1801,7 @@ class Channel {
     List<String> messageIDs,
   ) async {
     _checkInitialized();
-    final res = await _client.getMessagesById(id!, type, messageIDs);
-    final messages = res.messages;
-    state!.updateChannelState(state!.channelState.copyWith(messages: messages));
-    return res;
+    return _client.getMessagesById(id!, type, messageIDs);
   }
 
   /// Translate a message by given [messageId] and [language].

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 🐞 Fixed
 
+- Fixed `ScrollablePositionedList.scrollTo` taking the long-distance teleport path when called
+  immediately after mount (before `itemPositions` had been published). It now waits one frame
+  for layout, then animates the real pixel distance.
 - Fixed `StreamMessageListView` not auto-scrolling to the bottom on the user's own outgoing message
   until the server confirmed it.
 - Fixed `StreamMessageListView` tripping `A RenderViewport exceeded its maximum number of layout

--- a/packages/stream_chat_flutter/lib/scrollable_positioned_list/src/scrollable_positioned_list.dart
+++ b/packages/stream_chat_flutter/lib/scrollable_positioned_list/src/scrollable_positioned_list.dart
@@ -750,6 +750,16 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     Curve curve = Curves.linear,
     required List<double> opacityAnimationWeights,
   }) async {
+    // If `itemPositions` hasn't been published yet (e.g. a scroll requested
+    // from a post-frame callback right after mount), the in-viewport branch
+    // below would miss the target and fall through to the dual-controller
+    // teleport path — even when the target is actually a few items away.
+    // Wait one frame so layout can report positions, then proceed.
+    if (primary.itemPositionsNotifier.itemPositions.value.isEmpty) {
+      await SchedulerBinding.instance.endOfFrame;
+      if (!mounted) return;
+    }
+
     final direction = index > primary.target ? 1 : -1;
     final itemPosition =
         primary.itemPositionsNotifier.itemPositions.value.firstWhereOrNull(

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## Upcoming
 
+✅ Added
+
+- Added `StreamChannel.value` — exposes an already-initialized channel without running channel-page
+  positioning. Use it for sub-route and overlay wraps.
+
 🐞 Fixed
 
+- Fixed `StreamChannel.getMessage` hitting the network for thread replies and pinned messages
+  already in local state.
+- Fixed `MessageListCore` reloading the parent channel from its dispose path when running in
+  thread mode.
 - Fixed `StreamChannel.reloadChannel` merging the latest page on top of the previously loaded
   window instead of replacing it. The reload now matches a fresh open of the channel.
 

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -293,6 +293,10 @@ class MessageListCoreState extends State<MessageListCore> {
     // If the channel is up to date, we don't need to reload it.
     if (_upToDate) return;
 
+    // Thread conversations share the parent channel; reloading from a
+    // disposing thread would clobber the channel page state.
+    if (_isThreadConversation) return;
+
     try {
       return await _streamChannel?.reloadChannel();
     } catch (_) {
@@ -305,7 +309,7 @@ class MessageListCoreState extends State<MessageListCore> {
   @override
   void dispose() {
     _teardownController(widget.messageListController);
-    if (!_isThreadConversation) _reloadChannelIfNeeded();
+    _reloadChannelIfNeeded();
     super.dispose();
   }
 }

--- a/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/message_list_core.dart
@@ -305,7 +305,7 @@ class MessageListCoreState extends State<MessageListCore> {
   @override
   void dispose() {
     _teardownController(widget.messageListController);
-    _reloadChannelIfNeeded();
+    if (!_isThreadConversation) _reloadChannelIfNeeded();
     super.dispose();
   }
 }

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -45,7 +45,30 @@ class StreamChannel extends StatefulWidget {
     this.initialMessageId,
     this.errorBuilder = _defaultErrorBuilder,
     this.loadingBuilder = _defaultLoadingBuilder,
-  });
+  }) : _shouldPosition = true;
+
+  /// Exposes a [channel] to descendants without repositioning the loaded
+  /// window on mount.
+  ///
+  /// Use this when wrapping a channel in a sub-route or overlay for context
+  /// access only — e.g. a thread page, channel info screen, long-press
+  /// modal, or attachment viewer. The default constructor would otherwise
+  /// re-run channel-page positioning and overwrite the parent route's
+  /// loaded window.
+  ///
+  /// See also:
+  ///
+  ///  * [StreamChannel.new], which initializes the channel and positions it
+  ///    on mount.
+  const StreamChannel.value({
+    super.key,
+    required this.child,
+    required this.channel,
+  })  : showLoading = false,
+        initialMessageId = null,
+        errorBuilder = _defaultErrorBuilder,
+        loadingBuilder = _defaultLoadingBuilder,
+        _shouldPosition = false;
 
   /// The child of the widget
   final Widget child;
@@ -64,6 +87,10 @@ class StreamChannel extends StatefulWidget {
 
   /// Widget builder used in case an error occurs while building the channel.
   final ErrorWidgetBuilder errorBuilder;
+
+  // Whether to position the loaded window on mount (initialMessageId,
+  // last-read, or latest). Only false for StreamChannel.value.
+  final bool _shouldPosition;
 
   static Widget _defaultLoadingBuilder(BuildContext context) {
     final backgroundColor = _getDefaultBackgroundColor(context);
@@ -675,16 +702,43 @@ class StreamChannelState extends State<StreamChannel> {
     );
   }
 
-  ///
+  /// Returns the message with the given [messageId].
   Future<Message> getMessage(String messageId) async {
-    var message = channel.state?.messages.firstWhereOrNull(
-      (it) => it.id == messageId,
+    if (_findCachedMessage(messageId) case final cached?) return cached;
+
+    final response = await channel.getMessagesById([messageId]);
+    return response.messages.firstWhere(
+      (m) => m.id == messageId,
+      orElse: () => throw StateError('Message "$messageId" not found'),
     );
-    if (message == null) {
-      final response = await channel.getMessagesById([messageId]);
-      message = response.messages.first;
+  }
+
+  // Scans cached locations in decreasing hit-likelihood, returning on the
+  // first match. Plain for-loops over `firstWhereOrNull`/`expand` to avoid
+  // per-call closure and iterable allocations.
+  Message? _findCachedMessage(String messageId) {
+    final state = channel.state;
+    if (state == null) return null;
+
+    // Hot path: regular channel messages in the loaded window.
+    for (final message in state.messages) {
+      if (message.id == messageId) return message;
     }
-    return message;
+
+    // Thread replies — only helps when `messageId` is itself a reply; thread
+    // parents live in `state.messages`, not under `state.threads`.
+    for (final replies in state.threads.values) {
+      for (final message in replies) {
+        if (message.id == messageId) return message;
+      }
+    }
+
+    // Pinned messages can sit outside the loaded window, so check them last.
+    for (final message in state.pinnedMessages) {
+      if (message.id == messageId) return message;
+    }
+
+    return null;
   }
 
   /// Query channel members.
@@ -789,6 +843,10 @@ class StreamChannelState extends State<StreamChannel> {
 
     // Otherwise, we first initialize the channel if it's not yet initialized.
     if (channel.state == null) await channel.watch();
+
+    // If the widget was created using the StreamChannel.value constructor,
+    // we skip positioning so the already-loaded channel state is kept intact.
+    if (!widget._shouldPosition) return;
 
     // First we try to load the channel at the initial message if
     // 'initialMessageId' is provided in the widget.


### PR DESCRIPTION
## Summary

Small cluster of related fixes around channel-state isolation and thread-page UX.

- `Channel.getMessagesById` is now a pure fetch — no longer merges the response into `ChannelState.messages`. Resolving a thread parent for an in-channel reply previously injected the parent into the loaded channel window (typically at index 0, since parents predate the loaded window).
- `StreamChannel.getMessage` cache lookup now also scans `state.threads.values` and `state.pinnedMessages` before falling back to the network.
- Added `StreamChannel.value` constructor. Wraps a channel for context access without running channel-page positioning. Use for sub-route or overlay wraps (thread page, info screens, long-press modal, attachment viewer).
- `MessageListCore` no longer reloads the parent channel from its dispose path when the disposing instance is in thread mode.
- `ScrollablePositionedList._startScroll` waits one frame for layout when `itemPositions` is empty. Previously a `scrollTo` invoked right after mount took the dual-controller teleport path even for nearby targets, producing a multi-screen fake-scroll where a short animation was expected. Matches Compose's `LazyListState.animateScrollToItem` (which suspends until first composition).

## Test plan

- [ ] In a channel with a thread that has an in-channel reply, tap "View Thread" on the reply — thread opens at the target without an animated scroll-up, channel window unchanged on pop.
- [ ] Tap a quoted (old) message in the channel, then long-press any message — channel doesn't silently reload to latest behind the modal.
- [ ] Open a thread, pop back — channel's loaded window unchanged.
- [ ] `streamChannel.getMessage(threadReplyId)` for a reply already loaded in `state.threads` resolves from cache (no network call).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to wrap pre-initialized channels while skipping automatic positioning/loading.

* **Bug Fixes**
  * Fetching messages by ID no longer mutates the loaded message window.
  * Fixed premature long-distance scroll behavior immediately after widget mount.
  * Improved message lookup to check multiple in-memory caches before a network fetch.
  * Channel reload now replaces previously loaded messages instead of merging.
  * Prevented channel reloads during disposal for thread views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->