### PR TITLE
fix(llc, core): pause WebSocket reconnect while app is background (v9)

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Upcoming
+
+✅ Added
+
+- Added `StreamChatClient.pauseReconnect` / `resumeReconnect` to suspend the WebSocket's auto-retry loop without tearing down the user session.
+
+🐞 Fixed
+
+- Fixed an unhandled `WebSocketChannelException` surfacing when a reconnect attempt failed (e.g. DNS lookup failed in background); the duplicate signal on `sink.done` is now ignored since the stream's `onError` already handles it.
+
 ## 9.25.0
 
 - Minor bug fixes and improvements

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -505,6 +505,18 @@ class StreamChatClient {
     _ws.disconnect();
   }
 
+  /// Suspends the WebSocket's automatic reconnection without tearing down the
+  /// user session.
+  ///
+  /// While paused, unexpected socket closures (for example when the OS closes
+  /// the connection after the app is backgrounded) will not trigger retries.
+  /// Call [resumeReconnect] before re-establishing the connection.
+  void pauseReconnect() => _ws.pauseReconnect();
+
+  /// Re-enables the WebSocket's automatic reconnection after a previous
+  /// [pauseReconnect].
+  void resumeReconnect() => _ws.resumeReconnect();
+
   void _handleHealthCheckEvent(Event event) {
     final user = event.me;
     if (user != null) state.currentUser = user;

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -134,6 +134,10 @@ class WebSocket with TimerHelper {
     }
     _webSocketChannel =
         webSocketChannelProvider?.call(uri) ?? WebSocketChannel.connect(uri);
+    // Connection failures (e.g. DNS errors during background) are delivered
+    // via the stream's onError below; ignore the duplicate signal on sink.done
+    // so it doesn't surface as an unhandled future error.
+    _webSocketChannel?.sink.done.ignore();
     _subscribeToWebSocketChannel();
   }
 
