### PR TITLE
fix(ui): avoid redundant setState in MessageCard width measurement [v9]

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- `MessageCard` no longer re-runs `setState` on every post-frame measurement when the measured attachment width has not changed. ([#2761](https://github.com/GetStream/stream-chat-flutter/issues/2761))
+
 ## 9.25.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/message_card.dart
@@ -144,6 +144,7 @@ class _MessageCardState extends State<MessageCard> {
     final attachmentsWidth = renderBox.size.width;
 
     if (attachmentsWidth == 0) return;
+    if (widthLimit == attachmentsWidth) return;
 
     setState(() => widthLimit = attachmentsWidth);
   }


### PR DESCRIPTION
Backport of #2762 to the v9 branch.

## Summary

`MessageCard._updateWidthLimit` writes the measured attachment width to `widthLimit` via `setState` unconditionally — so any inherited-widget change that triggered `didChangeDependencies` (and thus re-ran the post-frame measurement) left the element dirty even when the value was identical. Adds the same one-line diff guard as on master.

## Notes

- v9 already gates the post-frame scheduling on `hasAttachments`, so text-only messages never enter this path — the guard is defense-in-depth on top of that.
- `MessageCard.build` doesn't read any inherited widgets directly, so this trigger is harder to manifest on v9 than on master. The regression test for the equivalent pattern lives on master in #2762.

## Test plan

- [x] `melos run analyze` / format clean.
- [ ] Manual smoke test in sample_app on v9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)