### PR TITLE
fix(persistence): port poll DAO null-user fix and chunked size guard from #2731

### DIFF
--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming Changes
+
+🐞 Fixed
+
+- `PollDao` no longer crashes when reading polls whose creator user is missing from the local cache.
+
 ## 9.25.0
 
 🚀 Performance

--- a/packages/stream_chat_persistence/lib/src/dao/poll_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/poll_dao.dart
@@ -20,7 +20,7 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
 
   Future<Poll> _pollFromJoinRow(TypedResult row) async {
     final pollEntity = row.readTable(polls);
-    final userEntity = row.readTable(users);
+    final userEntity = row.readTableOrNull(users);
     final allVotes = await _db.pollVoteDao.getPollVotes(pollEntity.id);
     final latestAnswers = allVotes.where((it) => it.isAnswer);
     final ownVotesAndAnswers = allVotes.where((it) => it.userId == _db.userId);
@@ -38,7 +38,7 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
     }
 
     return pollEntity.toPoll(
-      createdBy: userEntity.toUser(),
+      createdBy: userEntity?.toUser(),
       latestAnswers: latestAnswers.toList(),
       ownVotesAndAnswers: ownVotesAndAnswers.toList(),
       latestVotesByOption: latestVotesByOption,
@@ -68,9 +68,7 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
           [leftOuterJoin(users, polls.createdById.equalsExp(users.id))]).get();
       for (final row in rows) {
         final pollEntity = row.readTable(polls);
-        // Same as `_pollFromJoinRow` => reads users via `readTable` (not
-        // `readTableOrNull`) on a LEFT JOIN
-        final userEntity = row.readTable(users);
+        final userEntity = row.readTableOrNull(users);
         final allVotes = votesByPoll[pollEntity.id] ?? const <PollVote>[];
         result[pollEntity.id] = _buildPoll(pollEntity, userEntity, allVotes);
       }
@@ -99,7 +97,7 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
 
   Poll _buildPoll(
     PollEntity pollEntity,
-    UserEntity userEntity,
+    UserEntity? userEntity,
     List<PollVote> allVotes,
   ) {
     final latestAnswers = allVotes.where((it) => it.isAnswer);
@@ -118,7 +116,7 @@ class PollDao extends DatabaseAccessor<DriftChatDatabase> with _$PollDaoMixin {
     }
 
     return pollEntity.toPoll(
-      createdBy: userEntity.toUser(),
+      createdBy: userEntity?.toUser(),
       latestAnswers: latestAnswers.toList(),
       ownVotesAndAnswers: ownVotesAndAnswers.toList(),
       latestVotesByOption: latestVotesByOption,

--- a/packages/stream_chat_persistence/lib/src/db/query_utils.dart
+++ b/packages/stream_chat_persistence/lib/src/db/query_utils.dart
@@ -12,6 +12,9 @@ import 'dart:math' as math;
 /// chunk size of 900 leaves headroom for any other bound parameters that
 /// share the same statement (for example a `AND userId = ?` filter).
 Iterable<List<T>> chunked<T>(List<T> input, [int size = 900]) sync* {
+  if (size <= 0) {
+    throw ArgumentError.value(size, 'size', 'must be greater than 0');
+  }
   for (var i = 0; i < input.length; i += size) {
     yield input.sublist(i, math.min(i + size, input.length));
   }

--- a/packages/stream_chat_persistence/test/src/db/query_utils_test.dart
+++ b/packages/stream_chat_persistence/test/src/db/query_utils_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_chat_persistence/src/db/query_utils.dart';
+
+void main() {
+  group('chunked', () {
+    test('returns an empty iterable for an empty input', () {
+      expect(chunked(<int>[]).toList(), isEmpty);
+    });
+
+    test('yields a single chunk when input fits in one chunk', () {
+      final input = List.generate(5, (i) => i);
+      expect(chunked(input, 10).toList(), [input]);
+    });
+
+    test('splits input into evenly sized chunks', () {
+      final input = List.generate(6, (i) => i);
+      expect(chunked(input, 2).toList(), [
+        [0, 1],
+        [2, 3],
+        [4, 5],
+      ]);
+    });
+
+    test('handles a trailing partial chunk', () {
+      final input = List.generate(7, (i) => i);
+      expect(chunked(input, 3).toList(), [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6],
+      ]);
+    });
+
+    test('uses a default size of 900', () {
+      final input = List.generate(1000, (i) => i);
+      final chunks = chunked(input).toList();
+      expect(chunks, hasLength(2));
+      expect(chunks[0], hasLength(900));
+      expect(chunks[1], hasLength(100));
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => chunked([1, 2, 3], 0).toList(), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => chunked([1, 2, 3], -1).toList(), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
Linear: FLU-
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Ports the review fixes from #2731 (commit 15af7401) onto `v9`. These were applied during the merge-master-to-v10 PR but never landed on the `v9` branch directly.

- `PollDao`: switch the user side of the `polls LEFT JOIN users` read from `readTable(users)` to `readTableOrNull(users)` in both `_pollFromJoinRow` and `getPollsByIds`, and make `userEntity` nullable in `_buildPoll`. Without this, reading a poll whose creator user isn't in the local cache crashes (the LEFT JOIN legitimately returns no user row).
- `chunked()`: throw `ArgumentError` when `size <= 0` instead of looping forever / producing nonsense chunks.
- Adds a unit test file for `chunked()` covering the empty/single/even/partial/default-size cases plus the new zero/negative guards. All 7 tests pass locally (`flutter test test/src/db/query_utils_test.dart`).

## Screenshots / Videos

_NA — persistence-layer change._

| Before | After |
| --- | --- |
| `getPollById` / `getPollsByIds` throws when the creator user row is absent. | Returns the poll with `createdBy: null`. |