### PR TITLE
fix(ui): skip markThreadRead for reply-less thread parents

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fixed last-message preview flicker during channel-state reloads.
 - Fixed shadowed messages not hidden in channel list items.
+- Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
 
 ## 10.1.0
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -1207,6 +1207,8 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
   // The conditions are:
   // 1. The channel is up to date or we are in a thread conversation.
   // 2. There are unread messages or we are in a thread conversation.
+  // 3. In a thread, the parent has at least one reply — the server-side
+  //    thread object doesn't exist until the first reply lands.
   //
   // If any of the conditions are not met, the function returns early.
   // Otherwise, it calls the _markMessagesAsRead function to mark the messages
@@ -1216,6 +1218,10 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (channel == null) return;
 
     final isInThread = widget.parentMessage != null;
+
+    // A server-side thread object only exists once the parent has at least
+    // one reply; markThreadRead on a reply-less parent returns 404.
+    if (isInThread && (widget.parentMessage?.replyCount ?? 0) == 0) return;
 
     final isUpToDate = channel.state?.isUpToDate ?? false;
     if (!isInThread && !isUpToDate) return;

--- a/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
@@ -8,6 +8,10 @@
 //   2. `channel.state.isUpToDate` is true (or we're in a thread).
 //   3. `channel.state.unreadCount > 0`.
 //
+// In a thread, it fires `channel.markThreadRead(parentId)` instead, and is
+// additionally gated on the parent having at least one reply — the server-side
+// thread object only exists after the first reply, so an earlier call 404s.
+//
 // These tests pin the expected behavior so regressions in the underlying
 // position-listener flow (SPL `itemPositions`, scroll wiring, etc.) surface
 // here instead of as user-visible bugs.
