### PR TITLE
fix(llc): Fixed resetting channel unread count on `message.read` events delivered for threads

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - `Message.toJson` mention sanitization (`removeMentionsIfNotIncluded`) now requires `@token` to match at a word boundary, so e.g. typing `@administrator` no longer keeps a stale `admin` role mention alive, and `@channels` / `@hereafter` no longer keep `mentionedChannel` / `mentionedHere` set.
 - Fixed an unhandled `WebSocketChannelException` surfacing when a reconnect attempt failed (e.g. DNS lookup failed in background); the duplicate signal on `sink.done` is now ignored since the stream's `onError` already handles it.
+- Fixed resetting channel unread count on `message.read` events delivered for threads. 
 
 ## 10.0.1
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -3353,6 +3353,9 @@ class ChannelClientState {
       ..add(
         _channel.on(EventType.messageRead).listen(
           (event) {
+            // Skip handling the event if delivered for a thread
+            if (event.thread != null) return;
+
             final user = event.user;
             if (user == null) return;
 

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -5854,6 +5854,61 @@ void main() {
         },
       );
 
+      test(
+        'should not update channel read state on thread message read event',
+        () async {
+          final currentUser = User(id: 'test-user');
+          final currentRead = Read(
+            user: currentUser,
+            lastRead: DateTime(2020),
+            unreadMessages: 10,
+            lastReadMessageId: 'channel-msg-1',
+          );
+
+          // Setup initial channel read state
+          channel.state?.updateChannelState(
+            channel.state!.channelState.copyWith(
+              read: [currentRead],
+            ),
+          );
+
+          // Verify initial state
+          final read = channel.state?.read.first;
+          expect(read?.unreadMessages, 10);
+          expect(read?.lastReadMessageId, 'channel-msg-1');
+          expect(read?.lastRead.isAtSameMomentAs(DateTime(2020)), isTrue);
+
+          // Create a thread-scoped message.read event (thread != null)
+          final threadMessageReadEvent = Event(
+            cid: channel.cid,
+            type: EventType.messageRead,
+            user: currentUser,
+            createdAt: DateTime(2022),
+            lastReadMessageId: 'thread-reply-99',
+            thread: Thread(
+              channelCid: channel.cid!,
+              parentMessageId: 'parent-msg-1',
+              createdByUserId: currentUser.id,
+              replyCount: 3,
+              participantCount: 2,
+            ),
+          );
+
+          // Dispatch event
+          client.addEvent(threadMessageReadEvent);
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Channel read state must be untouched — thread reads
+          // must not clobber the channel-level Read.
+          final after = channel.state?.read.first;
+          expect(after?.unreadMessages, 10);
+          expect(after?.lastReadMessageId, 'channel-msg-1');
+          expect(after?.lastRead.isAtSameMomentAs(DateTime(2020)), isTrue);
+        },
+      );
+
       test('should update read state on notification mark unread event', () async {
         // Create the current read state
         final currentUser = User(id: 'test-user');


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-552

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
`message.read` events can be delivered for two purposes:
- when a channel is marked as read
- when a thread is marked as read

We currently don't distinguish between those, and we always reset the channel unread count, even if the event was delivered in a thread scope. In this PR, we completely skip the handling the of the `message.read` event, if it was delivered for a thread.
_Note: This also aligns the `message.read` handling with Android/iOS._

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8f1db706-cb63-474b-b391-f20213f276da" controls="controls"></video> |<video src="https://github.com/user-attachments/assets/da74bbbb-8465-4611-8fde-e460dd507dc3" controls="controls"></video> |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the SDK was incorrectly resetting a channel's unread count when read receipts were received for thread messages. Thread-level message read events no longer affect the channel-level read state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->