### PR TITLE
demo: test check_db_entities workflow (do not merge)

### DIFF
--- a/.github/workflows/check_db_entities.yml
+++ b/.github/workflows/check_db_entities.yml
@@ -1,11 +1,19 @@
 name: check_db_entities
 
 on:
-  pull_request:
+  pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Under pull_request_target, github.ref is the base branch, so we use
+  # the PR number to keep each PR's runs isolated.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+# pull_request_target gives a write token even for fork PRs, but only
+# if we explicitly request the scopes here.
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   # Centralizes every gating decision for this workflow — currently just a
@@ -47,11 +55,17 @@ jobs:
           ENTITY_DIR="packages/stream_chat_persistence/lib/src/entity"
           TEMP_FILE="modified_entities"
           BASE_BRANCH="${{ github.base_ref }}"
+          PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           echo "Using base branch: origin/$BASE_BRANCH for comparison"
 
+          # Fetch the PR head SHA as a ref only — no working-tree update,
+          # so no smudge filters / hooks run on PR-controlled files
+          # while we hold the write token.
+          git fetch --no-tags --depth=1 origin "$PR_HEAD_SHA"
+
           # Check if any entity files have changed compared to the base branch
-          git diff-index --name-only origin/$BASE_BRANCH -- $ENTITY_DIR | grep -E '\.dart$' > $TEMP_FILE || true
+          git diff --name-only "origin/$BASE_BRANCH...$PR_HEAD_SHA" -- $ENTITY_DIR | grep -E '\.dart$' > $TEMP_FILE || true
 
           if [ ! -s "$TEMP_FILE" ]; then
             echo "✅ No entity files changed."

--- a/packages/stream_chat_persistence/lib/src/entity/channels.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/channels.dart
@@ -1,4 +1,5 @@
 // coverage:ignore-file
+// demo: triggering check_db_entities workflow (revert before merge).
 import 'package:drift/drift.dart';
 import 'package:stream_chat_persistence/src/converter/converter.dart';
 


### PR DESCRIPTION
## Purpose

Same-repo demo PR to smoke-test the updated `check_db_entities` workflow from #2714. Targets the fix branch directly so the workflow file with the new logic is what runs.

**Do not merge.** Close after verification.

## What this validates

- Workflow runs without error under `pull_request_target`
- New diff strategy (fetch PR head SHA, `git diff base...pr_head`) correctly identifies the modified entity file
- Concurrency key is unique per PR
- Bot comment is posted

## What this does NOT validate

- The actual fork-token fix. Same-repo PRs always had write tokens under `pull_request`, so this can't reproduce the original 403. Only a real fork PR can validate that side of the change.

## Expected behaviour

The bot should post a "Database Entity Files Modified" comment listing `packages/stream_chat_persistence/lib/src/entity/channels.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)