### PR TITLE
docs(ui): update migration with learnings

### DIFF
--- a/migrations/redesign/headers_and_icons.md
+++ b/migrations/redesign/headers_and_icons.md
@@ -338,9 +338,41 @@ Both approaches are equivalent. If you already have a `StreamComponentFactory` e
 
 ## StreamChatConfigurationData New Fields
 
-Three new optional fields have been added to `StreamChatConfigurationData`. Existing code that does not pass them will use the defaults and requires no changes.
+### Removed: `reactionIcons`
+
+`StreamChatConfigurationData.reactionIcons` (`List<StreamReactionIcon>`) has been **removed**. Reaction icons are now resolved by a `ReactionIconResolver` stored on `reactionIconResolver`.
+
+| Removed                                       | Replacement                                         |
+| --------------------------------------------- | --------------------------------------------------- |
+| `StreamChatConfigurationData.reactionIcons`   | `StreamChatConfigurationData.reactionIconResolver`  |
+| `StreamReactionIcon` model class              | `StreamEmojiContent` (returned by `resolver.resolve(type)`) |
+
+To render a reaction emoji in a custom widget, call `resolver.resolve(type)` and pass the result to `StreamEmoji`:
+
+```dart
+final resolver = StreamChatConfiguration.of(context).reactionIconResolver;
+final content = resolver.resolve('like');           // returns StreamEmojiContent
+StreamEmoji(emoji: content, size: StreamEmojiSize.sm)
+```
+
+The `StreamEmojiSize` enum has values `.sm`, `.md`, and `.lg`.
+
+To supply a custom resolver, pass `reactionIconResolver:` to `StreamChatConfigurationData`:
+
+```dart
+StreamChat(
+  configData: StreamChatConfigurationData(
+    reactionIconResolver: MyCustomReactionIconResolver(),
+  ),
+  child: ...,
+)
+```
+
+---
 
 ### New Fields
