### PR TITLE
fix(ui): wire onUserAvatarTap on StreamMessageItem

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+🐞 Fixed
+
+- `StreamMessageItem.onUserAvatarTap` now fires when the author avatar is tapped. ([#2741](https://github.com/GetStream/stream-chat-flutter/issues/2741))
+
 ## 10.0.1
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_leading.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_leading.dart
@@ -21,7 +21,11 @@ import 'package:stream_core_flutter/stream_core_flutter.dart' as core;
 ///  * [StreamMessageFooter], the metadata slot below the bubble.
 class StreamMessageLeading extends core.NullableStatelessWidget {
   /// Creates a message leading slot for the given [message].
-  StreamMessageLeading({super.key, required Message message}) : props = .new(message: message);
+  StreamMessageLeading({
+    super.key,
+    required Message message,
+    VoidCallback? onTap,
+  }) : props = .new(message: message, onTap: onTap);
 
   /// Creates a message leading slot from pre-built [props].
   const StreamMessageLeading.fromProps({super.key, required this.props});
@@ -45,15 +49,23 @@ class StreamMessageLeading extends core.NullableStatelessWidget {
 ///  * [DefaultStreamMessageLeading], the default implementation.
 class StreamMessageLeadingProps {
   /// Creates properties for a message leading slot.
-  const StreamMessageLeadingProps({required this.message});
+  const StreamMessageLeadingProps({required this.message, this.onTap});
 
   /// The message whose author avatar to display.
   final Message message;
 
+  /// Called when the leading avatar is tapped.
+  ///
+  /// If null, the avatar is not tappable.
+  final VoidCallback? onTap;
+
   /// Returns a copy of this [StreamMessageLeadingProps] with the given fields
   /// replaced with new values.
-  StreamMessageLeadingProps copyWith({Message? message}) {
-    return StreamMessageLeadingProps(message: message ?? this.message);
+  StreamMessageLeadingProps copyWith({Message? message, VoidCallback? onTap}) {
+    return StreamMessageLeadingProps(
+      message: message ?? this.message,
+      onTap: onTap ?? this.onTap,
+    );
   }
 }
 
@@ -79,9 +91,14 @@ class DefaultStreamMessageLeading extends core.NullableStatelessWidget {
     final theme = core.StreamMessageItemTheme.of(context);
     final avatarSize = theme.avatarSize ?? StreamAvatarSize.md;
 
+    Widget avatar = StreamUserAvatar(user: user, showOnlineIndicator: false);
+    if (props.onTap case final onTap?) {
+      avatar = GestureDetector(behavior: .opaque, onTap: onTap, child: avatar);
+    }
+
     return core.StreamAvatarTheme(
       data: .new(size: avatarSize),
-      child: StreamUserAvatar(user: user, showOnlineIndicator: false),
+      child: avatar,
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_leading.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_leading.dart
@@ -61,7 +61,10 @@ class StreamMessageLeadingProps {
 
   /// Returns a copy of this [StreamMessageLeadingProps] with the given fields
   /// replaced with new values.
-  StreamMessageLeadingProps copyWith({Message? message, VoidCallback? onTap}) {
+  StreamMessageLeadingProps copyWith({
+    Message? message,
+    VoidCallback? onTap,
+  }) {
     return StreamMessageLeadingProps(
       message: message ?? this.message,
       onTap: onTap ?? this.onTap,

--- a/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
@@ -429,7 +429,13 @@ class DefaultStreamMessageItem extends StatelessWidget {
     final effectiveRepliesVisibility = resolve((theme) => theme?.repliesVisibility);
 
     final leadingWidget = effectiveAvatarVisibility.apply(
-      StreamMessageLeading(message: message),
+      StreamMessageLeading(
+        message: message,
+        onTap: switch ((props.onUserAvatarTap, message.user)) {
+          (final onTap?, final user?) => () => onTap(user),
+          _ => null,
+        },
+      ),
     );
 
     final headerWidget = effectiveAnnotationVisibility.apply(

--- a/packages/stream_chat_flutter/test/src/message_widget/stream_message_leading_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_widget/stream_message_leading_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+void main() {
+  Future<void> pumpLeading(
+    WidgetTester tester, {
+    required Message message,
+    VoidCallback? onTap,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: StreamChatTheme(
+          data: StreamChatThemeData(),
+          child: Scaffold(
+            body: Center(
+              child: StreamMessageLeading(
+                message: message,
+                onTap: onTap,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'invokes onTap when the avatar is tapped',
+    (tester) async {
+      var tapCount = 0;
+      final message = Message(
+        text: 'hello',
+        user: User(id: 'u1', name: 'Alice'),
+      );
+
+      await pumpLeading(
+        tester,
+        message: message,
+        onTap: () => tapCount++,
+      );
+
+      await tester.tap(find.byType(StreamUserAvatar));
+      expect(tapCount, 1);
+    },
+  );
+
+  testWidgets(
+    'does nothing when onTap is null',
+    (tester) async {
+      final message = Message(
+        text: 'hello',
+        user: User(id: 'u1', name: 'Alice'),
+      );
+
+      await pumpLeading(tester, message: message);
+
+      await tester.tap(find.byType(StreamUserAvatar));
+      // No GestureDetector should be wrapping the avatar when onTap is null.
+      expect(
+        find.descendant(
+          of: find.byType(StreamMessageLeading),
+          matching: find.byType(GestureDetector),
+        ),
+        findsNothing,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Fixes #2741: `onUserAvatarTap` set on `StreamMessageItem` was a no-op because `DefaultStreamMessageItem` never wired a tap handler onto the leading avatar.
- Added `onTap: VoidCallback?` to `StreamMessageLeadingProps`. `DefaultStreamMessageLeading` now wraps the avatar in a `GestureDetector(behavior: opaque)` when `onTap` is set.
- `DefaultStreamMessageItem` now passes a closure into the leading that invokes `onUserAvatarTap` with `message.user` when both are non-null. Visibility wrapping is unchanged, so `gone` / `hidden` semantics still apply.
- `onTap` is intentionally a `VoidCallback?` on the slot rather than `void Function(User)?` — the leading is a generic slot and custom builders may render non-avatar content (timestamps, status badges, etc.). Avatar-specific semantics belong on `DefaultStreamMessageItem`, which owns `onUserAvatarTap`.

## Test plan

- [x] `dart analyze --fatal-infos` on `stream_chat_flutter` — no issues
- [x] `melos run format` — no files changed
- [x] New widget test in `test/src/message_widget/stream_message_leading_test.dart` covering tap-fires-callback and null-callback-no-op cases — both pass
- [ ] Manual repro from the issue: register a `messageItem` builder with `onUserAvatarTap`, tap the avatar, confirm the callback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `onUserAvatarTap` callback to properly trigger when users tap message author avatars (issue `#2741`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->