### PR TITLE
perf(persistence): add indexes to speed up offline channel-list reads

### DIFF
--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Upcoming
+
+🚀 Performance
+
+- Add indices on the `channel_cid` column on the `Messages`, `Members`, and `Reads` tables to improve read times on large databases.
+- Add indices on the `message_id` column on the `Reactions` table to improve read times on large databases.
+
 ## 10.1.0
 
 ✅ Added

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -58,7 +58,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 1000 + 34;
+  int get schemaVersion => 1000 + 35;
 
   // Store DateTime as ISO-8601 text to preserve sub-second precision.
   @override

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -11737,6 +11737,22 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
   late final $ConnectionEventsTable connectionEvents = $ConnectionEventsTable(
     this,
   );
+  late final Index idxMessagesChannelCid = Index(
+    'idx_messages_channel_cid',
+    'CREATE INDEX idx_messages_channel_cid ON messages (channel_cid)',
+  );
+  late final Index idxReactionsMessageId = Index(
+    'idx_reactions_message_id',
+    'CREATE INDEX idx_reactions_message_id ON reactions (message_id)',
+  );
+  late final Index idxMembersChannelCid = Index(
+    'idx_members_channel_cid',
+    'CREATE INDEX idx_members_channel_cid ON members (channel_cid)',
+  );
+  late final Index idxReadsChannelCid = Index(
+    'idx_reads_channel_cid',
+    'CREATE INDEX idx_reads_channel_cid ON reads (channel_cid)',
+  );
   late final UserDao userDao = UserDao(this as DriftChatDatabase);
   late final ChannelDao channelDao = ChannelDao(this as DriftChatDatabase);
   late final MessageDao messageDao = MessageDao(this as DriftChatDatabase);
@@ -11778,6 +11794,10 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
     channelQueries,
     channelQueriesMetadata,
     connectionEvents,
+    idxMessagesChannelCid,
+    idxReactionsMessageId,
+    idxMembersChannelCid,
+    idxReadsChannelCid,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/packages/stream_chat_persistence/lib/src/entity/members.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/members.dart
@@ -5,6 +5,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Members] table in [DriftChatDatabase].
 @DataClassName('MemberEntity')
