### PR TITLE
chore(deps): bump jiffy to ^6.4.5

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -68,7 +68,7 @@ command:
       http_parser: ^4.1.2
       image_picker: ^1.2.2
       image_size_getter: ^2.4.1
-      jiffy: ^6.4.4
+      jiffy: ^6.4.5
       jose: ^0.3.5+1
       json_annotation: ^4.11.0
       just_audio: ^0.10.5

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Composer UI primitives (`StreamMessageComposerInputField`, `VoiceRecordingCallback`, and the outer/inner layout containers) are now owned by `stream_chat_flutter` and exported from this package. They were previously supplied by `stream_core_flutter`. The public API of `StreamMessageComposer` / `StreamChatMessageInput` and its sub-components is unchanged.
 - Re-export `StreamAvatarTheme` and `StreamAvatarThemeData` from `stream_core_flutter` so consumers can theme avatars without adding a separate `stream_core_flutter` import.
 - Added `messageLeading`, `messageHeader`, and `messageFooter` factory slots to `streamChatComponentBuilders` for overriding the message item's avatar, annotations, or metadata row without replacing the whole `messageItem`.
+- Bumped `jiffy` to `^6.4.5` to pick up cached locale and `DateFormat` lookups for cheaper relative-time formatting.
 
 🛑️ Breaking
 

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   http_parser: ^4.1.2
   image_picker: ^1.2.2
   image_size_getter: ^2.4.1
-  jiffy: ^6.4.4
+  jiffy: ^6.4.5
   just_audio: ^0.10.5
   lottie: ^3.3.3
   media_kit: ^1.2.6


### PR DESCRIPTION
## Summary
- Bumps `jiffy` from `^6.4.4` to `^6.4.5` in `melos.yaml` and `packages/stream_chat_flutter/pubspec.yaml`.
- Picks up the cached locale and `DateFormat` lookup work in [jama5262/jiffy#332](https://github.com/jama5262/jiffy/pull/332), making relative-time formatting cheaper.

Targets `v10.0.0` because jiffy 6.4.x requires `intl ^0.20.2`, which only resolves against the Flutter SDK floor on this branch (`>=3.38.1`); `master` is still pinned at `>=3.27.4` (intl 0.19.0).

## Test plan
- [ ] `melos bootstrap`
- [ ] `melos run lint:all`
- [ ] `melos run test:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)