@@ -255,10 +259,45 @@ class WebSocket with TimerHelper {
 
   int _reconnectAttempt = 0;
   bool _reconnectRequestInProgress = false;
+  bool _reconnectEnabled = true;
+
+  /// Whether automatic reconnection is currently enabled.
+  bool get reconnectEnabled => _reconnectEnabled;
+
+  /// Suspends automatic reconnection without tearing down the user session.
+  ///
+  /// While paused, unexpected socket closures (e.g. when the OS closes the
+  /// connection after the app is backgrounded) will not trigger retries.
+  /// Call [resumeReconnect] before re-establishing the connection.
+  void pauseReconnect() {
+    if (!_reconnectEnabled) return;
+    _logger?.info('Pausing reconnection');
+    _reconnectEnabled = false;
+  }
+
+  /// Re-enables automatic reconnection after a previous [pauseReconnect].
+  void resumeReconnect() {
+    if (_reconnectEnabled) return;
+    _logger?.info('Resuming reconnection');
+    _reconnectEnabled = true;
+  }
 
   void _reconnect({bool refreshToken = false}) async {
-    _logger?.info('Retrying connection : $_reconnectAttempt');
     if (_reconnectRequestInProgress) return;
+
+    // Tear down the dead channel and its timers up front so the health-check
+    // timer can't fire on a closed sink while we wait — both when retrying and
+    // when reconnect is paused.
+    _stopMonitoringEvents();
+    _closeWebSocketChannel();
+
+    if (!_reconnectEnabled) {
+      _logger?.info('Reconnect skipped: paused');
+      _connectionStatus = ConnectionStatus.disconnected;
+      return;
+    }
+
+    _logger?.info('Retrying connection : $_reconnectAttempt');
 
     if (_reconnectAttempt >= maxReconnectAttempts) {
       _logger?.severe('Max reconnect attempts reached: $maxReconnectAttempts');
@@ -266,10 +305,6 @@ class WebSocket with TimerHelper {
     }
 
     _reconnectRequestInProgress = true;
-
-    _stopMonitoringEvents();
-    // Closing any previously opened web-socket
-    _closeWebSocketChannel();
 
     _reconnectAttempt += 1;
     _connectionStatus = ConnectionStatus.connecting;
@@ -283,6 +318,9 @@ class WebSocket with TimerHelper {
         //
         // In either case, we should not attempt to reconnect.
         if (_user == null) return;
+
+        // Reconnect may have been paused while the delay was pending.
+        if (!_reconnectEnabled) return;
 
         final uri = await _buildUri(
           refreshToken: refreshToken,

--- a/packages/stream_chat/test/src/ws/websocket_test.dart
+++ b/packages/stream_chat/test/src/ws/websocket_test.dart
@@ -41,6 +41,9 @@ void main() {
     when(() => webSocketChannel.stream).thenAnswer(
       (_) => webSocketController.stream,
     );
+    when(() => webSocketSink.done).thenAnswer(
+      (_) => Completer<void>().future,
+    );
     when(() => webSocketSink.add(any())).thenAnswer((invocation) {
       webSocketController.add(invocation.positionalArguments.first);
     });
@@ -376,6 +379,98 @@ void main() {
         me: user,
       );
       webSocketSink.add(json.encode(event));
+
+      addTearDown(timer.cancel);
+    },
+  );
+
+  test(
+    'should not `reconnect` after connection closes while reconnect is paused',
+    () async {
+      // Construct with a short health-check interval so we can pump past it
+      // within the test and assert no health-check writes happen on the
+      // closed sink.
+      final pausedWebSocket = WebSocket(
+        apiKey: 'api-key',
+        baseUrl: 'ws://<local-ip>:8800',
+        tokenManager: tokenManager,
+        webSocketChannelProvider: (_, {protocols}) => webSocketChannel,
+        healthCheckInterval: 1,
+        reconnectionMonitorInterval: 1,
+      );
+      addTearDown(pausedWebSocket.disconnect);
+
+      final user = OwnUser(id: 'test-user');
+      const connectionId = 'test-connection-id';
+      // Sends connect event to web-socket stream
+      final timer = Timer(const Duration(milliseconds: 300), () {
+        final event = Event(
+          type: EventType.healthCheck,
+          connectionId: connectionId,
+          me: user,
+        );
+        webSocketSink.add(json.encode(event));
+      });
+
+      final statuses = <ConnectionStatus>[];
+      final sub = pausedWebSocket.connectionStatusStream.listen(statuses.add);
+
+      await pausedWebSocket.connect(user);
+      expect(pausedWebSocket.reconnectEnabled, isTrue);
+
+      pausedWebSocket.pauseReconnect();
+      expect(pausedWebSocket.reconnectEnabled, isFalse);
+
+      // Mark all writes-so-far as verified so the next assertion only sees
+      // calls made after the close.
+      verify(() => webSocketSink.add(any()));
+
+      // Simulate an OS-initiated socket close.
+      webSocketSink.close();
+
+      // Pump well past the health-check interval to prove its timer was
+      // cancelled and no further writes are attempted on the dead channel.
+      await Future.delayed(const Duration(seconds: 3));
+
+      // Status should settle to disconnected after the paused close, with no
+      // `connecting` flicker from a retry attempt.
+      expect(statuses, [
+        ConnectionStatus.disconnected,
+        ConnectionStatus.connecting,
+        ConnectionStatus.connected,
+        ConnectionStatus.disconnected,
+      ]);
+      // No additional sink writes after the close.
+      verifyNever(() => webSocketSink.add(any()));
+
+      addTearDown(() {
+        timer.cancel();
+        sub.cancel();
+      });
+    },
+  );
+
+  test(
+    'should `reconnect` again after `resumeReconnect`',
+    () async {
+      final user = OwnUser(id: 'test-user');
+      const connectionId = 'test-connection-id';
+      final timer = Timer(const Duration(milliseconds: 300), () {
+        final event = Event(
+          type: EventType.healthCheck,
+          connectionId: connectionId,
+          me: user,
+        );
+        webSocketSink.add(json.encode(event));
+      });
+
+      await webSocket.connect(user);
+
+      webSocket.pauseReconnect();
+      expect(webSocket.reconnectEnabled, isFalse);
+
+      webSocket.resumeReconnect();
+      expect(webSocket.reconnectEnabled, isTrue);
 
       addTearDown(timer.cancel);
     },

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed a reconnect storm when the OS closed the WebSocket during the background keep-alive window; reconnects are now paused on background and resumed on foreground.
+
 ## 9.25.0
 
 ✅ Added

--- a/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_chat_core.dart
@@ -331,6 +331,7 @@ final class _ChatLifecycleManager {
     _cancelBackgroundTimer();
     _cancelEventSubscription();
 
+    client.resumeReconnect();
     return client.maybeReconnect().ignore();
   }
 
@@ -340,6 +341,10 @@ final class _ChatLifecycleManager {
   void _onBackground() {
     _cancelBackgroundTimer();
     _cancelEventSubscription();
+
+    // Suspend automatic reconnection so that an OS-initiated socket close
+    // during the keep-alive window doesn't kick off a retry storm.
+    client.pauseReconnect();
 
     if (onBackgroundEvent case final handler?) {
       _eventSubscription = client.on().listen(handler);

--- a/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
@@ -221,6 +221,34 @@ void main() {
     );
 
     testWidgets(
+      'should pause reconnect on background and resume on foreground',
+      (tester) async {
+        // Arrange
+        await pumpStreamChatCore(tester);
+
+        // Act - background
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pumpAndSettle();
+
+        // Assert - reconnect paused, but no reconnect / disconnect yet.
+        verify(mockClient.pauseReconnect).called(1);
+        verifyNever(mockClient.resumeReconnect);
+
+        // Reset connection status so foreground triggers a reconnect.
+        when(
+          () => mockClient.wsConnectionStatus,
+        ).thenReturn(ConnectionStatus.disconnected);
+
+        // Act - foreground
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pumpAndSettle();
+
+        // Assert - reconnect resumed before re-opening the connection.
+        verify(mockClient.resumeReconnect).called(1);
+      },
+    );
+
+    testWidgets(
       'should listen for events when app goes to background with handler',
       (tester) async {
         // Arrange

--- a/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_chat_core_test.dart
@@ -240,7 +240,8 @@ void main() {
         ).thenReturn(ConnectionStatus.disconnected);
 
         // Act - foreground
-        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        tester.binding
+            .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
         await tester.pumpAndSettle();
 
         // Assert - reconnect resumed before re-opening the connection.


### PR DESCRIPTION
Backport of #2759 to the v9 branch.

## Summary

- Suspends the WebSocket's auto-retry loop while the app is backgrounded, so an OS-initiated socket close inside the `backgroundKeepAlive` window no longer kicks off a retry storm (and no longer surfaces an unhandled `WebSocketChannelException` when DNS / network is restricted in background).
- New `StreamChatClient.pauseReconnect` / `resumeReconnect` API; wired from `StreamChatCore._ChatLifecycleManager` on the existing background / foreground transitions. Foreground path resumes retries and calls `maybeReconnect` as before.
- Reordered `WebSocket._reconnect` so the dead-channel cleanup (`_stopMonitoringEvents`, `_closeWebSocketChannel`) always runs, even when retry is paused — prevents the health-check timer from firing on a closed sink during the paused window.
- Attached a no-op error handler to `WebSocketChannel.sink.done` in `_initWebSocketChannel`; the duplicate error delivery there was the source of the unhandled `WebSocketChannelException`, since the stream's `onError` already handles it.

## Test plan

- [x] `dart test packages/stream_chat/test/src/ws/websocket_test.dart` — new test exercises a paused-close while pumping past `healthCheckInterval` to assert no sink writes happen on the dead channel, plus the expected status transitions.
- [x] `flutter test packages/stream_chat_flutter_core/test/stream_chat_core_test.dart` — new lifecycle test verifies `pauseReconnect` on background and `resumeReconnect` on foreground.
- [x] `dart analyze --fatal-infos` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)