### PR TITLE
docs(repo): sync tutorial example with website tutorial

### DIFF
--- a/packages/stream_chat_flutter/example/lib/tutorial_part_1.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_1.dart
@@ -33,16 +33,22 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// If you now run the simulator you will see a single channel UI.
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
-  final channel = client.channel('messaging', id: 'flutterdevs');
+  final channel = client.channel(
+    'messaging',
+    id: 'flutterdevs',
+    extraData: const {
+      'members': ['tutorial-flutter'],
+    },
+  );
 
   await channel.watch();
 
@@ -93,7 +99,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_2.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_2.dart
@@ -31,13 +31,13 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// message is added to a channel.
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
   runApp(
@@ -95,7 +95,11 @@ class _ChannelListPageState extends State<ChannelListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: const StreamChannelListHeader(),
       body: StreamChannelListView(
         controller: _controller,
         onChannelTap: (channel) => Navigator.push(
@@ -120,7 +124,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_3.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_3.dart
@@ -32,13 +32,13 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// - We retrieve the count of unread messages from [Channel.state]
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
   runApp(
@@ -99,7 +99,11 @@ class _ChannelListPageState extends State<ChannelListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: const StreamChannelListHeader(),
       body: StreamChannelListView(
         controller: _listController,
         itemBuilder: _channelTileBuilder,
@@ -174,7 +178,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_4.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_4.dart
@@ -18,13 +18,13 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// message, you can tap on "Reply" and it will open the same [ThreadPage].
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
   runApp(
@@ -84,21 +84,27 @@ class _ChannelListPageState extends State<ChannelListPage> {
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-    body: StreamChannelListView(
-      controller: _listController,
-      onChannelTap: (channel) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => StreamChannel(
-              channel: channel,
-              child: const ChannelPage(),
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: const StreamChannelListHeader(),
+      body: StreamChannelListView(
+        controller: _listController,
+        onChannelTap: (channel) {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => StreamChannel(
+                channel: channel,
+                child: const ChannelPage(),
+              ),
             ),
-          ),
-        );
-      },
-    ),
-  );
+          );
+        },
+      ),
+    );
+  }
 }
 
 /// Displays the list of messages inside the channel.
