### PR TITLE
fix(llc): Fix `UpsertPushPreferencesResponse` null values parsing

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed failing to parse `null` values in `UpsertPushPreferencesResponse.userPreferences` JSON.
+
 ## 9.25.0
 
 - Minor bug fixes and improvements

--- a/packages/stream_chat/lib/src/core/api/responses.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.dart
@@ -53,8 +53,7 @@ class ErrorResponse extends _BaseResponse {
   Map<String, dynamic> toJson() => _$ErrorResponseToJson(this);
 
   @override
-  String toString() =>
-      'ErrorResponse(code: $code, '
+  String toString() => 'ErrorResponse(code: $code, '
       'message: $message, '
       'statusCode: $statusCode, '
       'moreInfo: $moreInfo)';
@@ -851,9 +850,7 @@ class UpsertPushPreferencesResponse extends _BaseResponse {
       _$UpsertPushPreferencesResponseFromJson(json);
 }
 
-Map<String, PushPreference> _userPreferencesFromJson(
-  Map<String, dynamic>? json,
-) {
+Map<String, PushPreference> _userPreferencesFromJson(Map<String, dynamic>? json) {
   if (json == null) return {};
   return {
     for (final MapEntry(:key, :value) in json.entries)

--- a/packages/stream_chat/lib/src/core/api/responses.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.dart
@@ -850,7 +850,9 @@ class UpsertPushPreferencesResponse extends _BaseResponse {
       _$UpsertPushPreferencesResponseFromJson(json);
 }
 
-Map<String, PushPreference> _userPreferencesFromJson(Map<String, dynamic>? json) {
+Map<String, PushPreference> _userPreferencesFromJson(
+  Map<String, dynamic>? json,
+) {
   if (json == null) return {};
   return {
     for (final MapEntry(:key, :value) in json.entries)

--- a/packages/stream_chat/lib/src/core/api/responses.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.dart
@@ -834,8 +834,11 @@ class GetUnreadCountResponse extends _BaseResponse {
 /// Model response for [StreamChatClient.setPushPreferences] api call
 @JsonSerializable(createToJson: false)
 class UpsertPushPreferencesResponse extends _BaseResponse {
-  /// Mapping of user IDs to their push preferences
-  @JsonKey(defaultValue: {})
+  /// Mapping of user IDs to their push preferences.
+  ///
+  /// Users whose user-global preferences were not touched by the upsert call
+  /// (the server returns `null` for them) are omitted from this map.
+  @JsonKey(fromJson: _userPreferencesFromJson)
   late Map<String, PushPreference> userPreferences;
 
   /// Mapping of user IDs to their channel-specific push preferences
@@ -845,4 +848,12 @@ class UpsertPushPreferencesResponse extends _BaseResponse {
   /// Create a new instance from a json
   static UpsertPushPreferencesResponse fromJson(Map<String, dynamic> json) =>
       _$UpsertPushPreferencesResponseFromJson(json);
+}
+
+Map<String, PushPreference> _userPreferencesFromJson(Map<String, dynamic>? json) {
+  if (json == null) return {};
+  return {
+    for (final MapEntry(:key, :value) in json.entries)
+      if (value != null) key: PushPreference.fromJson(value as Map<String, dynamic>),
+  };
 }

--- a/packages/stream_chat/lib/src/core/api/responses.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.dart
@@ -53,7 +53,8 @@ class ErrorResponse extends _BaseResponse {
   Map<String, dynamic> toJson() => _$ErrorResponseToJson(this);
 
   @override
-  String toString() => 'ErrorResponse(code: $code, '
+  String toString() =>
+      'ErrorResponse(code: $code, '
       'message: $message, '
       'statusCode: $statusCode, '
       'moreInfo: $moreInfo)';
@@ -850,10 +851,13 @@ class UpsertPushPreferencesResponse extends _BaseResponse {
       _$UpsertPushPreferencesResponseFromJson(json);
 }
 
-Map<String, PushPreference> _userPreferencesFromJson(Map<String, dynamic>? json) {
+Map<String, PushPreference> _userPreferencesFromJson(
+  Map<String, dynamic>? json,
+) {
   if (json == null) return {};
   return {
     for (final MapEntry(:key, :value) in json.entries)
-      if (value != null) key: PushPreference.fromJson(value as Map<String, dynamic>),
+      if (value != null)
+        key: PushPreference.fromJson(value as Map<String, dynamic>),
   };
 }

--- a/packages/stream_chat/lib/src/core/api/responses.g.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.g.dart
@@ -25,90 +25,99 @@ Map<String, dynamic> _$ErrorResponseToJson(ErrorResponse instance) =>
 
 SyncResponse _$SyncResponseFromJson(Map<String, dynamic> json) => SyncResponse()
   ..duration = json['duration'] as String?
-  ..events = (json['events'] as List<dynamic>?)
+  ..events =
+      (json['events'] as List<dynamic>?)
           ?.map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList() ??
       [];
 
 QueryChannelsResponse _$QueryChannelsResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryChannelsResponse()
-      ..duration = json['duration'] as String?
-      ..channels = (json['channels'] as List<dynamic>?)
-              ?.map((e) => ChannelState.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => QueryChannelsResponse()
+  ..duration = json['duration'] as String?
+  ..channels =
+      (json['channels'] as List<dynamic>?)
+          ?.map((e) => ChannelState.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 TranslateMessageResponse _$TranslateMessageResponseFromJson(
-        Map<String, dynamic> json) =>
-    TranslateMessageResponse()
-      ..duration = json['duration'] as String?
-      ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => TranslateMessageResponse()
+  ..duration = json['duration'] as String?
+  ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
 
 QueryMembersResponse _$QueryMembersResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryMembersResponse()
-      ..duration = json['duration'] as String?
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => QueryMembersResponse()
+  ..duration = json['duration'] as String?
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 PartialUpdateMemberResponse _$PartialUpdateMemberResponseFromJson(
-        Map<String, dynamic> json) =>
-    PartialUpdateMemberResponse()
-      ..duration = json['duration'] as String?
-      ..channelMember =
-          Member.fromJson(json['channel_member'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => PartialUpdateMemberResponse()
+  ..duration = json['duration'] as String?
+  ..channelMember = Member.fromJson(
+    json['channel_member'] as Map<String, dynamic>,
+  );
 
 QueryUsersResponse _$QueryUsersResponseFromJson(Map<String, dynamic> json) =>
     QueryUsersResponse()
       ..duration = json['duration'] as String?
-      ..users = (json['users'] as List<dynamic>?)
+      ..users =
+          (json['users'] as List<dynamic>?)
               ?.map((e) => User.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
 QueryBannedUsersResponse _$QueryBannedUsersResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryBannedUsersResponse()
-      ..duration = json['duration'] as String?
-      ..bans = (json['bans'] as List<dynamic>?)
-              ?.map((e) => BannedUser.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => QueryBannedUsersResponse()
+  ..duration = json['duration'] as String?
+  ..bans =
+      (json['bans'] as List<dynamic>?)
+          ?.map((e) => BannedUser.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 QueryReactionsResponse _$QueryReactionsResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryReactionsResponse()
-      ..duration = json['duration'] as String?
-      ..reactions = (json['reactions'] as List<dynamic>?)
-              ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => QueryReactionsResponse()
+  ..duration = json['duration'] as String?
+  ..reactions =
+      (json['reactions'] as List<dynamic>?)
+          ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 QueryRepliesResponse _$QueryRepliesResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryRepliesResponse()
-      ..duration = json['duration'] as String?
-      ..messages = (json['messages'] as List<dynamic>?)
-              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => QueryRepliesResponse()
+  ..duration = json['duration'] as String?
+  ..messages =
+      (json['messages'] as List<dynamic>?)
+          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 ListDevicesResponse _$ListDevicesResponseFromJson(Map<String, dynamic> json) =>
     ListDevicesResponse()
       ..duration = json['duration'] as String?
-      ..devices = (json['devices'] as List<dynamic>?)
+      ..devices =
+          (json['devices'] as List<dynamic>?)
               ?.map((e) => Device.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
 SendAttachmentResponse _$SendAttachmentResponseFromJson(
-        Map<String, dynamic> json) =>
-    SendAttachmentResponse()
-      ..duration = json['duration'] as String?
-      ..file = json['file'] as String?;
+  Map<String, dynamic> json,
+) => SendAttachmentResponse()
+  ..duration = json['duration'] as String?
+  ..file = json['file'] as String?;
 
 SendFileResponse _$SendFileResponseFromJson(Map<String, dynamic> json) =>
     SendFileResponse()
@@ -117,32 +126,33 @@ SendFileResponse _$SendFileResponseFromJson(Map<String, dynamic> json) =>
       ..thumbUrl = json['thumb_url'] as String?;
 
 SendReactionResponse _$SendReactionResponseFromJson(
-        Map<String, dynamic> json) =>
-    SendReactionResponse()
-      ..duration = json['duration'] as String?
-      ..message = Message.fromJson(json['message'] as Map<String, dynamic>)
-      ..reaction = Reaction.fromJson(json['reaction'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => SendReactionResponse()
+  ..duration = json['duration'] as String?
+  ..message = Message.fromJson(json['message'] as Map<String, dynamic>)
+  ..reaction = Reaction.fromJson(json['reaction'] as Map<String, dynamic>);
 
 ConnectGuestUserResponse _$ConnectGuestUserResponseFromJson(
-        Map<String, dynamic> json) =>
-    ConnectGuestUserResponse()
-      ..duration = json['duration'] as String?
-      ..accessToken = json['access_token'] as String
-      ..user = User.fromJson(json['user'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => ConnectGuestUserResponse()
+  ..duration = json['duration'] as String?
+  ..accessToken = json['access_token'] as String
+  ..user = User.fromJson(json['user'] as Map<String, dynamic>);
 
 UpdateUsersResponse _$UpdateUsersResponseFromJson(Map<String, dynamic> json) =>
     UpdateUsersResponse()
       ..duration = json['duration'] as String?
-      ..users = (json['users'] as Map<String, dynamic>?)?.map(
+      ..users =
+          (json['users'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, User.fromJson(e as Map<String, dynamic>)),
           ) ??
           {};
 
 UpdateMessageResponse _$UpdateMessageResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpdateMessageResponse()
-      ..duration = json['duration'] as String?
-      ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => UpdateMessageResponse()
+  ..duration = json['duration'] as String?
+  ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
 
 SendMessageResponse _$SendMessageResponseFromJson(Map<String, dynamic> json) =>
     SendMessageResponse()
@@ -158,72 +168,75 @@ GetMessageResponse _$GetMessageResponseFromJson(Map<String, dynamic> json) =>
           : ChannelModel.fromJson(json['channel'] as Map<String, dynamic>);
 
 SearchMessagesResponse _$SearchMessagesResponseFromJson(
-        Map<String, dynamic> json) =>
-    SearchMessagesResponse()
-      ..duration = json['duration'] as String?
-      ..results = (json['results'] as List<dynamic>?)
-              ?.map(
-                  (e) => GetMessageResponse.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..next = json['next'] as String?
-      ..previous = json['previous'] as String?;
+  Map<String, dynamic> json,
+) => SearchMessagesResponse()
+  ..duration = json['duration'] as String?
+  ..results =
+      (json['results'] as List<dynamic>?)
+          ?.map((e) => GetMessageResponse.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..next = json['next'] as String?
+  ..previous = json['previous'] as String?;
 
 GetMessagesByIdResponse _$GetMessagesByIdResponseFromJson(
-        Map<String, dynamic> json) =>
-    GetMessagesByIdResponse()
-      ..duration = json['duration'] as String?
-      ..messages = (json['messages'] as List<dynamic>?)
-              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => GetMessagesByIdResponse()
+  ..duration = json['duration'] as String?
+  ..messages =
+      (json['messages'] as List<dynamic>?)
+          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 UpdateChannelResponse _$UpdateChannelResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpdateChannelResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..message = json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => UpdateChannelResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members = (json['members'] as List<dynamic>?)
+      ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..message = json['message'] == null
+      ? null
+      : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 PartialUpdateChannelResponse _$PartialUpdateChannelResponseFromJson(
-        Map<String, dynamic> json) =>
-    PartialUpdateChannelResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList();
+  Map<String, dynamic> json,
+) => PartialUpdateChannelResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members = (json['members'] as List<dynamic>?)
+      ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+      .toList();
 
 InviteMembersResponse _$InviteMembersResponseFromJson(
-        Map<String, dynamic> json) =>
-    InviteMembersResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..message = json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => InviteMembersResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..message = json['message'] == null
+      ? null
+      : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 RemoveMembersResponse _$RemoveMembersResponseFromJson(
-        Map<String, dynamic> json) =>
-    RemoveMembersResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..message = json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => RemoveMembersResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..message = json['message'] == null
+      ? null
+      : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 SendActionResponse _$SendActionResponseFromJson(Map<String, dynamic> json) =>
     SendActionResponse()
@@ -236,7 +249,8 @@ AddMembersResponse _$AddMembersResponseFromJson(Map<String, dynamic> json) =>
     AddMembersResponse()
       ..duration = json['duration'] as String?
       ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
+      ..members =
+          (json['members'] as List<dynamic>?)
               ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
@@ -245,67 +259,72 @@ AddMembersResponse _$AddMembersResponseFromJson(Map<String, dynamic> json) =>
           : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 AcceptInviteResponse _$AcceptInviteResponseFromJson(
-        Map<String, dynamic> json) =>
-    AcceptInviteResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..message = json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => AcceptInviteResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..message = json['message'] == null
+      ? null
+      : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 RejectInviteResponse _$RejectInviteResponseFromJson(
-        Map<String, dynamic> json) =>
-    RejectInviteResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..message = json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => RejectInviteResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..message = json['message'] == null
+      ? null
+      : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 EmptyResponse _$EmptyResponseFromJson(Map<String, dynamic> json) =>
     EmptyResponse()..duration = json['duration'] as String?;
 
 ChannelStateResponse _$ChannelStateResponseFromJson(
-        Map<String, dynamic> json) =>
-    ChannelStateResponse()
-      ..duration = json['duration'] as String?
-      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..messages = (json['messages'] as List<dynamic>?)
-              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..members = (json['members'] as List<dynamic>?)
-              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..watcherCount = (json['watcher_count'] as num?)?.toInt() ?? 0
-      ..read = (json['read'] as List<dynamic>?)
-              ?.map((e) => Read.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => ChannelStateResponse()
+  ..duration = json['duration'] as String?
+  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+  ..messages =
+      (json['messages'] as List<dynamic>?)
+          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..members =
+      (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..watcherCount = (json['watcher_count'] as num?)?.toInt() ?? 0
+  ..read =
+      (json['read'] as List<dynamic>?)
+          ?.map((e) => Read.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 OGAttachmentResponse _$OGAttachmentResponseFromJson(
-        Map<String, dynamic> json) =>
-    OGAttachmentResponse()
-      ..duration = json['duration'] as String?
-      ..ogScrapeUrl = json['og_scrape_url'] as String
-      ..assetUrl = json['asset_url'] as String?
-      ..authorLink = json['author_link'] as String?
-      ..authorName = json['author_name'] as String?
-      ..imageUrl = json['image_url'] as String?
-      ..text = json['text'] as String?
-      ..thumbUrl = json['thumb_url'] as String?
-      ..title = json['title'] as String?
-      ..titleLink = json['title_link'] as String?
-      ..type = json['type'] as String?;
+  Map<String, dynamic> json,
+) => OGAttachmentResponse()
+  ..duration = json['duration'] as String?
+  ..ogScrapeUrl = json['og_scrape_url'] as String
+  ..assetUrl = json['asset_url'] as String?
+  ..authorLink = json['author_link'] as String?
+  ..authorName = json['author_name'] as String?
+  ..imageUrl = json['image_url'] as String?
+  ..text = json['text'] as String?
+  ..thumbUrl = json['thumb_url'] as String?
+  ..title = json['title'] as String?
+  ..titleLink = json['title_link'] as String?
+  ..type = json['type'] as String?;
 
 CallTokenPayload _$CallTokenPayloadFromJson(Map<String, dynamic> json) =>
     CallTokenPayload()
@@ -329,13 +348,14 @@ UserBlockResponse _$UserBlockResponseFromJson(Map<String, dynamic> json) =>
       ..createdAt = DateTime.parse(json['created_at'] as String);
 
 BlockedUsersResponse _$BlockedUsersResponseFromJson(
-        Map<String, dynamic> json) =>
-    BlockedUsersResponse()
-      ..duration = json['duration'] as String?
-      ..blocks = (json['blocks'] as List<dynamic>?)
-              ?.map((e) => UserBlock.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [];
+  Map<String, dynamic> json,
+) => BlockedUsersResponse()
+  ..duration = json['duration'] as String?
+  ..blocks =
+      (json['blocks'] as List<dynamic>?)
+          ?.map((e) => UserBlock.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [];
 
 CreatePollResponse _$CreatePollResponseFromJson(Map<String, dynamic> json) =>
     CreatePollResponse()
@@ -353,56 +373,61 @@ UpdatePollResponse _$UpdatePollResponseFromJson(Map<String, dynamic> json) =>
       ..poll = Poll.fromJson(json['poll'] as Map<String, dynamic>);
 
 CreatePollOptionResponse _$CreatePollOptionResponseFromJson(
-        Map<String, dynamic> json) =>
-    CreatePollOptionResponse()
-      ..duration = json['duration'] as String?
-      ..pollOption =
-          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => CreatePollOptionResponse()
+  ..duration = json['duration'] as String?
+  ..pollOption = PollOption.fromJson(
+    json['poll_option'] as Map<String, dynamic>,
+  );
 
 GetPollOptionResponse _$GetPollOptionResponseFromJson(
-        Map<String, dynamic> json) =>
-    GetPollOptionResponse()
-      ..duration = json['duration'] as String?
-      ..pollOption =
-          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => GetPollOptionResponse()
+  ..duration = json['duration'] as String?
+  ..pollOption = PollOption.fromJson(
+    json['poll_option'] as Map<String, dynamic>,
+  );
 
 UpdatePollOptionResponse _$UpdatePollOptionResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpdatePollOptionResponse()
-      ..duration = json['duration'] as String?
-      ..pollOption =
-          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => UpdatePollOptionResponse()
+  ..duration = json['duration'] as String?
+  ..pollOption = PollOption.fromJson(
+    json['poll_option'] as Map<String, dynamic>,
+  );
 
 CastPollVoteResponse _$CastPollVoteResponseFromJson(
-        Map<String, dynamic> json) =>
-    CastPollVoteResponse()
-      ..duration = json['duration'] as String?
-      ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => CastPollVoteResponse()
+  ..duration = json['duration'] as String?
+  ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
 
 RemovePollVoteResponse _$RemovePollVoteResponseFromJson(
-        Map<String, dynamic> json) =>
-    RemovePollVoteResponse()
-      ..duration = json['duration'] as String?
-      ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => RemovePollVoteResponse()
+  ..duration = json['duration'] as String?
+  ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
 
 QueryPollsResponse _$QueryPollsResponseFromJson(Map<String, dynamic> json) =>
     QueryPollsResponse()
       ..duration = json['duration'] as String?
-      ..polls = (json['polls'] as List<dynamic>?)
+      ..polls =
+          (json['polls'] as List<dynamic>?)
               ?.map((e) => Poll.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
       ..next = json['next'] as String?;
 
 QueryPollVotesResponse _$QueryPollVotesResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryPollVotesResponse()
-      ..duration = json['duration'] as String?
-      ..votes = (json['votes'] as List<dynamic>?)
-              ?.map((e) => PollVote.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..next = json['next'] as String?;
+  Map<String, dynamic> json,
+) => QueryPollVotesResponse()
+  ..duration = json['duration'] as String?
+  ..votes =
+      (json['votes'] as List<dynamic>?)
+          ?.map((e) => PollVote.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..next = json['next'] as String?;
 
 GetThreadResponse _$GetThreadResponseFromJson(Map<String, dynamic> json) =>
     GetThreadResponse()
@@ -410,20 +435,21 @@ GetThreadResponse _$GetThreadResponseFromJson(Map<String, dynamic> json) =>
       ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
 
 UpdateThreadResponse _$UpdateThreadResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpdateThreadResponse()
-      ..duration = json['duration'] as String?
-      ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => UpdateThreadResponse()
+  ..duration = json['duration'] as String?
+  ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
 
 QueryThreadsResponse _$QueryThreadsResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryThreadsResponse()
-      ..duration = json['duration'] as String?
-      ..threads = (json['threads'] as List<dynamic>?)
-              ?.map((e) => Thread.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..next = json['next'] as String?;
+  Map<String, dynamic> json,
+) => QueryThreadsResponse()
+  ..duration = json['duration'] as String?
+  ..threads =
+      (json['threads'] as List<dynamic>?)
+          ?.map((e) => Thread.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..next = json['next'] as String?;
 
 CreateDraftResponse _$CreateDraftResponseFromJson(Map<String, dynamic> json) =>
     CreateDraftResponse()
@@ -438,77 +464,78 @@ GetDraftResponse _$GetDraftResponseFromJson(Map<String, dynamic> json) =>
 QueryDraftsResponse _$QueryDraftsResponseFromJson(Map<String, dynamic> json) =>
     QueryDraftsResponse()
       ..duration = json['duration'] as String?
-      ..drafts = (json['drafts'] as List<dynamic>?)
+      ..drafts =
+          (json['drafts'] as List<dynamic>?)
               ?.map((e) => Draft.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
       ..next = json['next'] as String?;
 
 CreateReminderResponse _$CreateReminderResponseFromJson(
-        Map<String, dynamic> json) =>
-    CreateReminderResponse()
-      ..duration = json['duration'] as String?
-      ..reminder =
-          MessageReminder.fromJson(json['reminder'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => CreateReminderResponse()
+  ..duration = json['duration'] as String?
+  ..reminder = MessageReminder.fromJson(
+    json['reminder'] as Map<String, dynamic>,
+  );
 
 UpdateReminderResponse _$UpdateReminderResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpdateReminderResponse()
-      ..duration = json['duration'] as String?
-      ..reminder =
-          MessageReminder.fromJson(json['reminder'] as Map<String, dynamic>);
+  Map<String, dynamic> json,
+) => UpdateReminderResponse()
+  ..duration = json['duration'] as String?
+  ..reminder = MessageReminder.fromJson(
+    json['reminder'] as Map<String, dynamic>,
+  );
 
 QueryRemindersResponse _$QueryRemindersResponseFromJson(
-        Map<String, dynamic> json) =>
-    QueryRemindersResponse()
-      ..duration = json['duration'] as String?
-      ..reminders = (json['reminders'] as List<dynamic>?)
-              ?.map((e) => MessageReminder.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          []
-      ..next = json['next'] as String?;
+  Map<String, dynamic> json,
+) => QueryRemindersResponse()
+  ..duration = json['duration'] as String?
+  ..reminders =
+      (json['reminders'] as List<dynamic>?)
+          ?.map((e) => MessageReminder.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      []
+  ..next = json['next'] as String?;
 
 GetUnreadCountResponse _$GetUnreadCountResponseFromJson(
-        Map<String, dynamic> json) =>
-    GetUnreadCountResponse()
-      ..duration = json['duration'] as String?
-      ..totalUnreadCount = (json['total_unread_count'] as num).toInt()
-      ..totalUnreadThreadsCount =
-          (json['total_unread_threads_count'] as num).toInt()
-      ..totalUnreadCountByTeam =
-          (json['total_unread_count_by_team'] as Map<String, dynamic>?)?.map(
+  Map<String, dynamic> json,
+) => GetUnreadCountResponse()
+  ..duration = json['duration'] as String?
+  ..totalUnreadCount = (json['total_unread_count'] as num).toInt()
+  ..totalUnreadThreadsCount = (json['total_unread_threads_count'] as num)
+      .toInt()
+  ..totalUnreadCountByTeam =
+      (json['total_unread_count_by_team'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, (e as num).toInt()),
       )
-      ..channels = (json['channels'] as List<dynamic>)
-          .map((e) => UnreadCountsChannel.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..channelType = (json['channel_type'] as List<dynamic>)
-          .map((e) =>
-              UnreadCountsChannelType.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..threads = (json['threads'] as List<dynamic>)
-          .map((e) => UnreadCountsThread.fromJson(e as Map<String, dynamic>))
-          .toList();
+  ..channels = (json['channels'] as List<dynamic>)
+      .map((e) => UnreadCountsChannel.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..channelType = (json['channel_type'] as List<dynamic>)
+      .map((e) => UnreadCountsChannelType.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..threads = (json['threads'] as List<dynamic>)
+      .map((e) => UnreadCountsThread.fromJson(e as Map<String, dynamic>))
+      .toList();
 
 UpsertPushPreferencesResponse _$UpsertPushPreferencesResponseFromJson(
-        Map<String, dynamic> json) =>
-    UpsertPushPreferencesResponse()
-      ..duration = json['duration'] as String?
-      ..userPreferences = (json['user_preferences'] as Map<String, dynamic>?)
-              ?.map(
-            (k, e) =>
-                MapEntry(k, PushPreference.fromJson(e as Map<String, dynamic>)),
-          ) ??
-          {}
-      ..userChannelPreferences =
-          (json['user_channel_preferences'] as Map<String, dynamic>?)?.map(
-                (k, e) => MapEntry(
-                    k,
-                    (e as Map<String, dynamic>).map(
-                      (k, e) => MapEntry(
-                          k,
-                          ChannelPushPreference.fromJson(
-                              e as Map<String, dynamic>)),
-                    )),
-              ) ??
-              {};
+  Map<String, dynamic> json,
+) => UpsertPushPreferencesResponse()
+  ..duration = json['duration'] as String?
+  ..userPreferences = _userPreferencesFromJson(
+    json['user_preferences'] as Map<String, dynamic>?,
+  )
+  ..userChannelPreferences =
+      (json['user_channel_preferences'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(
+          k,
+          (e as Map<String, dynamic>).map(
+            (k, e) => MapEntry(
+              k,
+              ChannelPushPreference.fromJson(e as Map<String, dynamic>),
+            ),
+          ),
+        ),
+      ) ??
+      {};

--- a/packages/stream_chat/lib/src/core/api/responses.g.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.g.dart
@@ -494,12 +494,8 @@ UpsertPushPreferencesResponse _$UpsertPushPreferencesResponseFromJson(
         Map<String, dynamic> json) =>
     UpsertPushPreferencesResponse()
       ..duration = json['duration'] as String?
-      ..userPreferences = (json['user_preferences'] as Map<String, dynamic>?)
-              ?.map(
-            (k, e) =>
-                MapEntry(k, PushPreference.fromJson(e as Map<String, dynamic>)),
-          ) ??
-          {}
+      ..userPreferences = _userPreferencesFromJson(
+          json['user_preferences'] as Map<String, dynamic>?)
       ..userChannelPreferences =
           (json['user_channel_preferences'] as Map<String, dynamic>?)?.map(
                 (k, e) => MapEntry(

--- a/packages/stream_chat/lib/src/core/api/responses.g.dart
+++ b/packages/stream_chat/lib/src/core/api/responses.g.dart
@@ -25,99 +25,90 @@ Map<String, dynamic> _$ErrorResponseToJson(ErrorResponse instance) =>
 
 SyncResponse _$SyncResponseFromJson(Map<String, dynamic> json) => SyncResponse()
   ..duration = json['duration'] as String?
-  ..events =
-      (json['events'] as List<dynamic>?)
+  ..events = (json['events'] as List<dynamic>?)
           ?.map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList() ??
       [];
 
 QueryChannelsResponse _$QueryChannelsResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryChannelsResponse()
-  ..duration = json['duration'] as String?
-  ..channels =
-      (json['channels'] as List<dynamic>?)
-          ?.map((e) => ChannelState.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    QueryChannelsResponse()
+      ..duration = json['duration'] as String?
+      ..channels = (json['channels'] as List<dynamic>?)
+              ?.map((e) => ChannelState.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 TranslateMessageResponse _$TranslateMessageResponseFromJson(
-  Map<String, dynamic> json,
-) => TranslateMessageResponse()
-  ..duration = json['duration'] as String?
-  ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    TranslateMessageResponse()
+      ..duration = json['duration'] as String?
+      ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
 
 QueryMembersResponse _$QueryMembersResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryMembersResponse()
-  ..duration = json['duration'] as String?
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    QueryMembersResponse()
+      ..duration = json['duration'] as String?
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 PartialUpdateMemberResponse _$PartialUpdateMemberResponseFromJson(
-  Map<String, dynamic> json,
-) => PartialUpdateMemberResponse()
-  ..duration = json['duration'] as String?
-  ..channelMember = Member.fromJson(
-    json['channel_member'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    PartialUpdateMemberResponse()
+      ..duration = json['duration'] as String?
+      ..channelMember =
+          Member.fromJson(json['channel_member'] as Map<String, dynamic>);
 
 QueryUsersResponse _$QueryUsersResponseFromJson(Map<String, dynamic> json) =>
     QueryUsersResponse()
       ..duration = json['duration'] as String?
-      ..users =
-          (json['users'] as List<dynamic>?)
+      ..users = (json['users'] as List<dynamic>?)
               ?.map((e) => User.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
 QueryBannedUsersResponse _$QueryBannedUsersResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryBannedUsersResponse()
-  ..duration = json['duration'] as String?
-  ..bans =
-      (json['bans'] as List<dynamic>?)
-          ?.map((e) => BannedUser.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    QueryBannedUsersResponse()
+      ..duration = json['duration'] as String?
+      ..bans = (json['bans'] as List<dynamic>?)
+              ?.map((e) => BannedUser.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 QueryReactionsResponse _$QueryReactionsResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryReactionsResponse()
-  ..duration = json['duration'] as String?
-  ..reactions =
-      (json['reactions'] as List<dynamic>?)
-          ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    QueryReactionsResponse()
+      ..duration = json['duration'] as String?
+      ..reactions = (json['reactions'] as List<dynamic>?)
+              ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 QueryRepliesResponse _$QueryRepliesResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryRepliesResponse()
-  ..duration = json['duration'] as String?
-  ..messages =
-      (json['messages'] as List<dynamic>?)
-          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    QueryRepliesResponse()
+      ..duration = json['duration'] as String?
+      ..messages = (json['messages'] as List<dynamic>?)
+              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 ListDevicesResponse _$ListDevicesResponseFromJson(Map<String, dynamic> json) =>
     ListDevicesResponse()
       ..duration = json['duration'] as String?
-      ..devices =
-          (json['devices'] as List<dynamic>?)
+      ..devices = (json['devices'] as List<dynamic>?)
               ?.map((e) => Device.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [];
 
 SendAttachmentResponse _$SendAttachmentResponseFromJson(
-  Map<String, dynamic> json,
-) => SendAttachmentResponse()
-  ..duration = json['duration'] as String?
-  ..file = json['file'] as String?;
+        Map<String, dynamic> json) =>
+    SendAttachmentResponse()
+      ..duration = json['duration'] as String?
+      ..file = json['file'] as String?;
 
 SendFileResponse _$SendFileResponseFromJson(Map<String, dynamic> json) =>
     SendFileResponse()
@@ -126,33 +117,32 @@ SendFileResponse _$SendFileResponseFromJson(Map<String, dynamic> json) =>
       ..thumbUrl = json['thumb_url'] as String?;
 
 SendReactionResponse _$SendReactionResponseFromJson(
-  Map<String, dynamic> json,
-) => SendReactionResponse()
-  ..duration = json['duration'] as String?
-  ..message = Message.fromJson(json['message'] as Map<String, dynamic>)
-  ..reaction = Reaction.fromJson(json['reaction'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    SendReactionResponse()
+      ..duration = json['duration'] as String?
+      ..message = Message.fromJson(json['message'] as Map<String, dynamic>)
+      ..reaction = Reaction.fromJson(json['reaction'] as Map<String, dynamic>);
 
 ConnectGuestUserResponse _$ConnectGuestUserResponseFromJson(
-  Map<String, dynamic> json,
-) => ConnectGuestUserResponse()
-  ..duration = json['duration'] as String?
-  ..accessToken = json['access_token'] as String
-  ..user = User.fromJson(json['user'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    ConnectGuestUserResponse()
+      ..duration = json['duration'] as String?
+      ..accessToken = json['access_token'] as String
+      ..user = User.fromJson(json['user'] as Map<String, dynamic>);
 
 UpdateUsersResponse _$UpdateUsersResponseFromJson(Map<String, dynamic> json) =>
     UpdateUsersResponse()
       ..duration = json['duration'] as String?
-      ..users =
-          (json['users'] as Map<String, dynamic>?)?.map(
+      ..users = (json['users'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, User.fromJson(e as Map<String, dynamic>)),
           ) ??
           {};
 
 UpdateMessageResponse _$UpdateMessageResponseFromJson(
-  Map<String, dynamic> json,
-) => UpdateMessageResponse()
-  ..duration = json['duration'] as String?
-  ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    UpdateMessageResponse()
+      ..duration = json['duration'] as String?
+      ..message = Message.fromJson(json['message'] as Map<String, dynamic>);
 
 SendMessageResponse _$SendMessageResponseFromJson(Map<String, dynamic> json) =>
     SendMessageResponse()
@@ -168,75 +158,72 @@ GetMessageResponse _$GetMessageResponseFromJson(Map<String, dynamic> json) =>
           : ChannelModel.fromJson(json['channel'] as Map<String, dynamic>);
 
 SearchMessagesResponse _$SearchMessagesResponseFromJson(
-  Map<String, dynamic> json,
-) => SearchMessagesResponse()
-  ..duration = json['duration'] as String?
-  ..results =
-      (json['results'] as List<dynamic>?)
-          ?.map((e) => GetMessageResponse.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..next = json['next'] as String?
-  ..previous = json['previous'] as String?;
+        Map<String, dynamic> json) =>
+    SearchMessagesResponse()
+      ..duration = json['duration'] as String?
+      ..results = (json['results'] as List<dynamic>?)
+              ?.map(
+                  (e) => GetMessageResponse.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..next = json['next'] as String?
+      ..previous = json['previous'] as String?;
 
 GetMessagesByIdResponse _$GetMessagesByIdResponseFromJson(
-  Map<String, dynamic> json,
-) => GetMessagesByIdResponse()
-  ..duration = json['duration'] as String?
-  ..messages =
-      (json['messages'] as List<dynamic>?)
-          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    GetMessagesByIdResponse()
+      ..duration = json['duration'] as String?
+      ..messages = (json['messages'] as List<dynamic>?)
+              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 UpdateChannelResponse _$UpdateChannelResponseFromJson(
-  Map<String, dynamic> json,
-) => UpdateChannelResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members = (json['members'] as List<dynamic>?)
-      ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..message = json['message'] == null
-      ? null
-      : Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    UpdateChannelResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..message = json['message'] == null
+          ? null
+          : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 PartialUpdateChannelResponse _$PartialUpdateChannelResponseFromJson(
-  Map<String, dynamic> json,
-) => PartialUpdateChannelResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members = (json['members'] as List<dynamic>?)
-      ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-      .toList();
+        Map<String, dynamic> json) =>
+    PartialUpdateChannelResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+          .toList();
 
 InviteMembersResponse _$InviteMembersResponseFromJson(
-  Map<String, dynamic> json,
-) => InviteMembersResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..message = json['message'] == null
-      ? null
-      : Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    InviteMembersResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..message = json['message'] == null
+          ? null
+          : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 RemoveMembersResponse _$RemoveMembersResponseFromJson(
-  Map<String, dynamic> json,
-) => RemoveMembersResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..message = json['message'] == null
-      ? null
-      : Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    RemoveMembersResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..message = json['message'] == null
+          ? null
+          : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 SendActionResponse _$SendActionResponseFromJson(Map<String, dynamic> json) =>
     SendActionResponse()
@@ -249,8 +236,7 @@ AddMembersResponse _$AddMembersResponseFromJson(Map<String, dynamic> json) =>
     AddMembersResponse()
       ..duration = json['duration'] as String?
       ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-      ..members =
-          (json['members'] as List<dynamic>?)
+      ..members = (json['members'] as List<dynamic>?)
               ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
@@ -259,72 +245,67 @@ AddMembersResponse _$AddMembersResponseFromJson(Map<String, dynamic> json) =>
           : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 AcceptInviteResponse _$AcceptInviteResponseFromJson(
-  Map<String, dynamic> json,
-) => AcceptInviteResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..message = json['message'] == null
-      ? null
-      : Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    AcceptInviteResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..message = json['message'] == null
+          ? null
+          : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 RejectInviteResponse _$RejectInviteResponseFromJson(
-  Map<String, dynamic> json,
-) => RejectInviteResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..message = json['message'] == null
-      ? null
-      : Message.fromJson(json['message'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    RejectInviteResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..message = json['message'] == null
+          ? null
+          : Message.fromJson(json['message'] as Map<String, dynamic>);
 
 EmptyResponse _$EmptyResponseFromJson(Map<String, dynamic> json) =>
     EmptyResponse()..duration = json['duration'] as String?;
 
 ChannelStateResponse _$ChannelStateResponseFromJson(
-  Map<String, dynamic> json,
-) => ChannelStateResponse()
-  ..duration = json['duration'] as String?
-  ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
-  ..messages =
-      (json['messages'] as List<dynamic>?)
-          ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..members =
-      (json['members'] as List<dynamic>?)
-          ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..watcherCount = (json['watcher_count'] as num?)?.toInt() ?? 0
-  ..read =
-      (json['read'] as List<dynamic>?)
-          ?.map((e) => Read.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    ChannelStateResponse()
+      ..duration = json['duration'] as String?
+      ..channel = ChannelModel.fromJson(json['channel'] as Map<String, dynamic>)
+      ..messages = (json['messages'] as List<dynamic>?)
+              ?.map((e) => Message.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..members = (json['members'] as List<dynamic>?)
+              ?.map((e) => Member.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..watcherCount = (json['watcher_count'] as num?)?.toInt() ?? 0
+      ..read = (json['read'] as List<dynamic>?)
+              ?.map((e) => Read.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 OGAttachmentResponse _$OGAttachmentResponseFromJson(
-  Map<String, dynamic> json,
-) => OGAttachmentResponse()
-  ..duration = json['duration'] as String?
-  ..ogScrapeUrl = json['og_scrape_url'] as String
-  ..assetUrl = json['asset_url'] as String?
-  ..authorLink = json['author_link'] as String?
-  ..authorName = json['author_name'] as String?
-  ..imageUrl = json['image_url'] as String?
-  ..text = json['text'] as String?
-  ..thumbUrl = json['thumb_url'] as String?
-  ..title = json['title'] as String?
-  ..titleLink = json['title_link'] as String?
-  ..type = json['type'] as String?;
+        Map<String, dynamic> json) =>
+    OGAttachmentResponse()
+      ..duration = json['duration'] as String?
+      ..ogScrapeUrl = json['og_scrape_url'] as String
+      ..assetUrl = json['asset_url'] as String?
+      ..authorLink = json['author_link'] as String?
+      ..authorName = json['author_name'] as String?
+      ..imageUrl = json['image_url'] as String?
+      ..text = json['text'] as String?
+      ..thumbUrl = json['thumb_url'] as String?
+      ..title = json['title'] as String?
+      ..titleLink = json['title_link'] as String?
+      ..type = json['type'] as String?;
 
 CallTokenPayload _$CallTokenPayloadFromJson(Map<String, dynamic> json) =>
     CallTokenPayload()
@@ -348,14 +329,13 @@ UserBlockResponse _$UserBlockResponseFromJson(Map<String, dynamic> json) =>
       ..createdAt = DateTime.parse(json['created_at'] as String);
 
 BlockedUsersResponse _$BlockedUsersResponseFromJson(
-  Map<String, dynamic> json,
-) => BlockedUsersResponse()
-  ..duration = json['duration'] as String?
-  ..blocks =
-      (json['blocks'] as List<dynamic>?)
-          ?.map((e) => UserBlock.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      [];
+        Map<String, dynamic> json) =>
+    BlockedUsersResponse()
+      ..duration = json['duration'] as String?
+      ..blocks = (json['blocks'] as List<dynamic>?)
+              ?.map((e) => UserBlock.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [];
 
 CreatePollResponse _$CreatePollResponseFromJson(Map<String, dynamic> json) =>
     CreatePollResponse()
@@ -373,61 +353,56 @@ UpdatePollResponse _$UpdatePollResponseFromJson(Map<String, dynamic> json) =>
       ..poll = Poll.fromJson(json['poll'] as Map<String, dynamic>);
 
 CreatePollOptionResponse _$CreatePollOptionResponseFromJson(
-  Map<String, dynamic> json,
-) => CreatePollOptionResponse()
-  ..duration = json['duration'] as String?
-  ..pollOption = PollOption.fromJson(
-    json['poll_option'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    CreatePollOptionResponse()
+      ..duration = json['duration'] as String?
+      ..pollOption =
+          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
 
 GetPollOptionResponse _$GetPollOptionResponseFromJson(
-  Map<String, dynamic> json,
-) => GetPollOptionResponse()
-  ..duration = json['duration'] as String?
-  ..pollOption = PollOption.fromJson(
-    json['poll_option'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    GetPollOptionResponse()
+      ..duration = json['duration'] as String?
+      ..pollOption =
+          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
 
 UpdatePollOptionResponse _$UpdatePollOptionResponseFromJson(
-  Map<String, dynamic> json,
-) => UpdatePollOptionResponse()
-  ..duration = json['duration'] as String?
-  ..pollOption = PollOption.fromJson(
-    json['poll_option'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    UpdatePollOptionResponse()
+      ..duration = json['duration'] as String?
+      ..pollOption =
+          PollOption.fromJson(json['poll_option'] as Map<String, dynamic>);
 
 CastPollVoteResponse _$CastPollVoteResponseFromJson(
-  Map<String, dynamic> json,
-) => CastPollVoteResponse()
-  ..duration = json['duration'] as String?
-  ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    CastPollVoteResponse()
+      ..duration = json['duration'] as String?
+      ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
 
 RemovePollVoteResponse _$RemovePollVoteResponseFromJson(
-  Map<String, dynamic> json,
-) => RemovePollVoteResponse()
-  ..duration = json['duration'] as String?
-  ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    RemovePollVoteResponse()
+      ..duration = json['duration'] as String?
+      ..vote = PollVote.fromJson(json['vote'] as Map<String, dynamic>);
 
 QueryPollsResponse _$QueryPollsResponseFromJson(Map<String, dynamic> json) =>
     QueryPollsResponse()
       ..duration = json['duration'] as String?
-      ..polls =
-          (json['polls'] as List<dynamic>?)
+      ..polls = (json['polls'] as List<dynamic>?)
               ?.map((e) => Poll.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
       ..next = json['next'] as String?;
 
 QueryPollVotesResponse _$QueryPollVotesResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryPollVotesResponse()
-  ..duration = json['duration'] as String?
-  ..votes =
-      (json['votes'] as List<dynamic>?)
-          ?.map((e) => PollVote.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..next = json['next'] as String?;
+        Map<String, dynamic> json) =>
+    QueryPollVotesResponse()
+      ..duration = json['duration'] as String?
+      ..votes = (json['votes'] as List<dynamic>?)
+              ?.map((e) => PollVote.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..next = json['next'] as String?;
 
 GetThreadResponse _$GetThreadResponseFromJson(Map<String, dynamic> json) =>
     GetThreadResponse()
@@ -435,21 +410,20 @@ GetThreadResponse _$GetThreadResponseFromJson(Map<String, dynamic> json) =>
       ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
 
 UpdateThreadResponse _$UpdateThreadResponseFromJson(
-  Map<String, dynamic> json,
-) => UpdateThreadResponse()
-  ..duration = json['duration'] as String?
-  ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
+        Map<String, dynamic> json) =>
+    UpdateThreadResponse()
+      ..duration = json['duration'] as String?
+      ..thread = Thread.fromJson(json['thread'] as Map<String, dynamic>);
 
 QueryThreadsResponse _$QueryThreadsResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryThreadsResponse()
-  ..duration = json['duration'] as String?
-  ..threads =
-      (json['threads'] as List<dynamic>?)
-          ?.map((e) => Thread.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..next = json['next'] as String?;
+        Map<String, dynamic> json) =>
+    QueryThreadsResponse()
+      ..duration = json['duration'] as String?
+      ..threads = (json['threads'] as List<dynamic>?)
+              ?.map((e) => Thread.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..next = json['next'] as String?;
 
 CreateDraftResponse _$CreateDraftResponseFromJson(Map<String, dynamic> json) =>
     CreateDraftResponse()
@@ -464,78 +438,77 @@ GetDraftResponse _$GetDraftResponseFromJson(Map<String, dynamic> json) =>
 QueryDraftsResponse _$QueryDraftsResponseFromJson(Map<String, dynamic> json) =>
     QueryDraftsResponse()
       ..duration = json['duration'] as String?
-      ..drafts =
-          (json['drafts'] as List<dynamic>?)
+      ..drafts = (json['drafts'] as List<dynamic>?)
               ?.map((e) => Draft.fromJson(e as Map<String, dynamic>))
               .toList() ??
           []
       ..next = json['next'] as String?;
 
 CreateReminderResponse _$CreateReminderResponseFromJson(
-  Map<String, dynamic> json,
-) => CreateReminderResponse()
-  ..duration = json['duration'] as String?
-  ..reminder = MessageReminder.fromJson(
-    json['reminder'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    CreateReminderResponse()
+      ..duration = json['duration'] as String?
+      ..reminder =
+          MessageReminder.fromJson(json['reminder'] as Map<String, dynamic>);
 
 UpdateReminderResponse _$UpdateReminderResponseFromJson(
-  Map<String, dynamic> json,
-) => UpdateReminderResponse()
-  ..duration = json['duration'] as String?
-  ..reminder = MessageReminder.fromJson(
-    json['reminder'] as Map<String, dynamic>,
-  );
+        Map<String, dynamic> json) =>
+    UpdateReminderResponse()
+      ..duration = json['duration'] as String?
+      ..reminder =
+          MessageReminder.fromJson(json['reminder'] as Map<String, dynamic>);
 
 QueryRemindersResponse _$QueryRemindersResponseFromJson(
-  Map<String, dynamic> json,
-) => QueryRemindersResponse()
-  ..duration = json['duration'] as String?
-  ..reminders =
-      (json['reminders'] as List<dynamic>?)
-          ?.map((e) => MessageReminder.fromJson(e as Map<String, dynamic>))
-          .toList() ??
-      []
-  ..next = json['next'] as String?;
+        Map<String, dynamic> json) =>
+    QueryRemindersResponse()
+      ..duration = json['duration'] as String?
+      ..reminders = (json['reminders'] as List<dynamic>?)
+              ?.map((e) => MessageReminder.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          []
+      ..next = json['next'] as String?;
 
 GetUnreadCountResponse _$GetUnreadCountResponseFromJson(
-  Map<String, dynamic> json,
-) => GetUnreadCountResponse()
-  ..duration = json['duration'] as String?
-  ..totalUnreadCount = (json['total_unread_count'] as num).toInt()
-  ..totalUnreadThreadsCount = (json['total_unread_threads_count'] as num)
-      .toInt()
-  ..totalUnreadCountByTeam =
-      (json['total_unread_count_by_team'] as Map<String, dynamic>?)?.map(
+        Map<String, dynamic> json) =>
+    GetUnreadCountResponse()
+      ..duration = json['duration'] as String?
+      ..totalUnreadCount = (json['total_unread_count'] as num).toInt()
+      ..totalUnreadThreadsCount =
+          (json['total_unread_threads_count'] as num).toInt()
+      ..totalUnreadCountByTeam =
+          (json['total_unread_count_by_team'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, (e as num).toInt()),
       )
-  ..channels = (json['channels'] as List<dynamic>)
-      .map((e) => UnreadCountsChannel.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..channelType = (json['channel_type'] as List<dynamic>)
-      .map((e) => UnreadCountsChannelType.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..threads = (json['threads'] as List<dynamic>)
-      .map((e) => UnreadCountsThread.fromJson(e as Map<String, dynamic>))
-      .toList();
+      ..channels = (json['channels'] as List<dynamic>)
+          .map((e) => UnreadCountsChannel.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..channelType = (json['channel_type'] as List<dynamic>)
+          .map((e) =>
+              UnreadCountsChannelType.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..threads = (json['threads'] as List<dynamic>)
+          .map((e) => UnreadCountsThread.fromJson(e as Map<String, dynamic>))
+          .toList();
 
 UpsertPushPreferencesResponse _$UpsertPushPreferencesResponseFromJson(
-  Map<String, dynamic> json,
-) => UpsertPushPreferencesResponse()
-  ..duration = json['duration'] as String?
-  ..userPreferences = _userPreferencesFromJson(
-    json['user_preferences'] as Map<String, dynamic>?,
-  )
-  ..userChannelPreferences =
-      (json['user_channel_preferences'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(
-          k,
-          (e as Map<String, dynamic>).map(
-            (k, e) => MapEntry(
-              k,
-              ChannelPushPreference.fromJson(e as Map<String, dynamic>),
-            ),
-          ),
-        ),
-      ) ??
-      {};
+        Map<String, dynamic> json) =>
+    UpsertPushPreferencesResponse()
+      ..duration = json['duration'] as String?
+      ..userPreferences = (json['user_preferences'] as Map<String, dynamic>?)
+              ?.map(
+            (k, e) =>
+                MapEntry(k, PushPreference.fromJson(e as Map<String, dynamic>)),
+          ) ??
+          {}
+      ..userChannelPreferences =
+          (json['user_channel_preferences'] as Map<String, dynamic>?)?.map(
+                (k, e) => MapEntry(
+                    k,
+                    (e as Map<String, dynamic>).map(
+                      (k, e) => MapEntry(
+                          k,
+                          ChannelPushPreference.fromJson(
+                              e as Map<String, dynamic>)),
+                    )),
+              ) ??
+              {};

--- a/packages/stream_chat/test/src/core/api/responses_test.dart
+++ b/packages/stream_chat/test/src/core/api/responses_test.dart
@@ -4457,7 +4457,8 @@ void main() {
           },
           "user2": {
             "chat_level": "none"
-          }
+          },
+          "user3": null
         },
         "user_channel_preferences": {
           "user1": {
@@ -4482,7 +4483,10 @@ void main() {
       );
 
       expect(response.userPreferences, isA<Map<String, PushPreference>>());
+      // user3 had a `null` value in the response (no user-global prefs were
+      // touched by the upsert) — should be filtered outs.
       expect(response.userPreferences, hasLength(2));
+      expect(response.userPreferences.containsKey('user3'), isFalse);
 
       // Test user1 preferences
       final user1Prefs = response.userPreferences['user1']!;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
We currently fail to parse `null` values in the `UpsertPushPreferencesResponse.userPreferences` map (when response is in the following format):
```json
{
    user_preferences: {salvatore: null},
    user_channel_preferences: {salvatore: {messaging:!members-QOJWJvjGC-iBN9hHDdGMThtJxoUzR1kizb4pv-n0BtE: {chat_level: all}}},
    duration: "11.67ms"
}
```
Which is the response we get when we update channel-specific push preferences. In this case, the customer gets the error: `Failed to set push preferences: type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast`, even though the operation was successful. 

The fix makes the parser more robust, allowing the `user_preferences` JSON to have `null` values.