### PR TITLE
ci(repo): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/beta_version_analyze.yml
+++ b/.github/workflows/beta_version_analyze.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 2 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Does a sanity check on packages for the next beta version so we are not surprised by any breaking changes.
   analyze_beta_versions:

--- a/.github/workflows/distribute_external.yml
+++ b/.github/workflows/distribute_external.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   determine_platforms:
     runs-on: ubuntu-latest

--- a/.github/workflows/distribute_internal.yml
+++ b/.github/workflows/distribute_internal.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   determine_platforms:
     runs-on: ubuntu-latest

--- a/.github/workflows/legacy_version_analyze.yml
+++ b/.github/workflows/legacy_version_analyze.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   # Centralizes every gating decision for this workflow — path filter, draft
   # state, and push-vs-PR semantics. Downstream jobs only need a single

--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   stream_chat:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   conventional_pr_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   # Centralizes every gating decision for this workflow — path filter,
   # draft state, and push-vs-PR semantics. Downstream jobs only need a

--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -13,6 +13,10 @@ on:
           - sdk
           - docs
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   update_sdk_goldens:
     if: inputs.target == 'sdk' || inputs.target == 'both'

--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -14,8 +14,7 @@ on:
           - docs
 
 permissions:
-  actions: write
-  contents: read
+  contents: write
 
 jobs:
   update_sdk_goldens:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **24** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated several automation workflows to define explicit workflow-level permissions.
  * Most workflows now run with read-only access to repository contents and pull requests.
  * Where needed, one workflow retains write access to perform automation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->