@@ -109,7 +115,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[
@@ -154,10 +163,11 @@ class _ThreadPageState extends State<ThreadPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
-      appBar: StreamThreadHeader(
-        parent: widget.parent,
-      ),
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: StreamThreadHeader(parent: widget.parent),
       body: Column(
         children: <Widget>[
           Expanded(

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_5.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_5.dart
@@ -23,13 +23,13 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// outer scope needed such as messages from the [Channel.state].
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
   runApp(
@@ -90,7 +90,11 @@ class _ChannelListPageState extends State<ChannelListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: const StreamChannelListHeader(),
       body: StreamChannelListView(
         controller: _listController,
         onChannelTap: (channel) {
@@ -116,7 +120,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
@@ -4,28 +4,26 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Sixth step of the [tutorial](https://getstream.io/chat/flutter/tutorial/)
 ///
-/// The Flutter SDK comes with a fully designed set of widgets which you can
-/// customize to fit with your application style and typography.
-/// Changing the theme of Chat widgets works in a very similar way that
-/// [MaterialApp] and [Theme] do.
+/// The Flutter SDK ships fully designed widgets that you can theme to match
+/// your app. Theming works in two layers:
 ///
-/// All chat widgets use their own default styling out of the box. There are
-/// two ways to change the styling:
+/// 1. Design tokens — a [StreamTheme] registered as a [ThemeData] extension.
+///    Set a brand color here and Stream derives the rest of its semantic
+///    palette from the swatch automatically.
+/// 2. Per-widget overrides — a [StreamChatThemeData] passed via
+///    [StreamChat.themeData]. Tweak individual components without touching
+///    the rest of the theme.
 ///
-/// 1. Initialize the [StreamChatTheme] from your existing [MaterialApp] style
-/// 2. Construct a custom theme and provide all the customizations needed
+/// First, we register a [StreamTheme] on both [MaterialApp.theme] and
+/// [MaterialApp.darkTheme] with a custom green brand swatch. Message
+/// bubbles, sending indicators, unread badges, the composer cursor, and
+/// other accents pick up the new tone in one go.
 ///
-/// First, we create a new Material [Theme] and pick [Colors.green] as the
-/// swatch color. The theme is then passed to [MaterialApp] as usual.
-///
-/// Then, we create a new [StreamChatTheme] from the green theme we just
-/// created. After saving the app you will see that several widgets have
-/// been updated with the new color.
-///
-/// We also change the message color posted by the current user.
-///
-/// You can perform these more granular style changes using
-/// [StreamChatTheme.copyWith].
+/// On top of that, we build a [StreamChatThemeData] override for
+/// [StreamChatThemeData.channelListItemTheme]: bold titles and a
+/// light-green tile background that reuses `greenBrand.shade100`, the
+/// same shade Stream uses for outgoing message bubbles, so the channel
+/// list and the message list share the same green tone.
 Future<void> main() async {
   final client = StreamChatClient(
     'b67pax5b2wdq',
@@ -61,12 +59,7 @@ class MyApp extends StatelessWidget {
     final customTheme = StreamChatThemeData(
       channelListItemTheme: StreamChannelListItemThemeData(
         titleStyle: const TextStyle(fontWeight: FontWeight.bold),
-        backgroundColor: WidgetStateProperty.resolveWith((states) {
-          if (states.contains(WidgetState.selected)) {
-            return Colors.green.shade100;
-          }
-          return null;
-        }),
+        backgroundColor: WidgetStateProperty.all(greenBrand.shade100),
       ),
     );
 

--- a/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
+++ b/packages/stream_chat_flutter/example/lib/tutorial_part_6.dart
@@ -28,13 +28,13 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 /// [StreamChatTheme.copyWith].
 Future<void> main() async {
   final client = StreamChatClient(
-    's2dxdhpxd94g',
+    'b67pax5b2wdq',
     logLevel: Level.INFO,
   );
 
   await client.connectUser(
-    User(id: 'super-band-9'),
-    '''eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic3VwZXItYmFuZC05In0.0L6lGoeLwkz0aZRUcpZKsvaXtNEDHBcezVTZ0oPq40A''',
+    User(id: 'tutorial-flutter'),
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidHV0b3JpYWwtZmx1dHRlciJ9.S-MJpoSwDiqyXpUURgO5wVqJ4vKlIVFLSEyrFYCOE1c''',
   );
 
   runApp(
@@ -128,7 +128,11 @@ class _ChannelListPageState extends State<ChannelListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
+      appBar: const StreamChannelListHeader(),
       body: StreamChannelListView(
         controller: _listController,
         onChannelTap: (channel) {
@@ -154,7 +158,10 @@ class ChannelPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: const StreamChannelHeader(),
       body: Column(
         children: <Widget>[
@@ -199,7 +206,10 @@ class _ThreadPageState extends State<ThreadPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.backgroundApp,
       appBar: StreamThreadHeader(
         parent: widget.parent,
       ),


### PR DESCRIPTION
## Summary
- Aligns the six `tutorial_part_*.dart` example files with the refreshed Flutter Chat tutorial on getstream.io ([website PR](https://github.com/GetStream/getstream.io/pull/229)).
- Same demo creds across both surfaces (`tutorial-flutter` / `b67pax5b2wdq`) so readers see consistent channel state.
- `extraData.members` on first channel creation in part 1 — `.watch()` alone makes you a watcher but not a member, and part 2's member-filtered `StreamChannelListController` query needs you in the channel's `members` list to surface it.
- Every `ChannelListPage` Scaffold gains `appBar: StreamChannelListHeader()` to match the screenshot and pair with the existing `StreamChannelHeader` on channel pages.
- Every Scaffold's `backgroundColor` is `context.streamColorScheme.backgroundApp` so the chrome blends with Stream's theme tokens.

## Test plan
- [ ] `cd packages/stream_chat_flutter/example && flutter run lib/tutorial_part_1.dart` — channel renders with the new background tint.
- [ ] After part 1 runs once, `flutter run lib/tutorial_part_2.dart` — `flutterdevs` shows up in the channel list (proves the `extraData.members` fix).
- [ ] Run parts 3–6 — each shows the `StreamChannelListHeader` at the top of the list screen, and the tinted Scaffold background throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all tutorial examples with refreshed demo user credentials and expanded example setup (includes illustrative channel/member data) for clearer, up-to-date guidance.

* **Style**
  * Unified tutorial screen appearances by deriving scaffold background colors from the app color scheme.
  * Standardized one list item theme to a fixed brand tint for more consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->