### PR TITLE
fix(repo): update docs_screenshots channel-list stub for queryChannelsWithResult

### DIFF
--- a/docs/docs_screenshots/test/src/golden_client_stubs.dart
+++ b/docs/docs_screenshots/test/src/golden_client_stubs.dart
@@ -28,9 +28,12 @@ void stubQueryChannelsForGoldens(MockClient client, List<Channel> channels) {
   _ensureGoldenMocktailFallbacks();
   stubStreamClientEventStream(client);
   when(
-    () => client.queryChannels(
+    () => client.queryChannelsWithResult(
       filter: any(named: 'filter'),
       channelStateSort: any(named: 'channelStateSort'),
+      predefinedFilter: any(named: 'predefinedFilter'),
+      filterValues: any(named: 'filterValues'),
+      sortValues: any(named: 'sortValues'),
       state: any(named: 'state'),
       watch: any(named: 'watch'),
       presence: any(named: 'presence'),
@@ -39,7 +42,7 @@ void stubQueryChannelsForGoldens(MockClient client, List<Channel> channels) {
       paginationParams: any(named: 'paginationParams'),
       waitForConnect: any(named: 'waitForConnect'),
     ),
-  ).thenAnswer((_) => Stream.value(channels));
+  ).thenAnswer((_) => Stream.value(QueryChannelsResult(channels: channels)));
 }
 
 /// Stubs thread queries for [StreamThreadListController] goldens using [StreamThreadListController.fromValue].


### PR DESCRIPTION
Linear: FLU-
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`StreamChannelListController` switched from `client.queryChannels(...)` to `client.queryChannelsWithResult(...)` in #2709 (PredefinedFilters). The docs golden stub `stubQueryChannelsForGoldens` in `docs/docs_screenshots/test/src/golden_client_stubs.dart` was never updated, so mocktail threw `MissingStubError` on the new call and the controller hit its error branch — every `StreamChannelListView` golden (`channel_list_view.png`, `slidable_channel_list.png`) rendered the "Error loading channels / Retry" fallback instead of the channels.

This PR points the stub at `queryChannelsWithResult`, wraps the returned channels in `QueryChannelsResult(channels: channels)`, and adds `any(...)` matchers for the new named args (`predefinedFilter`, `filterValues`, `sortValues`).

Goldens themselves are not committed here — run the `update_goldens` workflow with `target: docs` after merge and the macOS job will regenerate `channel_list_view.png` and `slidable_channel_list.png`.

## Screenshots / Videos

n/a — golden regeneration follows in a separate auto-commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mocks to ensure compatibility with current API patterns and support for additional query parameters in channel-list testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->