### PR TITLE
fix(llc): suppress `EquatableMixin` deprecation warning in `StreamChatError`

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+🐞 Fixed
+
+- Fixed a deprecation warning from `equatable` causing CI analysis to fail.
+
 ## 9.26.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -5,6 +5,11 @@ import 'package:stream_chat/stream_chat.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 ///
+// ignore: deprecated_member_use
+// `EquatableMixin` is deprecated in equatable ≥2.0.8 in favour of
+// `with Equatable`, but switching would change the mixin type in the class
+// hierarchy (e.g. `error is EquatableMixin` → false), which is a breaking
+// change under semver. Migrate this when the next major version is cut.
 class StreamChatError with EquatableMixin implements Exception {
   ///
   const StreamChatError(this.message);

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -5,11 +5,11 @@ import 'package:stream_chat/stream_chat.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 ///
-// ignore: deprecated_member_use
 // `EquatableMixin` is deprecated in equatable ≥2.1.0 in favour of
 // `with Equatable`, but switching would change the mixin type in the class
 // hierarchy (e.g. `error is EquatableMixin` → false), which is a breaking
 // change under semver. Migrate this when the next major version is cut.
+// ignore: deprecated_member_use
 class StreamChatError with EquatableMixin implements Exception {
   ///
   const StreamChatError(this.message);

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -6,7 +6,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 ///
 // ignore: deprecated_member_use
-// `EquatableMixin` is deprecated in equatable ≥2.0.8 in favour of
+// `EquatableMixin` is deprecated in equatable ≥2.1.0 in favour of
 // `with Equatable`, but switching would change the mixin type in the class
 // hierarchy (e.g. `error is EquatableMixin` → false), which is a breaking
 // change under semver. Migrate this when the next major version is cut.


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`equatable` 2.1.0 [deprecated](https://pub.dev/packages/equatable/changelog) `EquatableMixin` in favour of `with Equatable`. Switching to `with Equatable` would be a breaking change under semver (changes the mixin type in the class hierarchy), so the deprecation warning is suppressed with an explanatory comment instead. The migration is deferred to the next major version.

## Screenshots / Videos

No UI changes.