### PR TITLE
chore(repo): sync sample_app version to SDK + add TestFlight internal builds

### DIFF
--- a/.github/workflows/distribute_internal.yml
+++ b/.github/workflows/distribute_internal.yml
@@ -149,3 +149,52 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
         run: bundle exec fastlane distribute_to_firebase
+
+  ios_testflight:
+    needs: determine_platforms
+    if: ${{ needs.determine_platforms.outputs.run_ios == 'true' }}
+    runs-on: macos-15 # Requires xcode 15 or later
+    timeout-minutes: 30
+    steps:
+      - name: Connect Bot
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
+
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
+      - name: "Install Flutter"
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+
+      - name: "Disable Swift Package Manager"
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: "Install Tools"
+        run: flutter pub global activate melos
+
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: sample_app/ios
+
+      - name: Distribute to TestFlight Internal
+        working-directory: sample_app/ios
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
+        run: bundle exec fastlane distribute_to_testflight_internal

--- a/sample_app/ios/fastlane/Fastfile
+++ b/sample_app/ios/fastlane/Fastfile
@@ -120,6 +120,30 @@ platform :ios do
     )
   end
 
+  desc "Build and distribute app to TestFlight Internal Testers with auto-incrementing build number"
+  # Usage: bundle exec fastlane ios distribute_to_testflight_internal
+  lane :distribute_to_testflight_internal do
+    match_me
+
+    current_build_number = latest_testflight_build_number(
+      api_key: appstore_api_key,
+      app_identifier: app_identifier
+    )
+
+    build_number = (current_build_number || 0).to_i + 1
+    build_ipa(export_method: "app-store", build_number: build_number)
+
+    upload_to_testflight(
+      api_key: appstore_api_key,
+      distribute_external: false,
+      notify_external_testers: false,
+      ipa: "#{root_path}/build/ios/ipa/ChatSample.ipa",
+      groups: ['Internal Testers'],
+      changelog: 'Lots of amazing new features to test out!',
+      skip_waiting_for_build_processing: true,
+    )
+  end
+
   desc "Upload iOS dSYMs from the most recent `flutter build ipa` to Firebase Crashlytics"
   private_lane :upload_dsyms_to_crashlytics do
     dsym_zip = zip(

--- a/sample_app/ios/fastlane/Fastfile
+++ b/sample_app/ios/fastlane/Fastfile
@@ -133,6 +133,8 @@ platform :ios do
     build_number = (current_build_number || 0).to_i + 1
     build_ipa(export_method: "app-store", build_number: build_number)
 
+    upload_dsyms_to_crashlytics
+
     upload_to_testflight(
       api_key: appstore_api_key,
       distribute_external: false,

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sample_app
 description: A new Flutter project.
 publish_to: "none"
-version: 2.2.0
+version: 10.0.0
 
 # Note: The environment configuration and dependency versions are managed by Melos.
 #

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sample_app
 description: A new Flutter project.
 publish_to: "none"
-version: 10.0.0
+version: 9.24.0
 
 # Note: The environment configuration and dependency versions are managed by Melos.
 #

--- a/tools/generate_version.dart
+++ b/tools/generate_version.dart
@@ -40,4 +40,23 @@ Future<void> main() async {
   await versionFile.writeAsString(updatedContent);
 
   print('✓ Successfully updated version to $version in $versionFilePath');
+
+  var cleanedVersion = version;
+  if (cleanedVersion.contains('-')) {
+    cleanedVersion = cleanedVersion.split('-').first;
+
+    print('Cleaned version for app: $cleanedVersion');
+  }
+
+  // Update the version in the sample_app pubspec.yaml
+  final sampleAppPubspecPath = p.join(rootDir, 'sample_app', 'pubspec.yaml');
+  final sampleAppPubspec = File(sampleAppPubspecPath).readAsStringSync();
+  final updatedSampleAppPubspec = sampleAppPubspec.replaceFirst(
+    RegExp('version: .+'),
+    'version: $cleanedVersion',
+  );
+
+  await File(sampleAppPubspecPath).writeAsString(updatedSampleAppPubspec);
+
+  print('✓ Successfully updated version to $cleanedVersion in $sampleAppPubspecPath');
 }

--- a/tools/generate_version.dart
+++ b/tools/generate_version.dart
@@ -58,5 +58,6 @@ Future<void> main() async {
 
   await File(sampleAppPubspecPath).writeAsString(updatedSampleAppPubspec);
 
-  print('✓ Successfully updated version to $cleanedVersion in $sampleAppPubspecPath');
+  print(
+      '✓ Successfully updated version to $cleanedVersion in $sampleAppPubspecPath');
 }


### PR DESCRIPTION
## Summary
Cherry-picks two changes from the `v10.0.0` branch onto `master`:

- **#2678** `chore(sample): Set appversion to main sdk version` — `tools/generate_version.dart` now also rewrites `sample_app/pubspec.yaml` to match the `stream_chat` package version. Sample app version bumped from `2.2.0` to `9.24.0` to match master's current SDK.
- **#2508** `add internal testflight builds` — new `distribute_to_testflight_internal` Fastlane lane and `ios_testflight` job in `distribute_internal.yml` that pushes builds to TestFlight's Internal Testers group on every push to `master`.

## Notes
- The `ios_testflight` workflow job was adapted from #2508 to match master's existing `ios` job conventions: added `maxim-lobanov/setup-xcode@v1` (xcode 26.3), added the `Disable Swift Package Manager` step, and removed the redundant `cache: true` flag.
- Dropped the `# TODO: Remove once feat/design-refresh is merged to master` comment from the workflow — it's moot now that this lives on master.
- The two trivial `docs_screenshots` formatting tweaks from #2678 were skipped — those files were deleted on master.

## Test plan
- [ ] CI passes (`distribute_internal.yml` should validate)
- [ ] Verify `dart run tools/generate_version.dart` updates both `version.dart` and `sample_app/pubspec.yaml`
- [ ] On next push to `master`, confirm the `ios_testflight` job successfully uploads to TestFlight Internal Testers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated iOS TestFlight distribution for internal beta testers (via CI + build lane).
  * Improved version propagation to ensure a cleaned/consistent version string across build tooling.

* **Version**
  * App version updated to 9.24.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->