### PR TITLE
chore(deps): bump jiffy to ^6.4.5

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -56,7 +56,7 @@ command:
       http_parser: ^4.0.2
       image_picker: ^1.1.2
       image_size_getter: ^2.3.0
-      jiffy: ^6.2.1
+      jiffy: ^6.4.5
       jose: ^0.3.5+1
       json_annotation: ^4.9.0
       just_audio: ">=0.9.38 <0.11.0"

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -19,6 +19,8 @@
 - `ScrollablePositionedList.padding` now accepts `EdgeInsetsGeometry` (resolved against
   `Directionality`), and `scrollTo` lands the target at the content-area edge by adjusting for
   leading padding.
+- Bumped `jiffy` to `^6.4.5` to pick up cached locale and `DateFormat` lookups for cheaper
+  relative-time formatting.
 
 ## 9.24.0
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   http_parser: ^4.0.2
   image_picker: ^1.1.2
   image_size_getter: ^2.3.0
-  jiffy: ^6.2.1
+  jiffy: ^6.4.5
   just_audio: ">=0.9.38 <0.11.0"
   lottie: ^3.1.2
   media_kit: ^1.2.2


### PR DESCRIPTION
## Summary
- Bumps `jiffy` from `^6.2.1` to `^6.4.5` in both `melos.yaml` and `packages/stream_chat_flutter/pubspec.yaml`.
- Picks up the cached locale and `DateFormat` lookup work in [jama5262/jiffy#332](https://github.com/jama5262/jiffy/pull/332), which makes relative-time formatting cheaper.

## Test plan
- [ ] `melos bootstrap`
- [ ] `melos run lint:all`
- [ ] `melos run test:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the `jiffy` dependency to enhance relative-time formatting performance throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->