### PR TITLE
fix(llc): Fixed resetting channel unread count on `message.read` events delivered for threads [v9]

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed an unhandled `WebSocketChannelException` surfacing when a reconnect attempt failed (e.g. DNS lookup failed in background); the duplicate signal on `sink.done` is now ignored since the stream's `onError` already handles it.
 - Fixed failing to parse `null` values in `UpsertPushPreferencesResponse.userPreferences` JSON.
+- Fixed resetting channel unread count on `message.read` events delivered for threads. 
 
 ## 9.25.0
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -3098,6 +3098,9 @@ class ChannelClientState {
       ..add(
         _channel.on(EventType.messageRead).listen(
           (event) {
+            // Skip handling the event if delivered for a thread
+            if (event.thread != null) return;
+
             final user = event.user;
             if (user == null) return;
 

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -4833,6 +4833,61 @@ void main() {
         },
       );
 
+      test(
+        'should not update channel read state on thread message read event',
+        () async {
+          final currentUser = User(id: 'test-user');
+          final currentRead = Read(
+            user: currentUser,
+            lastRead: DateTime(2020),
+            unreadMessages: 10,
+            lastReadMessageId: 'channel-msg-1',
+          );
+
+          // Setup initial channel read state
+          channel.state?.updateChannelState(
+            channel.state!.channelState.copyWith(
+              read: [currentRead],
+            ),
+          );
+
+          // Verify initial state
+          final read = channel.state?.read.first;
+          expect(read?.unreadMessages, 10);
+          expect(read?.lastReadMessageId, 'channel-msg-1');
+          expect(read?.lastRead.isAtSameMomentAs(DateTime(2020)), isTrue);
+
+          // Create a thread-scoped message.read event (thread != null)
+          final threadMessageReadEvent = Event(
+            cid: channel.cid,
+            type: EventType.messageRead,
+            user: currentUser,
+            createdAt: DateTime(2022),
+            lastReadMessageId: 'thread-reply-99',
+            thread: Thread(
+              channelCid: channel.cid!,
+              parentMessageId: 'parent-msg-1',
+              createdByUserId: currentUser.id,
+              replyCount: 3,
+              participantCount: 2,
+            ),
+          );
+
+          // Dispatch event
+          client.addEvent(threadMessageReadEvent);
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Channel read state must be untouched — thread reads
+          // must not clobber the channel-level Read.
+          final after = channel.state?.read.first;
+          expect(after?.unreadMessages, 10);
+          expect(after?.lastReadMessageId, 'channel-msg-1');
+          expect(after?.lastRead.isAtSameMomentAs(DateTime(2020)), isTrue);
+        },
+      );
+
       test('should update read state on notification mark unread event',
           () async {
         // Create the current read state


### PR DESCRIPTION
Port of #2780 to the `v9` branch.

Linear: FLU-552

## Description
`message.read` events can be delivered for two purposes:
- when a channel is marked as read
- when a thread is marked as read

We currently don't distinguish between those, and we always reset the channel unread count, even if the event was delivered in a thread scope. In this PR, we completely skip the handling of the `message.read` event, if it was delivered for a thread.

_Note: This also aligns the `message.read` handling with Android/iOS._

## Test plan
- [x] New unit test `should not update channel read state on thread message read event` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)