@@ -32,6 +36,7 @@ void main() {
   late StreamController<bool> isUpToDateController;
   late StreamController<int> unreadCountController;
   late StreamController<List<Message>> messagesController;
+  late StreamController<Map<String, List<Message>>> threadsController;
 
   setUpAll(() {
     registerFallbackValue(EventType.messageNew);
@@ -53,11 +58,14 @@ void main() {
     isUpToDateController = StreamController<bool>.broadcast();
     unreadCountController = StreamController<int>.broadcast();
     messagesController = StreamController<List<Message>>.broadcast();
+    threadsController = StreamController<Map<String, List<Message>>>.broadcast();
     addTearDown(isUpToDateController.close);
     addTearDown(unreadCountController.close);
     addTearDown(messagesController.close);
+    addTearDown(threadsController.close);
 
-    when(() => channelClientState.threadsStream).thenAnswer((_) => const Stream.empty());
+    when(() => channelClientState.threadsStream).thenAnswer((_) => threadsController.stream);
+    when(() => channelClientState.threads).thenReturn(const {});
     when(() => channelClientState.isUpToDateStream).thenAnswer((_) => isUpToDateController.stream);
     when(() => channelClientState.unreadCountStream).thenAnswer((_) => unreadCountController.stream);
     when(() => channelClientState.readStream).thenAnswer((_) => const Stream.empty());
@@ -68,8 +76,17 @@ void main() {
     when(() => channelClientState.currentUserReadStream).thenAnswer((_) => const Stream.empty());
     when(() => channelClientState.messagesStream).thenAnswer((_) => messagesController.stream);
 
-    // Mark-read mock returns immediately.
+    // Mark-read mocks return immediately.
     when(() => channel.markRead(messageId: any(named: 'messageId'))).thenAnswer((_) async => EmptyResponse());
+    when(() => channel.markThreadRead(any())).thenAnswer((_) async => EmptyResponse());
+    // Thread reply loader called by MessageListCore when parentMessage is set.
+    when(
+      () => channel.getReplies(
+        any(),
+        options: any(named: 'options'),
+        preferOffline: any(named: 'preferOffline'),
+      ),
+    ).thenAnswer((_) async => QueryRepliesResponse()..messages = []);
   });
 
   Future<void> pumpMessageList(
@@ -78,10 +95,17 @@ void main() {
     required bool isUpToDate,
     required int unreadCount,
     bool markReadWhenAtTheBottom = true,
+    Message? parentMessage,
   }) async {
     when(() => channelClientState.isUpToDate).thenReturn(isUpToDate);
     when(() => channelClientState.unreadCount).thenReturn(unreadCount);
     when(() => channelClientState.messages).thenReturn(messages);
+
+    // In thread mode, MessageListCore reads from state.threads[parentId] and
+    // subscribes to state.threadsStream. Seed both so the reply list renders.
+    if (parentMessage != null) {
+      when(() => channelClientState.threads).thenReturn({parentMessage.id: messages});
+    }
 
     await tester.runAsync(() async {
       await tester.pumpWidget(
@@ -94,6 +118,7 @@ void main() {
               child: StreamChannel(
                 channel: channel,
                 child: StreamMessageListView(
+                  parentMessage: parentMessage,
                   config: StreamMessageListViewConfiguration(
                     markReadWhenAtTheBottom: markReadWhenAtTheBottom,
                   ),
@@ -106,7 +131,11 @@ void main() {
       // Prime the streams.
       isUpToDateController.add(isUpToDate);
       unreadCountController.add(unreadCount);
-      messagesController.add(messages);
+      if (parentMessage != null) {
+        threadsController.add({parentMessage.id: messages});
+      } else {
+        messagesController.add(messages);
+      }
       await tester.pumpAndSettle();
     });
   }
@@ -185,6 +214,93 @@ void main() {
         verifyNever(
           () => channel.markRead(messageId: any(named: 'messageId')),
         );
+      },
+    );
+  });
+
+  group('thread markThreadRead gates', () {
+    testWidgets(
+      'does NOT fire when parentMessage.replyCount is 0 (thread does not yet exist server-side)',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final parent = Message(
+          id: 'parent-id',
+          user: other,
+          text: 'parent',
+          createdAt: DateTime.utc(2026),
+        );
+
+        await pumpMessageList(
+          tester,
+          parentMessage: parent,
+          messages: [],
+          isUpToDate: true,
+          unreadCount: 0,
+        );
+
+        verifyNever(() => channel.markThreadRead(any()));
+      },
+    );
+
+    testWidgets(
+      'fires when parentMessage.replyCount > 0',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final parent = Message(
+          id: 'parent-id',
+          user: other,
+          text: 'parent',
+          replyCount: 1,
+          createdAt: DateTime.utc(2026),
+        );
+        final reply = Message(
+          id: 'reply-id',
+          user: other,
+          text: 'reply',
+          parentId: parent.id,
+          createdAt: DateTime.utc(2026, 1, 1, 0, 1),
+        );
+
+        await pumpMessageList(
+          tester,
+          parentMessage: parent,
+          messages: [parent, reply],
+          isUpToDate: true,
+          unreadCount: 0,
+        );
+
+        verify(() => channel.markThreadRead(parent.id)).called(1);
+      },
+    );
+
+    testWidgets(
+      'does NOT fire markRead (channel-level) when in a thread',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final parent = Message(
+          id: 'parent-id',
+          user: other,
+          text: 'parent',
+          replyCount: 1,
+          createdAt: DateTime.utc(2026),
+        );
+        final reply = Message(
+          id: 'reply-id',
+          user: other,
+          text: 'reply',
+          parentId: parent.id,
+          createdAt: DateTime.utc(2026, 1, 1, 0, 1),
+        );
+
+        await pumpMessageList(
+          tester,
+          parentMessage: parent,
+          messages: [parent, reply],
+          isUpToDate: true,
+          unreadCount: 5,
+        );
+
+        verifyNever(() => channel.markRead(messageId: any(named: 'messageId')));
       },
     );
   });


### PR DESCRIPTION
## Summary

Opening a thread on a parent with no replies produced a guaranteed `StreamChatNetworkError` 404 (`Can't find thread with id ...`) every time. `_maybeMarkMessagesAsRead` unconditionally called `channel.markThreadRead(parentId)` when in a thread, but the server-side thread object only exists after the first reply lands.

Guard added to `_maybeMarkMessagesAsRead` in thread mode: skip when the parent's `replyCount` is 0. Matches the iOS SDK's precedent in `ChatThreadVC.shouldMarkThreadRead` (`if messageController.replies.isEmpty { return false }`, comment: _"If there are no replies, no thread is yet created"_).

Fixes #2806.

## Why `replyCount` on the parent

- `replyCount` is server-owned and populated via `message.updated` on the parent — nothing in the LLC bumps it locally, so it stays at `0` for optimistic-only replies too. Both "no replies" and "one local-only reply" produce the same `replyCount == 0`, and both cases want the same behavior: skip → no 404.
- Alternative (`channel.state.threads[parentId]?.isEmpty`) is less robust — the client's thread map is only populated once thread messages are paged in.

## Test plan

- [x] New regression test in `mark_read_test.dart`:
  - `does NOT fire when parentMessage.replyCount is 0` — the load-bearing guard.
  - `fires when parentMessage.replyCount > 0` — happy path.
  - `does NOT fire markRead (channel-level) when in a thread` — invariant guard.
- [x] Verified the regression test fails on `master` without the guard (`MockChannel.markThreadRead(parent-id) was called`) and passes with the guard.
- [x] `dart analyze` clean, `dart format` clean.

## Follow-up

- v9 backport is in a parallel PR (branch `bug/skip_mark_thread_read_when_no_replies_v9`).
- Cross-SDK check: **Android** (`MessageListController.markLastMessageReadInternal`) has the same latent bug and no explicit guard — worth tracking as a separate ticket if not already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread read-status marking so parent messages with no replies are no longer updated, preventing repeatable errors when opening a thread before the first reply.
  * Ensured thread views still correctly mark replies as read once the thread is available.
  * Confirmed thread mode no longer triggers channel-level read updates when thread-specific unread counts are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->