### PR TITLE
ci(repo): trigger conventional PR title check for v9 PRs

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -7,7 +7,8 @@ on:
       - synchronize
     branches:
       - master
-        
+      - v9
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

`pull_request_target` workflows are read from the **default branch (master)**, not from the PR's base branch — this is a documented GitHub security behavior. The `branches:` filter on master's `pr_title.yml` was just `[master]`, so PRs targeting `v9` silently skipped both the conventional-PR-title and changelog-update gates.

#2756 added `v9` to the same filter on the v9 branch, but that copy is never consulted for `pull_request_target` events; only master's version matters.

Confirmed via the runs API: comparing recent v9 backport PRs (#2760, #2763) shows `check_db_entities` (no `branches:` filter) ran, while `PR is Conventional and Semantic` did not.

## Test plan

- [x] YAML still parses.
- [ ] After merge, opening or editing the title of a v9 PR should trigger the `PR is Conventional and Semantic` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. Internal workflow configuration was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->