### PR TITLE
fix(core,ui): setting value after being disposed

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+🐛 Fixed
+
+- Fixed a use-after-dispose race condition in `StreamAttachmentPickerController`, `StreamAudioRecorderController`, and `StreamAudioPlaylistController`: async methods could write `value` after `dispose()`, causing a `notifyListeners()` assertion throw in debug mode. All three now use the `DisposeAwareValueNotifier` mixin from `stream_chat_flutter_core`.
+
 ✅ Added
 
 - Added support for `@channel`, `@here`, role, and user-group mentions — parsed on incoming messages, rendered as styled tappable spans in message text, and selectable from the composer's `@` autocomplete.

--- a/packages/stream_chat_flutter/lib/src/audio/audio_playlist_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/audio/audio_playlist_controller.dart
@@ -4,12 +4,14 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:stream_chat_flutter/src/audio/audio_playlist_state.dart';
+import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart' show DisposeAwareValueNotifier;
 import 'package:stream_core_flutter/stream_core_flutter.dart';
 
 /// {@template streamAudioPlaylistController}
 /// A controller for managing an audio playlist.
 /// {@endtemplate}
-class StreamAudioPlaylistController extends ValueNotifier<AudioPlaylistState> {
+class StreamAudioPlaylistController extends ValueNotifier<AudioPlaylistState>
+    with DisposeAwareValueNotifier<AudioPlaylistState> {
   /// {@macro streamAudioPlaylistController}
   factory StreamAudioPlaylistController(List<PlaylistTrack> tracks) {
     return StreamAudioPlaylistController.raw(

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker_controller.dart
@@ -10,7 +10,8 @@ import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 export 'package:stream_chat_flutter/src/message_input/stream_attachment_validator.dart';
 
 /// Controller class for [StreamAttachmentPicker].
-class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerValue> {
+class StreamAttachmentPickerController extends ValueNotifier<AttachmentPickerValue>
+    with DisposeAwareValueNotifier<AttachmentPickerValue> {
   /// Creates a new instance of [StreamAttachmentPickerController].
   ///
   /// The provided [validator] enforces per-attachment upload rules (size,

--- a/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
@@ -18,7 +18,8 @@ import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 /// to the recorder state changes and updates the [AudioRecorderState]
 /// accordingly.
 /// {@endtemplate}
-class StreamAudioRecorderController extends ValueNotifier<AudioRecorderState> {
+class StreamAudioRecorderController extends ValueNotifier<AudioRecorderState>
+    with DisposeAwareValueNotifier<AudioRecorderState> {
   /// {@macro streamAudioRecorderController}
   factory StreamAudioRecorderController({
     RecordConfig? config,

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Upcoming
 
+🐛 Fixed
+
+- Fixed a use-after-dispose race condition in all `PagedValueNotifier` subclasses (`StreamChannelListController`, `StreamUserListController`, `StreamMemberListController`, `StreamThreadListController`, `StreamDraftListController`, `StreamMessageReminderListController`, `StreamPollVoteListController`, `StreamReactionListController`, `StreamMessageSearchListController`): in-flight async loads could write `value` after `dispose()` had been called, triggering a `notifyListeners()` assertion throw in debug mode. A new `DisposeAwareValueNotifier` mixin guards the `value` setter and also prevents event subscriptions from being set up post-dispose.
+
 ✅ Added
 
+- Added `DisposeAwareValueNotifier<T>` mixin on `ValueNotifier<T>` that silently drops post-dispose `value` writes and exposes a `disposed` getter. Useful for any `ValueNotifier` subclass with async methods.
 - Added `mentionedChannel`, `mentionedHere`, `mentionedRoles`, `addMentionedRole`, `mentionedUserGroups`, and `addMentionedUserGroup` to `StreamMessageComposerController` for composing enhanced mentions.
 - Added `StreamMessageComposerController.setCommand(Command)` and `activeCommand` getter for set-aware command activation and tracking.
 - Added `StreamMessageComposerController.validateCommand(Command)` returning a nullable `CommandUnavailableReason` so callers can gate activation against the composer state.

--- a/packages/stream_chat_flutter_core/lib/src/paged_value_notifier.dart
+++ b/packages/stream_chat_flutter_core/lib/src/paged_value_notifier.dart
@@ -4,6 +4,44 @@ import 'package:stream_chat/stream_chat.dart' show StreamChatError;
 
 part 'paged_value_notifier.freezed.dart';
 
+/// A mixin for [ValueNotifier]s whose async methods may write to [value] after
+/// the notifier has already been disposed (e.g. an in-flight network request
+/// completes after the widget that owned the controller has been torn down).
+///
+/// Without this guard, the inherited [ValueNotifier.notifyListeners] throws an
+/// assertion error in debug mode when called on a disposed instance.
+///
+/// Apply this mixin to any [ValueNotifier] subclass whose [value] setter may be
+/// reached from an async context:
+///
+/// ```dart
+/// class MyController extends ValueNotifier<MyState>
+///     with DisposeAwareValueNotifier<MyState> { … }
+/// ```
+///
+/// After the notifier is disposed, any subsequent [value] write is silently
+/// discarded. Use the [disposed] getter to check disposal state if you also
+/// need to skip other side effects (e.g. setting up event subscriptions) that
+/// follow an async operation.
+mixin DisposeAwareValueNotifier<T> on ValueNotifier<T> {
+  bool _disposed = false;
+
+  /// Whether [dispose] has been called on this notifier.
+  bool get disposed => _disposed;
+
+  @override
+  set value(T newValue) {
+    if (_disposed) return;
+    super.value = newValue;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+}
+
 /// Default initial page size multiplier.
 const defaultInitialPagedLimitMultiplier = 3;
 
@@ -18,7 +56,8 @@ typedef PagedValueListenableBuilder<Key, Value> = ValueListenableBuilder<PagedVa
 ///
 /// [PagedValueNotifier] is a [ValueNotifier] that emits a [PagedValue]
 /// whenever the data is loaded or an error occurs.
-abstract class PagedValueNotifier<Key, Value> extends ValueNotifier<PagedValue<Key, Value>> {
+abstract class PagedValueNotifier<Key, Value> extends ValueNotifier<PagedValue<Key, Value>>
+    with DisposeAwareValueNotifier<PagedValue<Key, Value>> {
   /// Creates a [PagedValueNotifier]
   PagedValueNotifier(this._initialValue) : super(_initialValue);
 

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel_list_controller.dart
@@ -146,6 +146,7 @@ class StreamChannelListController extends PagedValueNotifier<int, Channel> {
         );
       }
       // start listening to events
+      if (disposed) return;
       _subscribeToChannelListEvents();
     } on StreamChatError catch (error) {
       value = PagedValue.error(error);

--- a/packages/stream_chat_flutter_core/lib/src/stream_draft_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_draft_list_controller.dart
@@ -122,6 +122,7 @@ class StreamDraftListController extends PagedValueNotifier<String, Draft> {
         nextPageKey: nextKey,
       );
       // Start listening to events
+      if (disposed) return;
       _subscribeToDraftListEvents();
     } on StreamChatError catch (error) {
       value = PagedValue.error(error);

--- a/packages/stream_chat_flutter_core/lib/src/stream_message_reminder_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_message_reminder_list_controller.dart
@@ -125,6 +125,7 @@ class StreamMessageReminderListController extends PagedValueNotifier<String, Mes
         nextPageKey: nextKey,
       );
       // Start listening to events
+      if (disposed) return;
       _subscribeToReminderListEvents();
     } on StreamChatError catch (error) {
       value = PagedValue.error(error);

--- a/packages/stream_chat_flutter_core/lib/src/stream_poll_vote_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_poll_vote_list_controller.dart
@@ -135,6 +135,7 @@ class StreamPollVoteListController extends PagedValueNotifier<String, PollVote> 
       );
 
       // start listening to events
+      if (disposed) return;
       _subscribeToPollVoteEvents();
     } on StreamChatError catch (error) {
       value = PagedValue.error(error);

--- a/packages/stream_chat_flutter_core/lib/src/stream_thread_list_controller.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_thread_list_controller.dart
@@ -158,6 +158,7 @@ class StreamThreadListController extends PagedValueNotifier<String, Thread> {
         nextPageKey: nextKey,
       );
       // Start listening to events
+      if (disposed) return;
       _subscribeToThreadListEvents();
     } on StreamChatError catch (error) {
       value = PagedValue.error(error);

--- a/packages/stream_chat_flutter_core/lib/stream_chat_flutter_core.dart
+++ b/packages/stream_chat_flutter_core/lib/stream_chat_flutter_core.dart
@@ -8,7 +8,12 @@ export 'src/lazy_load_scroll_view.dart';
 export 'src/message_list_core.dart' hide MessageListCoreState;
 export 'src/message_text_field_controller.dart';
 export 'src/paged_value_notifier.dart'
-    show PagedValueListenableBuilder, PagedValue, PagedValueNotifier, PagedValuePatternMatching;
+    show
+        DisposeAwareValueNotifier,
+        PagedValueListenableBuilder,
+        PagedValue,
+        PagedValueNotifier,
+        PagedValuePatternMatching;
 export 'src/paged_value_scroll_view.dart';
 export 'src/stream_channel.dart';
 export 'src/stream_channel_list_controller.dart';

--- a/packages/stream_chat_flutter_core/test/stream_draft_list_controller_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_draft_list_controller_test.dart
@@ -713,5 +713,100 @@ void main() {
 
       expect(controller.dispose, returnsNormally);
     });
+
+    // Regression tests for FLU-529: disposing a controller while a network
+    // request is in-flight must not throw "used after being disposed".
+    test(
+      'disposing during doInitialLoad does not throw when response arrives late',
+      () async {
+        final completer = Completer<QueryDraftsResponse>();
+        when(
+          () => client.queryDrafts(
+            filter: any(named: 'filter'),
+            sort: any(named: 'sort'),
+            pagination: any(named: 'pagination'),
+          ),
+        ).thenAnswer((_) => completer.future);
+
+        final controller = StreamDraftListController(client: client);
+        // Start the load but do NOT await — we want to dispose first.
+        final loadFuture = controller.doInitialLoad();
+        controller.dispose();
+
+        // Resolve the in-flight request after the controller is disposed.
+        final response = QueryDraftsResponse()
+          ..drafts = generateDrafts()
+          ..next = '';
+        completer.complete(response);
+
+        // The future should resolve cleanly with no assertion/exception.
+        await expectLater(loadFuture, completes);
+      },
+    );
+
+    test(
+      'disposing during loadMore does not throw when response arrives late',
+      () async {
+        const nextPageKey = 'page_2';
+        final existingDrafts = generateDrafts();
+
+        // Set up the controller already in a paged success state.
+        final controller = StreamDraftListController.fromValue(
+          PagedValue<String, Draft>(items: existingDrafts, nextPageKey: nextPageKey),
+          client: client,
+        );
+
+        final completer = Completer<QueryDraftsResponse>();
+        when(
+          () => client.queryDrafts(
+            filter: any(named: 'filter'),
+            sort: any(named: 'sort'),
+            pagination: any(named: 'pagination'),
+          ),
+        ).thenAnswer((_) => completer.future);
+
+        final loadMoreFuture = controller.loadMore(nextPageKey);
+        controller.dispose();
+
+        final response = QueryDraftsResponse()
+          ..drafts = generateDrafts(count: 1, startId: 999)
+          ..next = '';
+        completer.complete(response);
+
+        await expectLater(loadMoreFuture, completes);
+      },
+    );
+
+    test(
+      'event subscription is not created when disposed before response arrives',
+      () async {
+        final completer = Completer<QueryDraftsResponse>();
+        // Use a fresh mock client to track `on()` calls per-test.
+        final localClient = MockClient();
+        // Stub `on()` only if needed after dispose — we will verify it is NOT called.
+        when(localClient.on).thenAnswer((_) => const Stream.empty());
+        when(
+          () => localClient.queryDrafts(
+            filter: any(named: 'filter'),
+            sort: any(named: 'sort'),
+            pagination: any(named: 'pagination'),
+          ),
+        ).thenAnswer((_) => completer.future);
+
+        final controller = StreamDraftListController(client: localClient);
+        final loadFuture = controller.doInitialLoad();
+        controller.dispose();
+
+        final response = QueryDraftsResponse()
+          ..drafts = generateDrafts()
+          ..next = '';
+        completer.complete(response);
+        await loadFuture;
+
+        // `on()` is only called to set up the event subscription; if the guard
+        // works, it must not have been reached after dispose.
+        verifyNever(localClient.on);
+      },
+    );
   });
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-529

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
When a controller is disposed while it's loading data it tries to set the value anyway. 
That's throwing an exception in debug mode: 
<img width="994" height="255" alt="image" src="https://github.com/user-attachments/assets/76ed11bc-8e90-4aef-9ce5-c666589e484c" />

This PR makes sure the value setting is skipped when the controller is already disposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race conditions in attachment picker, audio recorder, and audio playlist controls that could cause crashes when async operations completed after controller disposal.
  * Enhanced lifecycle management to safely discard post-disposal updates instead of throwing errors.

* **Tests**
  * Added regression tests for disposal scenarios with in-flight async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->