### PR TITLE
fix(persistence): Ensure `messageLimit` is respected in `getChannelStates`

### DIFF
--- a/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
+++ b/packages/stream_chat_persistence/lib/src/stream_chat_persistence_client.dart
@@ -335,7 +335,11 @@ class StreamChatPersistenceClient extends ChatPersistenceClient {
     final pagedCids = envelopes.skip(offset).take(limit).map((s) => s.channel!.cid).toList();
 
     // 6) Hydrate ONLY the page.
-    return Future.wait(pagedCids.map(getChannelStateByCid));
+    final messagePagination = PaginationParams(
+      // Default limit is set to 25 in backend.
+      limit: messageLimit ?? 25,
+    );
+    return Future.wait(pagedCids.map((cid) => getChannelStateByCid(cid, messagePagination: messagePagination)));
   }
 
   @override

--- a/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
+++ b/packages/stream_chat_persistence/test/stream_chat_persistence_client_test.dart
@@ -323,10 +323,14 @@ void main() {
             lastReadMessageId: 'lastMessageId$i',
           ),
         );
+        const messageLimit = 25;
+        const messagePagination = PaginationParams(limit: messageLimit);
         when(() => mockDatabase.channelDao.getChannelByCid(pagedCid)).thenAnswer((_) async => c2);
         when(() => mockDatabase.memberDao.getMembersByCid(pagedCid)).thenAnswer((_) async => members);
         when(() => mockDatabase.readDao.getReadsByCid(pagedCid)).thenAnswer((_) async => reads);
-        when(() => mockDatabase.messageDao.getMessagesByCid(pagedCid)).thenAnswer((_) async => messages);
+        when(
+          () => mockDatabase.messageDao.getMessagesByCid(pagedCid, messagePagination: messagePagination),
+        ).thenAnswer((_) async => messages);
         when(() => mockDatabase.pinnedMessageDao.getMessagesByCid(pagedCid)).thenAnswer((_) async => messages);
         when(() => mockDatabase.draftMessageDao.getDraftMessageByCid(pagedCid)).thenAnswer((_) async => null);
 
@@ -335,6 +339,7 @@ void main() {
           channelStateSort: const [
             SortOption<ChannelState>.desc(ChannelSortKey.pinnedAt),
           ],
+          messageLimit: messageLimit,
           paginationParams: const PaginationParams(offset: 1, limit: 1),
         );
 
@@ -357,6 +362,11 @@ void main() {
         verify(() => mockDatabase.channelDao.getChannelByCid(pagedCid)).called(1);
         verifyNever(() => mockDatabase.channelDao.getChannelByCid('messaging:c0'));
         verifyNever(() => mockDatabase.channelDao.getChannelByCid('messaging:c1'));
+
+        // messageLimit forwarded as PaginationParams to the message DAO.
+        verify(
+          () => mockDatabase.messageDao.getMessagesByCid(pagedCid, messagePagination: messagePagination),
+        ).called(1);
       });
 
       test('returns empty list and skips hydration when no channels match', () async {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The `messageLimit` handling in the `StreamChatPersistenceClient#getChannelStates` was lost, most likely when merging `master` (with DB read optimisations) into `v10.0.0`. This PR restores the logic for forwarding the `messageLimit` to the `getChannelStateByCid` method.

## Screenshots / Videos
_NA_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved message pagination handling in channel conversations. When accessing paginated channels, message limits are now explicitly configured and applied during state loading, ensuring consistent and predictable behavior. Pagination settings are properly forwarded through all retrieval processes, with comprehensive testing to verify correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->