### PR TITLE
fix(persistence): treat thread reply pagination limit of 0 as unset

### DIFF
--- a/packages/stream_chat_persistence/CHANGELOG.md
+++ b/packages/stream_chat_persistence/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add indices on the `channel_cid` column on the `Messages`, `Members`, and `Reads` tables to improve read times on large databases.
 - Add indices on the `message_id` column on the `Reactions` table to improve read times on large databases.
 
+🐞 Fixed
+
+- `MessageDao.getThreadMessagesByParentId` now treats a `PaginationParams.limit` of `0` as "unset" and returns all matching replies, instead of returning none.
+
 ## 10.1.0
 
 ✅ Added

--- a/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
+++ b/packages/stream_chat_persistence/lib/src/dao/message_dao.dart
@@ -283,7 +283,7 @@ class MessageDao extends DatabaseAccessor<DriftChatDatabase> with _$MessageDaoMi
       );
     }
 
-    if (options != null) {
+    if (options != null && options.limit > 0) {
       query.limit(options.limit);
     }
 

--- a/packages/stream_chat_persistence/test/src/dao/message_dao_test.dart
+++ b/packages/stream_chat_persistence/test/src/dao/message_dao_test.dart
@@ -343,6 +343,26 @@ void main() {
       expect(replies.last.id, threadId(29));
     });
 
+    test('limit of 0 is treated as unset and returns all replies', () async {
+      await _prepareTestData(
+        cid,
+        threads: true,
+        mapAllThreadToFirstMessage: true,
+        count: 30,
+      );
+
+      final replies = await messageDao.getThreadMessagesByParentId(
+        parentId,
+        options: const PaginationParams(limit: 0),
+      );
+
+      // limit: 0 is treated as "unset" → no SQL LIMIT is applied → all 30
+      // replies are returned in ASC order: id0..id29.
+      expect(replies.length, 30);
+      expect(replies.first.id, threadId(0));
+      expect(replies.last.id, threadId(29));
+    });
+
     test('lessThan only excludes the cursor', () async {
       await _prepareTestData(
         cid,


### PR DESCRIPTION
## Summary

`MessageDao.getThreadMessagesByParentId` recently moved offline thread-reply pagination into SQL. That change turned a `PaginationParams.limit` of `0` into a SQL `LIMIT 0` (**zero rows**), whereas the pre-SQL implementation treated `0` as "unlimited" and returned every reply.

Across the stack, `limit: 0` means **unset**, not "empty":
- **Backend** `getReplies`: `limit == 0` is treated as unset → default page of 100.
- **iOS** (Core Data): `fetchLimit == 0` → unlimited (all rows).
- **Flutter (pre-port)**: `0` → returned all rows.

This PR only applies the SQL `LIMIT` when a positive limit is provided, restoring the "0 = unset → return all matching replies" contract.

```dart
if (options != null && options.limit > 0) {
  query.limit(options.limit);
}
```

Low-risk in practice — `PaginationParams.limit` is non-nullable and defaults to 10, and no in-repo call site passes 0 — so this is a latent-correctness fix.

Scope is intentionally **threads only**. `getMessagesByCid` has the same unguarded pattern but is left untouched here.

Originally surfaced while reviewing #2750 (the v9 backport), where the same fix was applied.

## Test

Added `limit of 0 is treated as unset and returns all replies` to the `getThreadMessagesByParentId` group: seeds 30 replies, queries with `PaginationParams(limit: 0)`, asserts all 30 come back in ASC order. Full group passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed threaded message retrieval when pagination limit is set to 0. All matching replies are now returned in ascending order instead of none.

* **Tests**
  * Added coverage to verify that a zero limit returns the complete set of thread replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->