+
+Three new optional fields have been added to `StreamChatConfigurationData`. Existing code that does not pass them will use the defaults and requires no changes.
 
 | Field                | Type                                   | Default | Description                                                                                                                               |
 | -------------------- | -------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -442,6 +474,7 @@ For message / reactions-related removals, see [message_widget.md](message_widget
 
 ## Migration Checklist
 
+- [ ] Replace `StreamChatConfigurationData.reactionIcons` with `reactionIconResolver`; render emoji via `resolver.resolve(type)` → `StreamEmoji(emoji: content, size: StreamEmojiSize.sm)`
 - [ ] Replace all `StreamSvgIcon(icon: StreamSvgIcons.*)` with `Icon(context.streamIcons.*)` using the mapping table above
 - [ ] Replace `showBackButton: false` with `automaticallyImplyLeading: false` on every header that used it
 - [ ] Move `onBackPressed: cb` to `leading: StreamBackButton(onPressed: cb)`

--- a/migrations/redesign/message_composer.md
+++ b/migrations/redesign/message_composer.md
@@ -13,6 +13,7 @@ This guide covers the migration for the message composer components in the Strea
 - [StreamMessageComposerInput Split](#streammessagecomposerinput-split)
 - [Message Input Placeholder API](#message-input-placeholder-api)
 - [Attachment Customization](#attachment-customization)
+- [Audio Recorder Migration](#audio-recorder-migration)
 - [Removed Widgets](#removed-widgets)
 - [Theme Removal: StreamMessageInputThemeData](#theme-removal-streammessageinputthemedata)
 - [Migration Checklist](#migration-checklist)
@@ -554,6 +555,64 @@ The following public widget is provided as a building block for custom attachmen
 
 ---
 
+## Audio Recorder Migration
+
+The audio recording widget has been redesigned. `StreamAudioRecorderButton` is **removed**; use `StreamAudioRecorder` instead.
+
+### `StreamAudioRecorderButton` → `StreamAudioRecorder`
+
+`StreamAudioRecorder` separates the recorder state from the UI: it exposes a `builder` callback that receives the current `AudioRecorderState` and a pre-built `button` widget, letting you render any custom chrome around the recording controls.
+
+**Before:**
+```dart
+StreamAudioRecorderButton(
+  controller: _recorder,
+)
+```
+
+**After:**
+```dart
+StreamAudioRecorder(
+  state: recorderState,     // AudioRecorderState from StreamAudioRecorderController
+  button: IconButton(       // your custom finish/send button
+    icon: const Icon(Icons.check),
+    onPressed: _finishRecording,
+  ),
+  builder: (context, state, button) {
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.delete_outline),
+          onPressed: () => _recorder.cancelRecord(),
+        ),
+        Expanded(
+          child: Center(
+            child: switch (state) {
+              RecordStateRecording(:final duration) =>
+                PlaybackTimerText(duration: duration),  // shows elapsed time
+              _ => const SizedBox.shrink(),
+            },
+          ),
+        ),
+        button,
+      ],
+    );
+  },
+)
+```
+
+### `PlaybackTimerText` for recording duration
+
+Use `PlaybackTimerText(duration: duration)` to display the recording elapsed time inside the `StreamAudioRecorder` builder. There is no `RecordingTimer` widget in v10 — `PlaybackTimerText` from `stream_core_flutter` is the correct replacement.
+
+| Old (does not exist in v10) | New                                              |
+| --------------------------- | ------------------------------------------------ |
+| `RecordingTimer`            | `PlaybackTimerText(duration: duration)`          |
+
+`PlaybackTimerText` formats a `Duration` as `MM:SS` and is re-exported from `stream_chat_flutter`.
+
+---
+
 ## Removed Widgets
 
 The following composer-adjacent widgets have been removed. Replace any direct references with the listed alternatives.
@@ -644,3 +703,5 @@ There is no one-to-one replacement — most fields on the old `StreamMessageInpu
 - [ ] Rename `StreamMessageInput.hintGetter` to `placeholderBuilder` and rewrite the callback to switch over `MessageInputPlaceholder` cases (`SlowModePlaceholder`, `CommandPlaceholder`, `AttachmentsPlaceholder`, `WriteMessagePlaceholder`) instead of the removed `HintType` enum. If you build directly on `StreamChatMessageInput`, compute the placeholder string yourself via `MessageInputPlaceholder.resolve(controller)` and pass it via the `placeholder: String` parameter.
 - [ ] Review the new placeholder precedence (`slowMode > command > attachments > writeMessage`) and override `placeholderBuilder` if you need to preserve the old order
 - [ ] Add command-specific placeholders for any backend-defined commands you ship by pattern-matching on `CommandPlaceholder.command` in your `placeholderBuilder`
+- [ ] Replace `StreamAudioRecorderButton` with `StreamAudioRecorder(state:, button:, builder:)`
+- [ ] Replace any `RecordingTimer(duration:)` usage with `PlaybackTimerText(duration: duration)` — `RecordingTimer` does not exist in v10

--- a/migrations/redesign/message_composer.md
+++ b/migrations/redesign/message_composer.md
@@ -603,7 +603,7 @@ StreamAudioRecorder(
 
 ### `PlaybackTimerText` for recording duration
 
-Use `PlaybackTimerText(duration: duration)` to display the recording elapsed time inside the `StreamAudioRecorder` builder. There is no `RecordingTimer` widget in v10 — `PlaybackTimerText` from `stream_core_flutter` is the correct replacement.
+Use `PlaybackTimerText(duration: duration)` to display the recording elapsed time inside the `StreamAudioRecorder` builder. There is no `RecordingTimer` widget in v10 — `PlaybackTimerText` is the correct replacement.
 
 | Old (does not exist in v10) | New                                              |
 | --------------------------- | ------------------------------------------------ |

--- a/migrations/redesign/message_list.md
+++ b/migrations/redesign/message_list.md
@@ -9,6 +9,7 @@ For changes to the individual message item / message widget, see [message_widget
 ## Table of Contents
 
 - [Quick Reference](#quick-reference)
+- [Customizing the Message Item](#customizing-the-message-item)
 - [Config & Builders Split](#config--builders-split)
   - [Behavior flags → `config`](#behavior-flags--config)
   - [Builder callbacks → `builders`](#builder-callbacks--builders)
@@ -27,13 +28,83 @@ For changes to the individual message item / message widget, see [message_widget
 | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `StreamMessageListView(swipeToReply: true, paginationLimit: 20, ...)`      | `StreamMessageListView(config: StreamMessageListViewConfiguration(...))`                        |
 | `StreamMessageListView(loadingBuilder: ..., emptyBuilder: ..., ...)`       | `StreamMessageListView(builders: StreamMessageListViewBuilders(...))`                           |
-| `messageBuilder` / `parentMessageBuilder`                                  | `messageBuilder` (root) / `builders.parentMessage`                                              |
+| `messageBuilder` / `parentMessageBuilder`                                  | Component factory (preferred) or `messageBuilder` (root) / `builders.parentMessage`            |
 | `MessageBuilder` typedef                                                   | `StreamMessageItemBuilder` typedef                                                              |
 | `ParentMessageBuilder` typedef                                             | `StreamMessageItemBuilder` typedef                                                              |
 | `OnQuotedMessageTap = void Function(String?)`                              | `void Function(Message quotedMessage)`                                                          |
 | `MessageDetails` argument                                                  | Removed — alignment via `StreamMessageLayout.of(context)`, user via `StreamChat.of(context)`    |
 | `showUnreadCountOnScrollToBottom: false` (old default)                     | `showUnreadCountOnScrollToBottom: true` (new default)                                           |
 | `StreamDraftListView` / `StreamDraftListTile` / `StreamDraftListTileTheme` | Removed — use `StreamDraftListController` + `PagedValueListView`                                |
+
+---
+
+## Customizing the Message Item
+
+v10 introduces two ways to customize how individual messages render. Choose based on scope:
+
+### Component factory — preferred for app-wide customization
+
+Register a `messageItem` builder on `StreamChat` via `StreamComponentBuilders`. This applies globally: the message list, thread list, action modal previews, and any other place that renders a `StreamMessageItem` all use the same builder automatically — with no extra wiring required.
+
+```dart
+StreamChat(
+  client: client,
+  componentBuilders: StreamComponentBuilders(
+    extensions: streamChatComponentBuilders(
+      messageItem: (context, props) {
+        // Option A: modify props and use the default layout
+        return DefaultStreamMessageItem(
+          props: props.copyWith(
+            actionsBuilder: (context, defaultActions) => [
+              ...defaultActions,
+              myCustomAction,
+            ],
+          ),
+        );
+        // Option B: replace entirely with a custom widget
+        // return MyCustomBubble(message: props.message);
+      },
+    ),
+  ),
+  child: ...,
+)
+```
+
+This is the approach that was not possible before v10. In v9 you had to pass `messageBuilder` to every `StreamMessageListView` separately, and any modal that displayed a message preview (e.g. the long-press actions sheet) would always fall back to the default widget because there was no way to hook into it globally.
+
+### `messageBuilder` — for per-list overrides
+
+`StreamMessageListView.messageBuilder` is still supported. Use it when you need behavior specific to one list — for example, adding swipe-to-reply only on the main channel view while keeping the default layout in thread views:
+
+```dart
+StreamMessageListView(
+  messageBuilder: (context, message, defaultProps) {
+    // StreamMessageItem.fromProps respects the global factory if one is set.
+    final defaultWidget = StreamMessageItem.fromProps(props: defaultProps);
+
+    if (message.isDeleted || message.state.isFailed) return defaultWidget;
+
+    return Swipeable(
+      key: ValueKey(message.id),
+      onSwiped: (_) => onReply(message),
+      child: defaultWidget,
+    );
+  },
+)
+```
+
+`messageBuilder` takes precedence over the component factory for that list. If `messageBuilder` is set, `StreamMessageItem.fromProps` still goes through the factory — so the two compose cleanly: the factory supplies the global style, and `messageBuilder` wraps or modifies it per-list.
+
+### Precedence
+
+```
+messageBuilder (per-list, highest priority)
+  └─ calls StreamMessageItem.fromProps()
+       └─ component factory (app-wide, if registered)
+            └─ DefaultStreamMessageItem (SDK default)
+```
+
+> **Rule of thumb:** use the component factory for anything that should look the same everywhere (custom bubbles, extra actions, branding). Use `messageBuilder` only when behavior genuinely differs per list (swipe gestures, list-specific wrappers).
 
 ---
 
@@ -293,10 +364,12 @@ PagedValueListView<String, Draft>(
 
 ## Migration Checklist
 
+- [ ] If you previously passed `messageBuilder` to every `StreamMessageListView` for app-wide styling, migrate that logic to the component factory via `StreamComponentBuilders(extensions: streamChatComponentBuilders(messageItem: ...))` on `StreamChat` — this automatically covers the action modal preview and all other lists
 - [ ] Move all `StreamMessageListView` behavior flags into `config: StreamMessageListViewConfiguration(...)`
 - [ ] Move all `StreamMessageListView` builder callbacks into `builders: StreamMessageListViewBuilders(...)` and rename per the table above (e.g. `loadingBuilder` → `loading`, `emptyBuilder` → `empty`, `dateDividerBuilder` → `dateDivider`)
-- [ ] Keep `messageBuilder` as a top-level parameter; move `parentMessageBuilder` into `builders.parentMessage`
+- [ ] Keep `messageBuilder` as a top-level parameter only for per-list behavior (e.g. swipe wrappers); move `parentMessageBuilder` into `builders.parentMessage`
 - [ ] Update `messageBuilder` / `parentMessage` callbacks to the new `StreamMessageItemBuilder` signature `(BuildContext, Message, StreamMessageItemProps)`
+- [ ] Inside `messageBuilder`, call `StreamMessageItem.fromProps(props: defaultProps)` instead of using the old `defaultWidget` — this ensures the global component factory is still invoked
 - [ ] Replace `defaultWidget.copyWith(...)` calls with `StreamMessageItem.fromProps(props: defaultProps.copyWith(...))`
 - [ ] Replace `MessageDetails` usage — use `StreamMessageLayout.of(context)` for alignment, `StreamChat.of(context).currentUser` for user ID
 - [ ] Update `onQuotedMessageTap` from `void Function(String?)` to `void Function(Message)`

--- a/migrations/redesign/message_widget.md
+++ b/migrations/redesign/message_widget.md
@@ -325,7 +325,21 @@ MaterialApp(
 
 `StreamColorSwatch.fromColor(Color, [Brightness])` accepts any `Color` and derives the full swatch automatically. `StreamColorScheme.light(brand:)` / `StreamColorScheme.dark(brand:)` are convenience constructors that replace only the brand swatch.
 
-For fine-grained per-alignment control (e.g. different colors for sent vs. received), use `StreamMessageBubbleStyle` inside `StreamMessageItemThemeData` as shown in the [StreamMessageItemThemeData](#streammessageitemthemedata) section.
+For fine-grained per-alignment control (e.g. different colors for sent vs. received), use `StreamMessageBubbleStyle` inside `StreamMessageItemThemeData` with `StreamMessageLayoutProperty`. `StreamMessageLayoutProperty.resolveWith` receives the current `StreamMessageLayout` — which carries alignment, stack position, and other layout details — and returns the value for that specific message:
+
+```dart
+StreamMessageItemThemeData(
+  bubble: StreamMessageBubbleStyle(
+    backgroundColor: StreamMessageLayoutProperty.resolveWith((layout) {
+      return layout.alignment == StreamMessageAlignment.end
+          ? const Color(0xFFDCF8C6) // own message
+          : Colors.white;           // other message
+    }),
+  ),
+)
+```
+
+See the [StreamMessageItemThemeData](#streammessageitemthemedata) section for the full theme example.
 
 **Before (explicit `messageTheme` parameter):**
 ```dart

--- a/migrations/redesign/message_widget.md
+++ b/migrations/redesign/message_widget.md
@@ -70,9 +70,15 @@ The old design used a single monolithic `StreamMessageItem` with 50+ parameters 
 
 ### Component Factory Pattern
 
-The new design adds a **component factory** layer for app-wide customization. The `messageBuilder` / `parentMessageBuilder` callbacks on `StreamMessageListView` are still supported for per-list customization.
+The new design adds a **component factory** layer for app-wide customization. This is the **preferred way** to customize the message widget in v10.
 
-**App-wide customization via component factory:**
+**Why the factory is preferred over `messageBuilder`:**
+
+In v9, `messageBuilder` was the only customization hook — but it only applied to the list you passed it to. Any other place that renders a message (most notably the long-press actions modal, which shows a preview of the message being acted on) always used the default widget. You had no way to make those previews match your custom bubble without forking SDK internals.
+
+In v10, `StreamMessageItem` resolves its builder from `StreamComponentFactory` (via `context.chatComponentBuilder<StreamMessageItemProps>()`). Register a factory once on `StreamChat` and every `StreamMessageItem` across the app — message list, thread list, actions modal preview — uses your custom widget automatically.
+
+**App-wide customization via component factory (preferred):**
 ```dart
 StreamChat(
   client: client,
@@ -93,16 +99,21 @@ StreamChat(
 )
 ```
 
-**Per-list customization via `messageBuilder` (still supported):**
+**Per-list customization via `messageBuilder` (use only for list-specific behavior):**
 ```dart
 StreamMessageListView(
   messageBuilder: (context, message, defaultProps) {
-    return StreamMessageItem.fromProps(props: defaultProps);
+    // StreamMessageItem.fromProps goes through the factory, so global
+    // customization is still applied even inside a per-list messageBuilder.
+    final defaultWidget = StreamMessageItem.fromProps(props: defaultProps);
+    return Swipeable(onSwiped: (_) => onReply(message), child: defaultWidget);
   },
 )
 ```
 
-Both can be combined — the component factory applies first, then the per-list `messageBuilder` can further customize or wrap the result. See [message_list.md](message_list.md) for details on the `messageBuilder` signature and the new `config` / `builders` split on `StreamMessageListView`.
+The two compose cleanly: `messageBuilder` takes precedence for that list; calling `StreamMessageItem.fromProps` inside it still invokes the factory. Reserve `messageBuilder` for behavior that genuinely differs per list (gesture wrappers, list-specific layout changes). Everything else belongs in the factory.
+
+See [message_list.md](message_list.md) for details on the `messageBuilder` signature, the `config` / `builders` split, and when to choose each approach.
 
 ---
 

--- a/migrations/redesign/message_widget.md
+++ b/migrations/redesign/message_widget.md
@@ -290,6 +290,32 @@ actionsBuilder: (context, defaultActions) {
 | `StreamChatThemeData.otherMessageTheme`    | Placement-aware styling via `StreamMessageLayoutProperty.resolveWith` on individual style fields (e.g. `bubble`, `metadata`) |
 | `StreamMessageItem.messageTheme` parameter | Resolved from context via `StreamMessageItemTheme.of(context)`             |
 
+### Changing the own-message bubble color
+
+The own-message bubble background is derived from `StreamColorScheme.brand.shade100`. The simplest way to change it app-wide is to provide a custom brand swatch via `StreamTheme` as a `ThemeExtension`:
+
+```dart
+// In your MaterialApp theme:
+MaterialApp(
+  theme: ThemeData(
+    extensions: [
+      StreamTheme(
+        colorScheme: StreamColorScheme.light(
+          // StreamColorSwatch.fromColor generates a full 11-shade swatch from
+          // a single color. shade100 ≈ a light tint — this becomes the own-message
+          // bubble background. For example, WhatsApp green produces ≈ #DCF8C6.
+          brand: StreamColorSwatch.fromColor(const Color(0xFF25D366)),
+        ),
+      ),
+    ],
+  ),
+)
+```
+
+`StreamColorSwatch.fromColor(Color, [Brightness])` accepts any `Color` and derives the full swatch automatically. `StreamColorScheme.light(brand:)` / `StreamColorScheme.dark(brand:)` are convenience constructors that replace only the brand swatch.
+
+For fine-grained per-alignment control (e.g. different colors for sent vs. received), use `StreamMessageBubbleStyle` inside `StreamMessageItemThemeData` as shown in the [StreamMessageItemThemeData](#streammessageitemthemedata) section.
+
 **Before (explicit `messageTheme` parameter):**
 ```dart
 StreamMessageItem(

--- a/migrations/v10-migration.md
+++ b/migrations/v10-migration.md
@@ -8,6 +8,7 @@ This guide covers all breaking changes in **Stream Chat Flutter SDK v10.0.0**. W
 
 - [Who Should Read This](#who-should-read-this)
 - [Quick Reference](#quick-reference)
+- [StreamChat Widget](#streamchat-widget)
 - [Attachment Picker](#attachment-picker)
     - [AttachmentPickerType](#attachmentpickertype)
     - [StreamAttachmentPickerOption](#streamattachmentpickeroption)
@@ -60,12 +61,41 @@ Each breaking change section includes an **"Introduced in"** tag so you can quic
 
 | Feature Area                                        | Key Changes                                                                          |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [**StreamChat Widget**](#streamchat-widget)         | `streamChatThemeData:` renamed to `themeData:`                                       |
 | [**Attachment Picker**](#attachment-picker)         | Sealed class hierarchy, builder pattern for options, typed result handling           |
 | [**Reactions**](#reactions)                         | `Reaction` object API, explicit `onReactionPicked` callbacks required                |
 | [**Message UI**](#message-ui)                       | `StreamAttachmentWidgetTapCallback` signature `void Function(Message, Attachment)`; sealed `MessageAction` hierarchy with `actionsBuilder` |
 | [**Message State**](#message-state--deletion)       | `MessageDeleteScope` replaces `bool hard`, delete-for-me support                     |
 | [**File Upload**](#file-upload)                     | Four new abstract methods on `AttachmentFileUploader`                                |
 | [**Unread Threads Banner**](#unread-threads-banner) | Wrapper pattern with `child`, `enabled`, `onRefresh`; removed `onTap`, `minHeight`   |
+
+---
+
+## StreamChat Widget
+
+### `streamChatThemeData` renamed to `themeData`
+
+> **Introduced in:** v10.0.0
+
+The `streamChatThemeData` constructor parameter on `StreamChat` has been renamed to `themeData`.
+
+**Before:**
+```dart
+StreamChat(
+  client: client,
+  streamChatThemeData: myTheme,
+  child: child!,
+)
+```
+
+**After:**
+```dart
+StreamChat(
+  client: client,
+  themeData: myTheme,
+  child: child!,
+)
+```
 
 ---
 
@@ -199,6 +229,22 @@ StreamMessageComposer(
 
 > **Important:**  
 > The picker is now inline. If you previously opened the picker programmatically, integrate it into the composer instead of calling a separate function.
+
+#### Custom composer implementations
+
+If you have a fully custom composer (i.e. you do **not** use `StreamMessageComposer`) and need to add attachments programmatically, there is no public API to open the inline picker from outside the composer. Instead, build your own custom attachment picker or use a platform file picker directly and add the result to your `StreamMessageComposerController`:
+
+```dart
+// Using the image_picker package (add to pubspec.yaml: image_picker: ^1.0.0)
+Future<void> _openGallery() async {
+  final image = await ImagePicker().pickImage(source: ImageSource.gallery);
+  if (image == null || !mounted) return;
+  final attachment = await image.toAttachment(type: AttachmentType.image);
+  _controller.addAttachment(attachment);
+}
+```
+
+The `XFile.toAttachment(type:)` extension method is provided by `stream_chat_flutter`.
 
 ---
 
@@ -1239,6 +1285,7 @@ This appendix provides a chronological reference of breaking changes by beta ver
 ## Migration Checklist
 
 ### For v10.0.0 (stable)
+- [ ] Rename `StreamChat` constructor parameter `streamChatThemeData:` → `themeData:`
 - [ ] Move `StreamMessageListView` behavior flags to `config: StreamMessageListViewConfiguration(...)`
 - [ ] Move `StreamMessageListView` builder callbacks to `builders: StreamMessageListViewBuilders(...)`
 - [ ] Rename `StreamMessageInputController` → `StreamMessageComposerController`

--- a/migrations/v10-migration.md
+++ b/migrations/v10-migration.md
@@ -707,8 +707,8 @@ StreamMessageItem(
 
 #### Key Changes:
 
-- `showReactionTail` parameter has been removed
-- Tail now automatically shows when the picker is visible
+- `showReactionTail` parameter has been removed. Tail now automatically shows when the picker is visible.
+- `StreamMessageItem` is now a thin shell that resolves its builder from `StreamComponentFactory`. Register a global builder on `StreamChat` to override the message widget app-wide — no per-list wiring needed.
 
 #### Migration Steps:
 
@@ -727,8 +727,50 @@ StreamMessageItem(
 );
 ```
 
+#### Global message widget customization via component factory
+
+In v9 the only customization hook was `messageBuilder` on `StreamMessageListView`, which only applied to that one list. The long-press actions modal and any other place that renders a message always showed the default widget.
+
+In v10, `StreamMessageItem` looks up a builder from `StreamComponentFactory`. Register one on `StreamChat` and every message rendered anywhere in the app — list, thread view, actions modal preview — uses your custom widget automatically:
+
+```dart
+StreamChat(
+  client: client,
+  componentBuilders: StreamComponentBuilders(
+    extensions: streamChatComponentBuilders(
+      messageItem: (context, props) {
+        // Modify props and use the default layout:
+        return DefaultStreamMessageItem(
+          props: props.copyWith(
+            actionsBuilder: (context, defaultActions) => [
+              ...defaultActions,
+              myCustomAction,
+            ],
+          ),
+        );
+        // Or replace entirely:
+        // return MyCustomBubble(message: props.message);
+      },
+    ),
+  ),
+  child: ...,
+)
+```
+
+`StreamMessageListView.messageBuilder` is still supported for per-list overrides. Inside it, call `StreamMessageItem.fromProps(props: defaultProps)` to ensure the factory is still invoked:
+
+```dart
+StreamMessageListView(
+  messageBuilder: (context, message, defaultProps) {
+    final widget = StreamMessageItem.fromProps(props: defaultProps);
+    return Swipeable(onSwiped: (_) => onReply(message), child: widget);
+  },
+)
+```
+
 > **Important:**  
-> The `showReactionTail` parameter is no longer supported. Tail is now always shown when the picker is visible.
+> The `showReactionTail` parameter is no longer supported. Tail is now always shown when the picker is visible.  
+> Prefer the component factory over `messageBuilder` for any customization that should apply globally (custom bubbles, extra actions, branding). Use `messageBuilder` only for per-list behavior such as swipe gestures.
 
 ---
 
@@ -1058,6 +1100,10 @@ StreamMessageListView(
 )
 ```
 
+**`messageBuilder` vs the component factory**
+
+`messageBuilder` is still the right tool for per-list behavior (e.g. a swipe-to-reply wrapper on one specific list). For anything that should look the same everywhere — custom bubble style, extra actions, branding — use the component factory on `StreamChat` instead. The factory applies to all message lists, thread views, and the long-press actions modal preview without any per-list wiring. See the [`StreamMessageItem`](#streammessageitem) section above for the full example.
+
 ---
 
 ### StreamMessageComposerController Rename
@@ -1286,6 +1332,7 @@ This appendix provides a chronological reference of breaking changes by beta ver
 
 ### For v10.0.0 (stable)
 - [ ] Rename `StreamChat` constructor parameter `streamChatThemeData:` → `themeData:`
+- [ ] If you passed `messageBuilder` to multiple `StreamMessageListView` instances for app-wide styling, consolidate into `StreamComponentBuilders(extensions: streamChatComponentBuilders(messageItem: ...))` on `StreamChat` — the factory also covers the actions modal preview automatically
 - [ ] Move `StreamMessageListView` behavior flags to `config: StreamMessageListViewConfiguration(...)`
 - [ ] Move `StreamMessageListView` builder callbacks to `builders: StreamMessageListViewBuilders(...)`
 - [ ] Rename `StreamMessageInputController` → `StreamMessageComposerController`


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Tested migrating an app and added some missing migration docs in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guides for reaction icon handling, including the move from `reactionIcons` to a resolver-based flow for rendering emojis.
  * Added an “Audio Recorder Migration” section covering the redesigned recorder UI and the replacement for the recording/playback timer.
  * Expanded message-widget and message-list customization guidance, emphasizing app-wide component factory usage and clarifying `messageBuilder` per-list precedence.
  * Enhanced the v10 migration checklist, including the `streamChatThemeData:` → `themeData:` rename and composer/attachments customization steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->