### PR TITLE
feat(llc): Sanitize `X-Stream-Client` to prevent customers overriding internal values (v9)

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🔄 Changed
+
+- `StreamChatClient.updateSystemEnvironment` now sanitizes the passed `SystemEnvironment`: `sdkName`, `sdkVersion`, and `osName` are locked to internal defaults, and `sdkIdentifier` only accepts the `dart` → `flutter` promotion (other values, including a `flutter` → `dart` demotion, are ignored). `appName`, `appVersion`, `osVersion`, and `deviceModel` continue to pass through as-is.
+
 ## 9.26.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -152,21 +152,33 @@ class StreamChatClient {
 
   /// Updates the system environment information used by the client.
   ///
-  /// It allows you to set environment-specific information that will be
-  /// included in API requests, such as the application name, platform details,
-  /// and version information.
+  /// The passed [environment] is sanitized before being applied:
+  ///
+  /// Overridable fields (passed through as-is):
+  /// - [SystemEnvironment.appName]
+  /// - [SystemEnvironment.appVersion]
+  /// - [SystemEnvironment.osVersion]
+  /// - [SystemEnvironment.deviceModel]
+  ///
+  /// Immutable fields (custom values are ignored, internal defaults are
+  /// preserved):
+  /// - [SystemEnvironment.sdkName]
+  /// - [SystemEnvironment.sdkIdentifier]
+  /// - [SystemEnvironment.sdkVersion]
+  /// - [SystemEnvironment.osName]
   ///
   /// Example:
   /// ```dart
   /// client.updateSystemEnvironment(
   ///   SystemEnvironment(
-  ///     name: 'my_app',
-  ///     version: '1.0.0',
+  ///     sdkName: 'stream-chat',
+  ///     sdkIdentifier: 'dart',
+  ///     sdkVersion: StreamChatClient.packageVersion,
+  ///     appName: 'my_app',
+  ///     appVersion: '1.0.0',
   ///   ),
   /// );
   /// ```