+@TableIndex(name: 'idx_members_channel_cid', columns: {#channelCid})
 class Members extends Table {
   /// The interested user id
   TextColumn get userId => text()();

--- a/packages/stream_chat_persistence/lib/src/entity/messages.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/messages.dart
@@ -7,6 +7,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Messages] table in [DriftChatDatabase].
 @DataClassName('MessageEntity')
+@TableIndex(name: 'idx_messages_channel_cid', columns: {#channelCid})
 class Messages extends Table {
   /// The message id
   TextColumn get id => text()();

--- a/packages/stream_chat_persistence/lib/src/entity/reactions.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/reactions.dart
@@ -5,6 +5,7 @@ import 'package:stream_chat_persistence/src/entity/messages.dart';
 
 /// Represents a [Reactions] table in [DriftChatDatabase].
 @DataClassName('ReactionEntity')
+@TableIndex(name: 'idx_reactions_message_id', columns: {#messageId})
 class Reactions extends Table {
   /// The id of the user that sent the reaction
   TextColumn get userId => text().nullable()();

--- a/packages/stream_chat_persistence/lib/src/entity/reads.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/reads.dart
@@ -4,6 +4,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Reads] table in [DriftChatDatabase].
 @DataClassName('ReadEntity')
+@TableIndex(name: 'idx_reads_channel_cid', columns: {#channelCid})
 class Reads extends Table {
   /// Date of the read event
   DateTimeColumn get lastRead => dateTime()();


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-555

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

### Problem

Pull-to-refresh on the channel list freezes the UI (spinner stops animating) for several seconds on large local databases. The refresh runs the offline read first, synchronously on the **main isolate** (default `ConnectionMode.regular`). Each `getChannelStateByCid` fires per-channel lookups on `messages`/`members`/`reads` (by `channel_cid`) and `reactions` (by `message_id`) — and the persistence schema had **no indexes**, so every one is a **full table scan**, run ~30× per refresh (page size). Cost grows linearly with total local rows, blocking the UI thread for seconds once the cache is large.

### Fix

Add SQLite indexes on the columns the offline read filters by, via drift `@TableIndex` annotations:

- `messages(channel_cid)` — the dominant one (largest table, scanned 30× per refresh)
- `members(channel_cid)`
- `reads(channel_cid)`
- `reactions(message_id)`

`schemaVersion` is bumped (1034 → 1035). No hand-written migration is needed — `DriftChatDatabase.migration.onUpgrade` is already fully destructive (drops all tables + `createAll()` on any version change), so `createAll()` builds the indexes for both fresh installs and upgrades.

Pinned-message tables (`pinned_messages`, `pinned_message_reactions`) are intentionally **not** indexed — they're structurally small (a handful of pins per channel), so a scan is cheap and an index would only add write cost.

### Measured impact

Offline-read median time (the frozen-spinner window):

| Environment | Data | Before | After |
| --- | --- | ---: | ---: |
| iPhone (iOS 26.5.1), profile | 1.5M messages | **4.34 s** | **92 ms** (~47×) |
| Host (macOS) | 200k messages | 640 ms | 100 ms |

The read also becomes **flat** — it no longer degrades as the DB grows.

**Write overhead** (measured, host):
- Insert-only path (`message.new` → `updateMessages`): **+2%** (index B-tree maintenance; grows only logarithmically with table size).
- Bulk sync path (`updateChannelStates`, 50k msgs): **44% faster** — that path deletes existing rows by `channel_cid`/`message_id` before re-inserting, and those deletes were full scans without the index.

Verified: `flutter analyze` clean, all 310 persistence tests pass, and the hang was reproduced before/after on a physical iPhone and an Android emulator.

### Test instructions

The change is schema-only. To reproduce the before/after manually, apply the debug seed-handle patch below to the sample app, seed a large local DB, enable airplane mode (so the online query can't mask the offline read), and pull-to-refresh.

<details>
<summary>Debug seed-handle patch (adds a "Seed stress DB data" drawer action to the sample app) — <code>git apply</code> this</summary>

```diff
# DB stress-test seed handle (sample app) — debug tooling, not part of the fix.
#
# Adds a debug-only "Seed stress DB data" action to the sample app drawer
# (Configuration section) that writes large amounts of dummy channels/messages
# straight into the local SQLite cache, to reproduce the channel-list
# pull-to-refresh hang on large offline databases.
#
# Apply from the repo root:
#   git apply sample_app/tool/db_stress_seed_handle.patch
#
# Run the sample app (profile mode recommended, esp. on iOS):
#   cd sample_app && flutter run --profile
#
# In the app: drawer -> "Seed stress DB data" -> pick a preset -> enable
# airplane mode -> pull-to-refresh. Revert with:
#   git apply -R sample_app/tool/db_stress_seed_handle.patch
#
diff --git a/sample_app/lib/pages/channel_list_page.dart b/sample_app/lib/pages/channel_list_page.dart
index 4b7cd032a..00a617ff2 100644
--- a/sample_app/lib/pages/channel_list_page.dart
+++ b/sample_app/lib/pages/channel_list_page.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app_badger/flutter_app_badger.dart';
 import 'package:go_router/go_router.dart';
@@ -14,6 +15,7 @@ import 'package:sample_app/pages/thread_list_page.dart';
 import 'package:sample_app/routes/routes.dart';
 import 'package:sample_app/utils/shared_location_service.dart';
 import 'package:sample_app/widgets/channel_list.dart';
+import 'package:sample_app/widgets/db_stress_seeder_sheet.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 class ChannelListPage extends StatefulWidget {
@@ -258,6 +260,25 @@ class LeftDrawer extends StatelessWidget {
               ),
             ),
 
+            // ── Debug: seed the local DB to reproduce the refresh hang ──
+            // Shown in debug + profile builds (hidden in release). Profile mode
+            // is the right way to reproduce: AOT avoids debug-JIT crashes and
+            // gives realistic timings.
+            if (!kReleaseMode)
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: spacing.xs),
+                child: StreamListTile(
+                  contentPadding: EdgeInsets.symmetric(horizontal: spacing.sm, vertical: spacing.xxxs),
+                  leading: const Icon(Icons.storage_outlined, size: 24),
+                  title: const Text('Seed stress DB data'),
+                  trailing: Icon(Icons.chevron_right_outlined, size: 20, color: colorScheme.textTertiary),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    showDbStressSeederSheet(context);
+                  },
+                ),
+              ),
+
             const Spacer(),
 
             // ── Bottom actions ──
diff --git a/sample_app/lib/utils/db_stress_seeder.dart b/sample_app/lib/utils/db_stress_seeder.dart
new file mode 100644
index 000000000..3d18281ab
--- /dev/null
+++ b/sample_app/lib/utils/db_stress_seeder.dart
@@ -0,0 +1,163 @@
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+/// Writes a large amount of dummy channel/message data straight into the local
+/// SQLite cache to reproduce the pull-to-refresh UI hang on-device.
+///
+/// The hang is the synchronous, main-isolate offline read the SDK runs first on
+/// every refresh (`queryChannelStates`). Its cost grows with the total rows in
+/// the local DB because the per-channel message/member/read lookups are
+/// unindexed full table scans. This seeder inflates that DB.
+///
+/// The seeded channels are registered under the same predefined-filter query
+/// cache the sample app's channel list uses, so they show up in the offline
+/// read (and the refresh that follows it hangs). Reproduce like this:
+///   1. Tap the seed action and wait for it to finish.
+///   2. Pull-to-refresh the channel list — the spinner freezes for seconds.
+///   3. For a repeatable hang, enable airplane mode first so the online query
+///      can't replace the seeded cache; every pull-to-refresh then hangs.
+class DbStressSeeder {
+  DbStressSeeder({
+    required this.client,
+    required this.userId,
+  });
+
+  /// The connected client whose persistence cache is seeded.
+  final StreamChatClient client;
+
+  /// The current user id — seeded channels are members-scoped to this id and
+  /// registered under the channel list's predefined-filter cache for this user.
+  final String userId;
+
+  /// Predefined filter used by the sample app channel list (see
+  /// `ChannelList._channelListController`).
+  static const _predefinedFilter = 'stream_chat_flutter_sample_app';
+
+  static const _cidPrefix = 'messaging:stress-seed';
+
+  /// Hard ceiling on total seeded messages. Beyond this the debug (JIT) build
+  /// starts crashing on startup under memory pressure while reading the cache.
+  static const _maxTotalMessages = 600000;
+
+  /// Seeds [channels] channels, each with [messagesPerChannel] messages and
+  /// [membersPerChannel] members, into the local DB.
+  ///
+  /// [onProgress] is called with the number of channels written so far so the
+  /// caller can show progress. Returns the total messages written.
+  Future<int> seed({
+    required int channels,
+    required int messagesPerChannel,
+    int membersPerChannel = 2,
+    void Function(int seededChannels, int totalChannels)? onProgress,
+  }) async {
+    final persistence = client.chatPersistenceClient;
+    if (persistence == null) {
+      throw StateError('No persistence client — offline storage is disabled.');
+    }
+
+    if (channels * messagesPerChannel > _maxTotalMessages) {
+      throw ArgumentError(
+        'Refusing to seed ${channels * messagesPerChannel} messages — exceeds '
+        'the $_maxTotalMessages ceiling that keeps the app bootable.',
+      );
+    }
+
+    final base = DateTime(2024);
+    const batchSize = 25;
+
+    for (var start = 0; start < channels; start += batchSize) {
+      final end = (start + batchSize).clamp(0, channels);
+      final states = <ChannelState>[
+        for (var i = start; i < end; i++)
+          _channelState(i, channels, messagesPerChannel, membersPerChannel, base),
+      ];
+      await persistence.updateChannelStates(states);
+      onProgress?.call(end, channels);
+    }
+
+    // Register the seeded cids under the channel list's predefined-filter cache
+    // so the offline read returns them. This is the runtime
+    // StreamChatPersistenceClient override (the base impl no-ops for
+    // predefined filters).
+    final cids = [for (var i = 0; i < channels; i++) '$_cidPrefix-$i'];
+    await persistence.saveChannelQueries(
+      cids: cids,
+      predefinedFilter: _predefinedFilter,
+      filterValues: {'user_id': userId},
+      resolvedFilter: Filter.in_('members', [userId]),
+      resolvedSort: const [SortOption.desc(ChannelSortKey.lastUpdated)],
+      clearQueryCache: true,
+    );
+
+    return channels * messagesPerChannel;
+  }
+
+  /// Removes previously seeded channels and their query cache.
+  Future<void> clear() async {
+    final persistence = client.chatPersistenceClient;
+    if (persistence == null) return;
+    // Dropping the whole cache is the simplest reliable reset for a dev tool.
+    await persistence.flush();
+  }
+
+  ChannelState _channelState(
+    int index,
+    int totalChannels,
+    int messagesPerChannel,
+    int membersPerChannel,
+    DateTime base,
+  ) {
+    final cid = '$_cidPrefix-$index';
+    final channelTime = base.add(Duration(minutes: totalChannels - index));
+
+    final members = [
+      for (var m = 0; m < membersPerChannel; m++)
+        Member(
+          userId: m == 0 ? userId : 'stress-buddy-$m',
+          user: User(id: m == 0 ? userId : 'stress-buddy-$m'),
+          channelRole: 'channel_member',
+        ),
+    ];
+
+    final reads = [
+      for (final member in members)
+        Read(lastRead: channelTime, user: member.user!, unreadMessages: 0),
+    ];
+
+    final messages = [
+      for (var msg = 0; msg < messagesPerChannel; msg++)
+        _message(cid, index, msg, base),
+    ];
+
+    return ChannelState(
+      channel: ChannelModel(
+        cid: cid,
+        type: 'messaging',
+        id: 'stress-seed-$index',
+        createdAt: channelTime,
+        updatedAt: channelTime,
+        lastMessageAt: channelTime,
+        memberCount: members.length,
+        extraData: {'name': 'Stress seed $index'},
+      ),
+      members: members,
+      membership: members.first,
+      read: reads,
+      messages: messages,
+    );
+  }
+
+  Message _message(String cid, int channelIndex, int msgIndex, DateTime base) {
+    final sender = User(id: msgIndex.isEven ? userId : 'stress-buddy-1');
+    final createdAt = base.add(Duration(seconds: channelIndex * 1000 + msgIndex));
+
+    return Message(
+      id: '$cid-$msgIndex',
+      type: 'regular',
+      user: sender,
+      createdAt: createdAt,
+      updatedAt: createdAt,
+      text: 'Stress seed message $msgIndex in channel $channelIndex — filler '
+          'text to give each row a realistic payload for scanning.',
+    );
+  }
+}
diff --git a/sample_app/lib/widgets/db_stress_seeder_sheet.dart b/sample_app/lib/widgets/db_stress_seeder_sheet.dart
new file mode 100644
index 000000000..e429fdb2f
--- /dev/null
+++ b/sample_app/lib/widgets/db_stress_seeder_sheet.dart
@@ -0,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:sample_app/utils/db_stress_seeder.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+/// A seeding preset: a channel count x messages-per-channel with the rough
+/// on-device offline-read hang it produced in benchmarking.
+class _Preset {
+  const _Preset(this.channels, this.messagesPerChannel, this.expectedHang);
+  final int channels;
+  final int messagesPerChannel;
+  final String expectedHang;
+
+  int get totalMessages => channels * messagesPerChannel;
+  String get label => '$channels channels x $messagesPerChannel msgs '
+      '(${(totalMessages / 1000).round()}k messages)';
+}
+
+// Sizes are capped well below the point where the debug (JIT) build starts
+// crashing on startup under memory pressure. The hang is already obvious here;
+// larger DBs risk bricking the app until a reinstall.
+const _presets = [
+  _Preset(200, 500, '~0.5s hang'),
+  _Preset(500, 500, '~1.3s hang'),
+  _Preset(500, 1000, '~2.5s hang'),
+];
+
+/// Opens the DB stress-seeder sheet. Debug tool: writes large amounts of dummy
+/// data into the local cache so the pull-to-refresh hang can be reproduced.
+Future<void> showDbStressSeederSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => const _DbStressSeederSheet(),
+  );
+}
+
+class _DbStressSeederSheet extends StatelessWidget {
+  const _DbStressSeederSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Seed stress DB data', style: textTheme.headingSm),
+            const SizedBox(height: 4),
+            Text(
+              'Writes dummy channels + messages into the local cache, then '
+              'pull-to-refresh to reproduce the offline-read hang. Enable '
+              'airplane mode first for a repeatable hang.',
+              style: textTheme.captionDefault.copyWith(color: colorScheme.textTertiary),
+            ),
+            const SizedBox(height: 16),
+            for (final preset in _presets)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: ListTile(
+                  tileColor: colorScheme.backgroundElevation1,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  title: Text(preset.label),
+                  subtitle: Text(preset.expectedHang),
+                  trailing: const Icon(Icons.play_arrow_rounded),
+                  onTap: () => _runSeed(context, preset),
+                ),
+              ),
+            const SizedBox(height: 8),
+            TextButton.icon(
+              icon: const Icon(Icons.delete_outline),
+              label: const Text('Clear seeded data (flush cache)'),
+              onPressed: () => _runClear(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _runSeed(BuildContext context, _Preset preset) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final chat = StreamChat.of(context);
+    final userId = chat.currentUser?.id;
+    if (userId == null) return;
+
+    navigator.pop(); // close the sheet
+
+    final seeder = DbStressSeeder(client: chat.client, userId: userId);
+    final progress = ValueNotifier<double>(0);
+
+    showDialog<void>(
+      context: navigator.context,
+      barrierDismissible: false,
+      builder: (_) => _ProgressDialog(progress: progress),
+    );
+
+    try {
+      final total = await seeder.seed(
+        channels: preset.channels,
+        messagesPerChannel: preset.messagesPerChannel,
+        onProgress: (seeded, all) => progress.value = seeded / all,
+      );
+      navigator.pop(); // close progress dialog
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Seeded $total messages. Pull-to-refresh to reproduce.'),
+        ),
+      );
+    } catch (e) {
+      navigator.pop();
+      messenger.showSnackBar(SnackBar(content: Text('Seeding failed: $e')));
+    } finally {
+      progress.dispose();
+    }
+  }
+
+  Future<void> _runClear(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final chat = StreamChat.of(context);
+    final userId = chat.currentUser?.id;
+    if (userId == null) return;
+
+    navigator.pop();
+    final seeder = DbStressSeeder(client: chat.client, userId: userId);
+    await seeder.clear();
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Local cache flushed.')),
+    );
+  }
+}
+
+class _ProgressDialog extends StatelessWidget {
+  const _ProgressDialog({required this.progress});
+
+  final ValueNotifier<double> progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Seeding…'),
+      content: ValueListenableBuilder<double>(
+        valueListenable: progress,
+        builder: (_, value, __) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LinearProgressIndicator(value: value == 0 ? null : value),
+            const SizedBox(height: 8),
+            Text('${(value * 100).round()}%'),
+          ],
+        ),
+      ),
+    );
+  }
+}
```

</details>

## Screenshots / Videos

Behavior change only (no UI code changes). Same device, same seeded data, same steps — pull-to-refresh on a large offline DB:

| Before (no indexes) | After (indexes) |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/19773f75-9397-4bcf-9bf9-592923ef87ba"></video> | <video src="https://github.com/user-attachments/assets/3804f8cc-d3eb-4c79-99b8-329bdc516d09"></video> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved database query speed for channels, messages, members, reads, and reactions by adding new indexes.
* **Chores**
  * Updated the database schema version to support the latest storage changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->