### PR TITLE
ci(repo): skip sample app build when targeting master

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -167,7 +167,7 @@ jobs:
     name: build (${{ matrix.platform }})
     needs: gate
     runs-on: ${{ matrix.os }}
-    if: needs.gate.outputs.should_run == 'true'
+    if: needs.gate.outputs.should_run == 'true' && github.event_name == 'pull_request'
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

PR builds already cover pre-merge validation, and `distribute_internal` builds (and ships) both platforms on every master push — so running the sample app `build` matrix again on master push is duplicate work.

The build job now runs only on `pull_request` events. Since the workflow only triggers `push` on master, this leaves PR builds untouched and skips the redundant master-push build.

```yaml
if: needs.gate.outputs.should_run == 'true' && github.event_name == 'pull_request'
```

| Trigger | Outcome |
|---|---|
| Push to master | skip |
| PR → master | run |
| PR → v10.0.0 | run |

## Test plan

- [ ] After merge, the next master push leaves `build (android)` and `build (ios)` skipped.
- [ ] PRs (any target) still trigger both build jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)