-  ///
-  /// See [SystemEnvironment] for more information on the available fields.
   void updateSystemEnvironment(SystemEnvironment environment) {
     _systemEnvironmentManager.updateEnvironment(environment);
   }

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -171,9 +171,6 @@ class StreamChatClient {
   /// ```dart
   /// client.updateSystemEnvironment(
   ///   SystemEnvironment(
-  ///     sdkName: 'stream-chat',
-  ///     sdkIdentifier: 'dart',
-  ///     sdkVersion: StreamChatClient.packageVersion,
   ///     appName: 'my_app',
   ///     appVersion: '1.0.0',
   ///   ),

--- a/packages/stream_chat/lib/src/core/http/system_environment_manager.dart
+++ b/packages/stream_chat/lib/src/core/http/system_environment_manager.dart
@@ -9,17 +9,17 @@ import 'package:stream_chat/version.dart';
 /// {@endtemplate}
 class SystemEnvironmentManager {
   /// {@macro systemEnvironmentManager}
-  SystemEnvironmentManager({
-    SystemEnvironment? environment,
-  }) : _environment = switch (environment) {
-          final env? => env,
-          _ => SystemEnvironment(
-              sdkName: 'stream-chat',
-              sdkIdentifier: 'dart',
-              sdkVersion: PACKAGE_VERSION,
-              osName: CurrentPlatform.name,
-            ),
-        };
+  SystemEnvironmentManager({SystemEnvironment? environment})
+      : _environment = SystemEnvironment(
+          sdkName: _sdkName,
+          sdkIdentifier: _SdkIdentifier.dart,
+          sdkVersion: PACKAGE_VERSION,
+          osName: CurrentPlatform.name,
+        ) {
+    if (environment != null) updateEnvironment(environment);
+  }
+
+  static const _sdkName = 'stream-chat';
 
   /// Returns the Stream client user agent string based on the current
   /// [environment] value.
@@ -31,7 +31,38 @@ class SystemEnvironmentManager {
 
   /// Updates the current [SystemEnvironment].
   void updateEnvironment(SystemEnvironment environment) {
-    _environment = environment;
+    _environment = _sanitize(environment);
+  }
+
+  /// Sanitizes the passed [SystemEnvironment]
+  /// Ignores custom values for:
+  /// - sdkName
+  /// - sdkVersion
+  /// - osName
+  /// Allows only the dart -> flutter promotion for:
+  /// - sdkIdentifier (any other value, including a flutter -> dart
+  ///   demotion, is ignored)
+  /// Allows overriding of:
+  /// - appName
+  /// - appVersion
+  /// - osVersion
+  /// - deviceModel
+  SystemEnvironment _sanitize(SystemEnvironment environment) {
+    final incoming = _SdkIdentifier(environment.sdkIdentifier);
+    final current = _SdkIdentifier(_environment.sdkIdentifier);
+    final sdkIdentifier =
+        incoming.precedence < current.precedence ? current : incoming;
+    final osName = _environment.osName;
+    return SystemEnvironment(
+      sdkName: _sdkName,
+      sdkIdentifier: sdkIdentifier,
+      sdkVersion: PACKAGE_VERSION,
+      appName: environment.appName,
+      appVersion: environment.appVersion,
+      osName: osName,
+      osVersion: environment.osVersion,
+      deviceModel: environment.deviceModel,
+    );
   }
 }
 
@@ -62,4 +93,19 @@ extension XStreamClientHeaderExtension on SystemEnvironment {
       if (deviceModel case final model?) 'device_model=$model',
     ].nonNulls.join('|');
   }
+}
+
+/// Known SDK identifiers ranked by precedence. A proposed update is only
+/// accepted when its precedence is greater than or equal to the current
+/// identifier's, which makes the dart -> flutter transition one-way and
+/// causes unknown identifiers to fall back to the current value.
+extension type const _SdkIdentifier(String value) implements String {
+  static const dart = _SdkIdentifier('dart');
+  static const flutter = _SdkIdentifier('flutter');
+
+  int get precedence => switch (this) {
+        dart => 0,
+        flutter => 1,
+        _ => -1,
+      };
 }

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -189,8 +189,8 @@ class WebSocket with TimerHelper {
       'api_key': apiKey,
       'authorization': token.rawValue,
       'stream-auth-type': token.authType.name,
-      if (userAgent != null) 'X-Stream-Client': jsonEncode(userAgent),
       ...queryParameters,
+      if (userAgent != null) 'X-Stream-Client': jsonEncode(userAgent),
     };
 
     final scheme = switch (baseUrl) {

--- a/packages/stream_chat/test/src/core/http/system_environment_manager_test.dart
+++ b/packages/stream_chat/test/src/core/http/system_environment_manager_test.dart
@@ -20,40 +20,89 @@ void main() {
       expect(manager.environment.sdkVersion, equals(PACKAGE_VERSION));
     });
 
