### PR TITLE
fix(ci): add multi_json to sample_app Gemfiles

### DIFF
--- a/sample_app/android/Gemfile
+++ b/sample_app/android/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "multi_json"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/sample_app/ios/Gemfile
+++ b/sample_app/ios/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "cocoapods"
+gem "multi_json"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)


### PR DESCRIPTION
## Summary

- Sample-app Android & iOS builds started failing on PRs with `bundler: failed to load command: fastlane … multi_json is not part of the bundle.`
- Root cause: `representable` (pulled in transitively by `fastlane → google-apis-playcustomapp_v1 → google-apis-core`) does `require 'multi_json'` but no longer declares it as a runtime dep. With no `Gemfile.lock` in the repo, each CI run resolves fresh from rubygems, and a recently published gem version dropped `multi_json` from the transitive chain. Ruby 3.3's stricter bundle enforcement then turns the missing gem into a hard `LoadError`.
- Fix: declare `gem "multi_json"` explicitly in both `sample_app/android/Gemfile` and `sample_app/ios/Gemfile`.

This is latent on `master` (build job is skipped on push) and currently surfacing on PRs targeting `v10.0.0` (e.g. #2716, #2679). Landing on `master` and merging down to `v10.0.0` unblocks both.

## Test plan

- [ ] CI `build (android)` passes on this PR
- [ ] CI `build (ios)` passes on this PR
- [ ] After merge, rebase/merge `master` into `v10.0.0` and confirm #2716 builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `multi_json` dependency to Android and iOS build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->