### PR TITLE
fix(ui): map xxl avatar to xxl online indicator size

### DIFF
--- a/docs/docs_screenshots/pubspec.yaml
+++ b/docs/docs_screenshots/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
+      ref: 73ce5122a2f57e6106f35e95a2482bde0136a8e0
       path: packages/stream_core_flutter
 
 dev_dependencies:

--- a/docs/docs_screenshots/pubspec.yaml
+++ b/docs/docs_screenshots/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 333f7b72485f308b282cc85973223a2919fd8153
+      ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
       path: packages/stream_core_flutter
 
 dev_dependencies:

--- a/melos.yaml
+++ b/melos.yaml
@@ -102,7 +102,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
+          ref: 73ce5122a2f57e6106f35e95a2482bde0136a8e0
           path: packages/stream_core_flutter
       synchronized: ^3.4.0
       thumblr: ^0.0.4

--- a/melos.yaml
+++ b/melos.yaml
@@ -102,7 +102,7 @@ command:
       stream_core_flutter:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: 333f7b72485f308b282cc85973223a2919fd8153
+          ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
           path: packages/stream_core_flutter
       synchronized: ^3.4.0
       thumblr: ^0.0.4

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 🐞 Fixed
 
+- `StreamUserAvatar` with `StreamAvatarSize.xxl` now uses `StreamOnlineIndicatorSize.xxl` (20px) instead of `xl` (16px), matching the Chat SDK design system spec.
 - `StreamMessageComposer` no longer clobbers pre-populated composer state (text, quoted message, attachments) when the channel's draft stream emits its initial `null` (no draft on server). The reset now fires only on an actual non-null → null transition, distinguishing "no draft yet" from "draft was removed".
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/components/avatar/stream_user_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/components/avatar/stream_user_avatar.dart
@@ -135,7 +135,8 @@ class StreamUserAvatar extends StatelessWidget {
     .xs || .sm => StreamOnlineIndicatorSize.sm,
     .md => StreamOnlineIndicatorSize.md,
     .lg => StreamOnlineIndicatorSize.lg,
-    .xl || .xxl => StreamOnlineIndicatorSize.xl,
+    .xl => StreamOnlineIndicatorSize.xl,
+    .xxl => StreamOnlineIndicatorSize.xxl,
   };
 }
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
+      ref: 73ce5122a2f57e6106f35e95a2482bde0136a8e0
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.4.0

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 333f7b72485f308b282cc85973223a2919fd8153
+      ref: 9baab9b1c0e3e90f0cc815f785ca5ca45e11ee99
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.4.0

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   stream_core_flutter:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 9baab9b1c0e3e90f0cc815f785ca5ca45e11ee99
+      ref: a3876a69673d362a60c3c1655a84acbb07dff3d4
       path: packages/stream_core_flutter
   svg_icon_widget: ^0.0.1
   synchronized: ^3.4.0


### PR DESCRIPTION
## Summary

- Splits the `_indicatorSizeForAvatarSize` mapping in `StreamUserAvatar` so `.xxl` maps to the new `StreamOnlineIndicatorSize.xxl` (20px) instead of `xl` (16px).
- Bumps `stream_core_flutter` git ref to pick up the new size variant.

Fixes the online indicator dimensions on the xxl avatar (Contact Info screen) — [per spec](https://www.figma.com/design/Us73erK1xFNcB5EH3hyq6Y/Chat-SDK-Design-System?node-id=3035-67272&t=5HK2KaS8jo6s7ZOW-11): 20px diameter, 2px inner border.

Depends on https://github.com/GetStream/stream-core-flutter/pull/116 — the `stream_core_flutter` ref should be moved to `main` once that PR merges.

## Test plan

- [ ] Verify the indicator renders at 20px diameter with a 2px inner border on `StreamUserAvatar` with `StreamAvatarSize.xxl`
- [ ] `melos run analyze`

🤖 Generated with [Claude Code](https://claude.com/claude-code)