-    test('initializes with custom environment', () {
+    test('sanitizes environment passed to constructor', () {
       const customEnv = SystemEnvironment(
         sdkName: 'custom-sdk',
-        sdkIdentifier: 'custom',
+        sdkIdentifier: 'flutter',
         sdkVersion: '1.0.0',
+        appName: 'test-app',
       );
 
       manager = SystemEnvironmentManager(environment: customEnv);
 
-      expect(manager.environment.sdkName, equals('custom-sdk'));
-      expect(manager.environment.sdkIdentifier, equals('custom'));
-      expect(manager.environment.sdkVersion, equals('1.0.0'));
+      // Immutable fields are forced to internal values.
+      expect(manager.environment.sdkName, equals('stream-chat'));
+      expect(manager.environment.sdkVersion, equals(PACKAGE_VERSION));
+      expect(manager.environment.osName, equals(CurrentPlatform.name));
+      // Whitelisted sdkIdentifier is accepted.
+      expect(manager.environment.sdkIdentifier, equals('flutter'));
+      // App fields are passed through.
+      expect(manager.environment.appName, equals('test-app'));
     });
 
-    test('updates environment', () {
+    test('sanitizes environment on update', () {
       const newEnv = SystemEnvironment(
-        sdkName: 'updated-sdk',
-        sdkIdentifier: 'updated',
-        sdkVersion: '2.0.0',
+        sdkName: 'stream-chat-android',
+        sdkIdentifier: 'android',
+        sdkVersion: '99.0.0',
+        appName: 'test-app',
+        appVersion: '2.0.0',
+        osName: 'spoofed-os',
+        osVersion: '14',
+        deviceModel: 'Pixel 7',
       );
 
       manager.updateEnvironment(newEnv);
 
-      expect(manager.environment.sdkName, equals('updated-sdk'));
-      expect(manager.environment.sdkIdentifier, equals('updated'));
-      expect(manager.environment.sdkVersion, equals('2.0.0'));
+      // Immutable fields are forced to internal values.
+      expect(manager.environment.sdkName, equals('stream-chat'));
+      expect(manager.environment.sdkVersion, equals(PACKAGE_VERSION));
+      expect(manager.environment.osName, equals(CurrentPlatform.name));
+      // Unknown sdkIdentifier falls back to the current value.
+      expect(manager.environment.sdkIdentifier, equals('dart'));
+      // App/device/os-version fields are passed through.
+      expect(manager.environment.appName, equals('test-app'));
+      expect(manager.environment.appVersion, equals('2.0.0'));
+      expect(manager.environment.osVersion, equals('14'));
+      expect(manager.environment.deviceModel, equals('Pixel 7'));
+    });
+
+    test('allows promoting sdkIdentifier from dart to flutter', () {
+      manager.updateEnvironment(
+        const SystemEnvironment(
+          sdkName: 'stream-chat',
+          sdkIdentifier: 'flutter',
+          sdkVersion: PACKAGE_VERSION,
+        ),
+      );
+
+      expect(manager.environment.sdkIdentifier, equals('flutter'));
+    });
+
+    test('ignores demotion of sdkIdentifier from flutter to dart', () {
+      manager
+        ..updateEnvironment(
+          const SystemEnvironment(
+            sdkName: 'stream-chat',
+            sdkIdentifier: 'flutter',
+            sdkVersion: PACKAGE_VERSION,
+          ),
+        )
+        ..updateEnvironment(
+          const SystemEnvironment(
+            sdkName: 'stream-chat',
+            sdkIdentifier: 'dart',
+            sdkVersion: PACKAGE_VERSION,
+          ),
+        );
+
+      expect(manager.environment.sdkIdentifier, equals('flutter'));
     });
 
     test('userAgent returns proper header string', () {
       expect(
         manager.userAgent,
-        equals(
-          'stream-chat-dart-v$PACKAGE_VERSION|os=${CurrentPlatform.name}',
-        ),
+        equals('stream-chat-dart-v$PACKAGE_VERSION|os=${CurrentPlatform.name}'),
       );
     });
   });
@@ -66,10 +115,7 @@ void main() {
         sdkVersion: '1.0.0',
       );
 
-      expect(
-        env.xStreamClientHeader,
-        equals('stream-chat-dart-v1.0.0'),
-      );
+      expect(env.xStreamClientHeader, equals('stream-chat-dart-v1.0.0'));
     });
 
     test('includes app name when available', () {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-565

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

Backport of: https://github.com/GetStream/stream-chat-flutter/pull/2790

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Hardens the `X-Stream-Client` header so SDK-identifying metadata can't be spoofed via `StreamChatClient.updateSystemEnvironment` or overridden through custom WebSocket query parameters.

**`SystemEnvironmentManager` now sanitizes any `SystemEnvironment` it receives** (both in the constructor and in `updateEnvironment`):

- **Immutable fields** — forced to internal defaults, custom values ignored:
  - `sdkName` (locked to `stream-chat`)
  - `sdkVersion` (locked to `PACKAGE_VERSION`)
  - `osName` (locked to `CurrentPlatform.name`)
- **`sdkIdentifier`** — only the one-way `dart` → `flutter` promotion is accepted. A `flutter` → `dart` demotion and any unknown identifier fall back to the current value. This lets the Flutter UI layer upgrade the identifier while preventing downgrades/spoofing.
- **Overridable fields** — continue to pass through as-is:
  - `appName`, `appVersion`, `osVersion`, `deviceModel`

**WebSocket header ordering** — the `X-Stream-Client` header is now applied *after* `...queryParameters` in the connection params, so caller-supplied query parameters can no longer override it.

Doc comments on `StreamChatClient.updateSystemEnvironment` were updated to document the overridable vs. immutable fields.

### Test instructions

Covered by unit tests in `system_environment_manager_test.dart`:
- sanitizes environment passed to the constructor
- sanitizes environment on update (immutable fields forced, unknown `sdkIdentifier` falls back)
- allows promoting `sdkIdentifier` `dart` → `flutter`
- ignores demotion `flutter` → `dart`

Run: `melos run test --scope=stream_chat` (or the single file above).

## Screenshots / Videos

No UI changes.