### PR TITLE
test: trigger check_db_entities (do not merge)

### DIFF
--- a/packages/stream_chat_persistence/lib/src/entity/messages.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/messages.dart
@@ -1,4 +1,5 @@
 // coverage:ignore-file
+// test: trigger check_db_entities workflow (revert before merge)
 import 'package:drift/drift.dart';
 import 'package:stream_chat_persistence/src/converter/list_converter.dart';
 import 'package:stream_chat_persistence/src/converter/map_converter.dart';


### PR DESCRIPTION
## Summary

Exercises the updated `check_db_entities` workflow from #2771 by making a
comment-only edit to an entity file **without** bumping `schemaVersion`.

Base is `chore/enforce-db-version-bump` (not `master`) because the
workflow runs on `pull_request_target`, which uses the workflow file from
the **base** of the PR — so we need the new logic deployed to the base.

## Expected behavior

- ❌ `check_db_entities` job fails.
- Bot posts a comment listing `messages.dart` and a ` ```diff ` block
  suggesting `int get schemaVersion => 1000 + 33;` → `1000 + 34;`.

## After verifying

Close this PR without merging. The entity edit on `test/db-entity-check-trigger`
gets thrown away; #2771 itself is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)