### PR TITLE
perf(persistence): add indexes to speed up offline channel-list reads (v9)

### DIFF
--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Added support for predefined filters for `QueryChannels` on `StreamChatPersistenceClient`.
 
+🚀 Performance
+
+- Add indices on the `channel_cid` column on the `Messages`, `Members`, and `Reads` tables to improve read times on large databases.
+- Add indices on the `message_id` column on the `Reactions` table to improve read times on large databases.
+
 ## 9.26.0
 
 🐞 Fixed

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.dart
@@ -56,7 +56,7 @@ class DriftChatDatabase extends _$DriftChatDatabase {
 
   // you should bump this number whenever you change or add a table definition.
   @override
-  int get schemaVersion => 30;
+  int get schemaVersion => 31;
 
   // Store DateTime as ISO-8601 text to preserve sub-second precision.
   @override

--- a/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
+++ b/packages/stream_chat_persistence/lib/src/db/drift_chat_database.g.dart
@@ -8881,6 +8881,14 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
       $ChannelQueriesMetadataTable(this);
   late final $ConnectionEventsTable connectionEvents =
       $ConnectionEventsTable(this);
+  late final Index idxMessagesChannelCid = Index('idx_messages_channel_cid',
+      'CREATE INDEX idx_messages_channel_cid ON messages (channel_cid)');
+  late final Index idxReactionsMessageId = Index('idx_reactions_message_id',
+      'CREATE INDEX idx_reactions_message_id ON reactions (message_id)');
+  late final Index idxMembersChannelCid = Index('idx_members_channel_cid',
+      'CREATE INDEX idx_members_channel_cid ON members (channel_cid)');
+  late final Index idxReadsChannelCid = Index('idx_reads_channel_cid',
+      'CREATE INDEX idx_reads_channel_cid ON reads (channel_cid)');
   late final UserDao userDao = UserDao(this as DriftChatDatabase);
   late final ChannelDao channelDao = ChannelDao(this as DriftChatDatabase);
   late final MessageDao messageDao = MessageDao(this as DriftChatDatabase);
@@ -8917,7 +8925,11 @@ abstract class _$DriftChatDatabase extends GeneratedDatabase {
         reads,
         channelQueries,
         channelQueriesMetadata,
-        connectionEvents
+        connectionEvents,
+        idxMessagesChannelCid,
+        idxReactionsMessageId,
+        idxMembersChannelCid,
+        idxReadsChannelCid
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(

--- a/packages/stream_chat_persistence/lib/src/entity/members.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/members.dart
@@ -5,6 +5,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Members] table in [DriftChatDatabase].
 @DataClassName('MemberEntity')
+@TableIndex(name: 'idx_members_channel_cid', columns: {#channelCid})
 class Members extends Table {
   /// The interested user id
   TextColumn get userId => text()();

--- a/packages/stream_chat_persistence/lib/src/entity/messages.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/messages.dart
@@ -7,6 +7,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Messages] table in [DriftChatDatabase].
 @DataClassName('MessageEntity')
+@TableIndex(name: 'idx_messages_channel_cid', columns: {#channelCid})
 class Messages extends Table {
   /// The message id
   TextColumn get id => text()();

--- a/packages/stream_chat_persistence/lib/src/entity/reactions.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/reactions.dart
@@ -5,6 +5,7 @@ import 'package:stream_chat_persistence/src/entity/messages.dart';
 
 /// Represents a [Reactions] table in [DriftChatDatabase].
 @DataClassName('ReactionEntity')
+@TableIndex(name: 'idx_reactions_message_id', columns: {#messageId})
 class Reactions extends Table {
   /// The id of the user that sent the reaction
   TextColumn get userId => text()();

--- a/packages/stream_chat_persistence/lib/src/entity/reads.dart
+++ b/packages/stream_chat_persistence/lib/src/entity/reads.dart
@@ -4,6 +4,7 @@ import 'package:stream_chat_persistence/src/entity/channels.dart';
 
 /// Represents a [Reads] table in [DriftChatDatabase].
 @DataClassName('ReadEntity')
+@TableIndex(name: 'idx_reads_channel_cid', columns: {#channelCid})
 class Reads extends Table {
   /// Date of the read event
   DateTimeColumn get lastRead => dateTime()();


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-555

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Backport of #2795 from `master` to `v9`.

**Original commit:** ab2014560 — perf(persistence): add SQLite indexes to speed up offline channel-list reads

Adds `@TableIndex` annotations on the columns the offline read filters by:

- `messages(channel_cid)` — dominant (largest table, scanned ~30× per refresh)
- `members(channel_cid)`
- `reads(channel_cid)`
- `reactions(message_id)`

Schema version bumped 30 → 31. The migration strategy on v9 is fully destructive (`createAll()` on any version change), so no hand-written migration is needed — both fresh installs and upgrades pick up the indexes automatically.

The `.g.dart` file was updated by adding only the index `late final` declarations and `allSchemaEntities` list entries, without running a full `build_runner` regeneration (which would produce unrelated codegen-version diff noise on v9).

**Port type:** Manual (schema version number differs between master and v9; all other changes applied identically).

## Screenshots / Videos

No UI changes.