### PR TITLE
fix(llc): normalize strings when comparing ComparableField (v9)

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -7,6 +7,7 @@
 🐞 Fixed
 
 - Fixed a deprecation warning from `equatable` causing CI analysis to fail.
+- `ComparableField` now folds diacritics/ligatures and ignores case when comparing strings, so `SortOption` on fields like `name` no longer pushes lowercase or non-ASCII names (`jhon`, `Łukasz`, `Øystein`) to the end of client-sorted lists ([#2601](https://github.com/GetStream/stream-chat-flutter/issues/2601)).
 
 ## 9.26.0
 

--- a/packages/stream_chat/lib/src/core/api/sort_order.dart
+++ b/packages/stream_chat/lib/src/core/api/sort_order.dart
@@ -34,6 +34,12 @@ enum NullOrdering {
 /// // Sort channels by last message date in descending order
 /// final sort = SortOption<ChannelState>("last_message_at");
 /// ```
+///
+/// String comparisons are diacritic- and case-insensitive by default so client
+/// ordering aligns with what the server returns for sorts like `name` (see
+/// [ComparableField]). Pass a custom [Comparator] via the `comparator`
+/// parameter to override this — e.g. to sort raw codepoints or apply a
+/// locale-aware collator.
 @JsonSerializable(includeIfNull: false)
 class SortOption<T extends ComparableFieldProvider> {
   /// Creates a new SortOption instance with the specified field and direction.

--- a/packages/stream_chat/lib/src/core/models/comparable_field.dart
+++ b/packages/stream_chat/lib/src/core/models/comparable_field.dart
@@ -1,3 +1,5 @@
+import 'package:stream_chat/src/core/util/string_sort_normalizer.dart';
+
 /// A wrapper class for values that implements [Comparable].
 ///
 /// This class is used to compare values of different types in a way that
@@ -8,6 +10,10 @@
 /// For example, when sorting a list of objects with different types of fields,
 /// using this class will ensure that all values are compared correctly
 /// regardless of their type.
+///
+/// String comparisons fold diacritics and ligatures to base characters
+/// (`Ł→l`, `Ø→o`, `Æ→ae`, `é→e`) and ignore case, so ordering aligns with
+/// what the server returns for name-like sorts.
 class ComparableField<T> implements Comparable<ComparableField<T>> {
   const ComparableField._(this.value);
 
@@ -24,12 +30,20 @@ class ComparableField<T> implements Comparable<ComparableField<T>> {
   int compareTo(ComparableField<T> other) {
     return switch ((value, other.value)) {
       (final num a, final num b) => a.compareTo(b),
-      (final String a, final String b) => a.compareTo(b),
+      (final String a, final String b) => _compareStrings(a, b),
       (final DateTime a, final DateTime b) => a.compareTo(b),
       (final bool a, final bool b) when a == b => 0,
       (final bool a, final bool b) => a && !b ? 1 : -1, // true > false
       _ => 0 // All comparisons were equal or incomparable types
     };
+  }
+
+  // Compares using the shared server-parity normalizer.
+  static int _compareStrings(String a, String b) {
+    final normalizedA = normalizeStringForSort(a);
+    final normalizedB = normalizeStringForSort(b);
+
+    return normalizedA.compareTo(normalizedB);
   }
 }
 

--- a/packages/stream_chat/lib/src/core/util/string_sort_normalizer.dart
+++ b/packages/stream_chat/lib/src/core/util/string_sort_normalizer.dart
@@ -1,0 +1,98 @@
+import 'package:diacritic/diacritic.dart';
+import 'package:meta/meta.dart';
+
+const _maxAscii = 0x7F;
+const _apostrophe = 0x0027;
+
+// Japanese: Hiragana + Katakana blocks.
+const _hiraganaStart = 0x3040;
+const _hiraganaEnd = 0x309F;
+const _katakanaStart = 0x30A0;
+const _katakanaEnd = 0x30FF;
+
+// Thai.
+const _thaiStart = 0x0E00;
+const _thaiEnd = 0x0E7F;
+
+// Vietnamese: tone-marked Latin range + unique letters (Đ/đ, Ơ/ơ, Ư/ư).
+const _vietnameseToneStart = 0x1EA0;
+const _vietnameseToneEnd = 0x1EF1;
+const _vietnameseDUpper = 0x0110;
+const _vietnameseDLower = 0x0111;
+const _vietnameseOHornUpper = 0x01A0;
+const _vietnameseOHornLower = 0x01A1;
+const _vietnameseUHornUpper = 0x01AF;
+const _vietnameseUHornLower = 0x01B0;
+
+/// Normalizes `value` into a client-side sort key that matches how the
+/// backend sorts by name.
+///
+/// Applied in order:
+///
+/// 1. Fold Latin diacritics and ligatures — `é → e`, `Ł → l`, `Æ → ae`.
+/// 2. Preserve Japanese, Thai, and Vietnamese-specific runes unchanged.
+/// 3. Lowercase.
+/// 4. Trim leading/trailing ASCII apostrophes (U+0027) then whitespace.
+///
+/// Mirrors backend [`NormalizeName`][ref].
+///
+/// [ref]: https://github.com/GetStream/chat/blob/b92bf7991752a29e9f67b6ffe69b0bc529f5c48c/lib/combined/utils/text.go#L88-L95
+@internal
+String normalizeStringForSort(String value) {
+  if (value.isEmpty) return value;
+  final folded = value.runes.map(_foldRune).join();
+  return _trimApostropheEdges(folded.toLowerCase()).trim();
+}
+
+// Returns the sort form of `rune`. ASCII and preserved-script runes pass
+// through unchanged; everything else routes through `removeDiacritics`.
+String _foldRune(int rune) {
+  if (rune <= _maxAscii) return String.fromCharCode(rune);
+  if (_isJapaneseRune(rune)) return String.fromCharCode(rune);
+  if (_isThaiRune(rune)) return String.fromCharCode(rune);
+  if (_isVietnameseSpecificRune(rune)) return String.fromCharCode(rune);
+
+  return removeDiacritics(String.fromCharCode(rune));
+}
+
+// Trims leading/trailing U+0027 apostrophes from `value`. Curly Unicode
+// variants (U+2018, U+2019, U+201B) are intentionally not matched —
+// mirrors the backend's `IsApostrophe` predicate.
+String _trimApostropheEdges(String value) {
+  var start = 0;
+  var end = value.length;
+  while (start < end && value.codeUnitAt(start) == _apostrophe) {
+    start += 1;
+  }
+  while (end > start && value.codeUnitAt(end - 1) == _apostrophe) {
+    end -= 1;
+  }
+  if (start == 0 && end == value.length) return value;
+
+  return value.substring(start, end);
+}
+
+bool _isJapaneseRune(int rune) {
+  if (rune >= _hiraganaStart && rune <= _hiraganaEnd) return true;
+  if (rune >= _katakanaStart && rune <= _katakanaEnd) return true;
+
+  return false;
+}
+
+bool _isThaiRune(int rune) {
+  if (rune >= _thaiStart && rune <= _thaiEnd) return true;
+
+  return false;
+}
+
+bool _isVietnameseSpecificRune(int rune) {
+  if (rune >= _vietnameseToneStart && rune <= _vietnameseToneEnd) return true;
+  if (rune == _vietnameseDLower) return true;
+  if (rune == _vietnameseDUpper) return true;
+  if (rune == _vietnameseOHornLower) return true;
+  if (rune == _vietnameseOHornUpper) return true;
+  if (rune == _vietnameseUHornLower) return true;
+  if (rune == _vietnameseUHornUpper) return true;
+
+  return false;
+}

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -23,6 +23,7 @@ environment:
 dependencies:
   async: ^2.11.0
   collection: ^1.17.2
+  diacritic: ^0.1.5
   dio: ^5.4.3+1
   equatable: ^2.0.5
   freezed_annotation: ">=2.4.1 <4.0.0"

--- a/packages/stream_chat/test/src/core/models/comparable_field_test.dart
+++ b/packages/stream_chat/test/src/core/models/comparable_field_test.dart
@@ -42,6 +42,18 @@ void main() {
       });
     });
 
+    // Regression: https://github.com/GetStream/stream-chat-flutter/issues/2601
+    // The reporter observed lowercase-starting names and non-ASCII names
+    // (Polish `Ł`, Norwegian `Ø`) getting pushed to the end of a list
+    // sorted by `SortOption.asc('name')`, because the old comparator was
+    // a raw codepoint compare.
+    test('sorts issue #2601 names into a sensible order', () {
+      final names = ['Zara', 'jhon', 'Łukasz', 'Øystein', 'Adam', 'Marek'];
+      final sorted = [...names]..sort((a, b) => ComparableField.fromValue(a)!.compareTo(ComparableField.fromValue(b)!));
+
+      expect(sorted, ['Adam', 'jhon', 'Łukasz', 'Marek', 'Øystein', 'Zara']);
+    });
+
     group('compare strings', () {
       test('should compare strings alphabetically', () {
         final a = ComparableField.fromValue('banana');
@@ -52,12 +64,107 @@ void main() {
         expect(a.compareTo(ComparableField.fromValue('banana')!), equals(0));
       });
 
-      test('should respect case sensitivity in string comparison', () {
-        final a = ComparableField.fromValue('Apple');
-        final b = ComparableField.fromValue('apple');
+      test('should ignore case in the primary comparison', () {
+        final zara = ComparableField.fromValue('Zara');
+        final jhon = ComparableField.fromValue('jhon');
 
-        // Uppercase comes before lowercase in ASCII
-        expect(a!.compareTo(b!), lessThan(0));
+        // With a naive codepoint compare 'jhon' would sort after 'Zara' (0x6A
+        // > 0x5A). Case-insensitive normalization puts 'jhon' before 'Zara'.
+        expect(jhon!.compareTo(zara!), lessThan(0));
+      });
+
+      test('should fold ligatures and stroked letters to base characters', () {
+        // Backend sorts these against their base forms (Ł→l, Ø→o, Æ→ae) so
+        // 'Łukasz' lands between 'Lukas' and 'Marek', not after 'Zara'.
+        final lukas = ComparableField.fromValue('Lukas');
+        final lukasz = ComparableField.fromValue('Łukasz');
+        final marek = ComparableField.fromValue('Marek');
+        final zara = ComparableField.fromValue('Zara');
+
+        expect(lukas!.compareTo(lukasz!), lessThan(0));
+        expect(lukasz.compareTo(marek!), lessThan(0));
+        expect(lukasz.compareTo(zara!), lessThan(0));
+
+        final oystein = ComparableField.fromValue('Øystein');
+        expect(oystein!.compareTo(zara), lessThan(0));
+
+        final aegon = ComparableField.fromValue('Ægon');
+        final adam = ComparableField.fromValue('Adam');
+        expect(adam!.compareTo(aegon!), lessThan(0));
+        expect(aegon.compareTo(ComparableField.fromValue('Bob')!), lessThan(0));
+      });
+
+      test('should strip combining diacritical marks', () {
+        // Accented characters compare as if the diacritic were absent: 'José'
+        // sorts alongside 'Jose', not after all ASCII.
+        final jose = ComparableField.fromValue('José');
+        final joseAscii = ComparableField.fromValue('Jose');
+        final juan = ComparableField.fromValue('Juan');
+
+        expect(jose!.compareTo(juan!), lessThan(0));
+        // Same normalized key — the comparator returns 0.
+        expect(joseAscii!.compareTo(jose), equals(0));
+      });
+
+      test('should trim surrounding apostrophes and whitespace', () {
+        // Backend applies `TrimApostrophe` and `TrimSpace` after
+        // normalization, so leading/trailing U+0027 apostrophes and
+        // whitespace fall off the primary key. `'Ali` sorts adjacent to
+        // `Ali` (before `Bob`), not somewhere else entirely. Only U+0027
+        // is trimmed — curly Unicode apostrophes (U+2018/U+2019) match the
+        // backend's `IsApostrophe` predicate and stay in the key.
+        final values = [
+          'Bob',
+          "'Ali",
+          '  Ali  ',
+          '’Ali', // curly apostrophe — NOT trimmed
+          'Ali',
+        ];
+
+        final sorted = [...values]
+          ..sort((a, b) {
+            final fa = ComparableField.fromValue(a)!;
+            final fb = ComparableField.fromValue(b)!;
+            return fa.compareTo(fb);
+          });
+
+        // The three ASCII-apostrophe/whitespace variants of `Ali` cluster
+        // together and land before `Bob`; the curly-apostrophe variant
+        // sorts after `Bob` because U+2019 stays in the primary key and
+        // sorts higher than ASCII letters.
+        expect(sorted.take(3).toSet(), {"'Ali", '  Ali  ', 'Ali'});
+        expect(sorted[3], 'Bob');
+        expect(sorted[4], '’Ali');
+      });
+
+      test('should preserve Vietnamese-specific characters', () {
+        // Backend's `IsVietnameseSpecificRune` keeps `Đ/đ`, `Ơ/ơ`, `Ư/ư`, and
+        // the tone-marked range U+1EA0..U+1EF1 out of the normalization fold.
+        // So `Đăng` should sort by `đ` (U+0111 = 273), not by `d` (0x64).
+        final dang = ComparableField.fromValue('Đăng');
+        final ea = ComparableField.fromValue('Ea');
+        // `đ` > `e` in raw codepoint order, so Vietnamese `Đăng` sorts after
+        // the plain-Latin `Ea` — the opposite of what codepoint-blind folding
+        // would produce.
+        expect(dang!.compareTo(ea!), greaterThan(0));
+
+        // But `Chi` still sorts before `Đăng` because `c` < `đ`.
+        final chi = ComparableField.fromValue('Chi');
+        expect(chi!.compareTo(dang), lessThan(0));
+
+        // Non-Vietnamese diacritics on shared Latin letters (`ă` U+0103) are
+        // still folded — only the Vietnamese-specific ranges are preserved.
+        // So `Ăn` (U+0102 A-with-breve) still normalizes to `an`.
+        final an = ComparableField.fromValue('Ăn');
+        final bo = ComparableField.fromValue('Bo');
+        expect(an!.compareTo(bo!), lessThan(0));
+      });
+
+      test('equal-normalized values compare as equal', () {
+        final upper = ComparableField.fromValue('Apple');
+        final lower = ComparableField.fromValue('apple');
+
+        expect(upper!.compareTo(lower!), equals(0));
       });
     });
 

--- a/packages/stream_chat/test/src/core/models/comparable_field_test.dart
+++ b/packages/stream_chat/test/src/core/models/comparable_field_test.dart
@@ -49,7 +49,8 @@ void main() {
     // a raw codepoint compare.
     test('sorts issue #2601 names into a sensible order', () {
       final names = ['Zara', 'jhon', 'Łukasz', 'Øystein', 'Adam', 'Marek'];
-      final sorted = [...names]..sort((a, b) => ComparableField.fromValue(a)!.compareTo(ComparableField.fromValue(b)!));
+      final sorted = [...names]..sort((a, b) => ComparableField.fromValue(a)!
+          .compareTo(ComparableField.fromValue(b)!));
 
       expect(sorted, ['Adam', 'jhon', 'Łukasz', 'Marek', 'Øystein', 'Zara']);
     });
@@ -121,8 +122,7 @@ void main() {
           'Ali',
         ];
 
-        final sorted = [...values]
-          ..sort((a, b) {
+        final sorted = [...values]..sort((a, b) {
             final fa = ComparableField.fromValue(a)!;
             final fb = ComparableField.fromValue(b)!;
             return fa.compareTo(fb);

--- a/packages/stream_chat/test/src/core/util/string_sort_normalizer_test.dart
+++ b/packages/stream_chat/test/src/core/util/string_sort_normalizer_test.dart
@@ -1,0 +1,142 @@
+import 'package:stream_chat/src/core/util/string_sort_normalizer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeStringForSort', () {
+    // Cases mirror the backend's `TestNormalizeName` at
+    // https://github.com/GetStream/chat/blob/b92bf7991752a29e9f67b6ffe69b0bc529f5c48c/lib/combined/utils/text_test.go#L300-L341
+    // so any drift between client and server for these inputs shows up here.
+    group('backend TestNormalizeName parity', () {
+      const cases = <(String description, String input, String expected)>[
+        ('empty', '', ''),
+        ('simple lowercase', 'hello', 'hello'),
+        ('uppercase', 'HELLO', 'hello'),
+        ('mixed case', 'Hello World', 'hello world'),
+
+        // Backend guarantees NormalizeName never stems — same for us.
+        ('no stem running', 'running', 'running'),
+        ('no stem dogs', 'dogs', 'dogs'),
+
+        // Diacritic folding.
+        ('diacritics', 'résumé', 'resume'),
+        ('turkish', 'Günaydın', 'gunaydin'),
+
+        // Apostrophe handling: inner apostrophe preserved, only trailing/
+        // leading U+0027 apostrophes are trimmed.
+        ('apostrophe', "O'Brien", "o'brien"),
+
+        // NormalizeName does NOT apply space normalization, so symbols pass
+        // through.
+        ('numbers and symbols preserved', '123!@#', '123!@#'),
+      ];
+
+      for (final (description, input, expected) in cases) {
+        test(description, () {
+          expect(normalizeStringForSort(input), expected);
+        });
+      }
+    });
+
+    // Vietnamese-preserved chars must survive the fold — the backend keeps
+    // them out of `UnicodeNormalizationMap` via `IsVietnameseSpecificRune`.
+    group('Vietnamese preservation', () {
+      test('preserves đ / Đ (U+0110 / U+0111)', () {
+        expect(normalizeStringForSort('Đăng'), 'đang'); // ă folds to a
+        expect(normalizeStringForSort('đủ'), 'đủ'); // đ + ủ both Vietnamese
+      });
+
+      test('preserves ơ / Ơ, ư / Ư (horn letters)', () {
+        expect(normalizeStringForSort('Ơn'), 'ơn');
+        expect(normalizeStringForSort('Ư'), 'ư');
+      });
+
+      test('preserves the U+1EA0..U+1EF1 tone-marked block', () {
+        // "Tiếng Việt rất đẹp và phức tạp" — the "và" folds (à not
+        // Vietnamese-specific); everything else with tone marks stays.
+        // Matches the backend's `NormalizeText` expected output for the
+        // same input at text_test.go:152.
+        expect(
+          normalizeStringForSort('Tiếng Việt rất đẹp và phức tạp'),
+          'tiếng việt rất đẹp va phức tạp',
+        );
+      });
+
+      test('non-preserved diacritics on shared Latin letters still fold', () {
+        // `ă` (U+0103, A-with-breve) is used in Vietnamese but is NOT in
+        // the preserved ranges — backend folds it too.
+        expect(normalizeStringForSort('Ăn'), 'an');
+      });
+    });
+
+    group('ligatures and stroked letters (per diacritic package)', () {
+      test('folds Ł, Ø, Æ, Þ', () {
+        expect(normalizeStringForSort('Łukasz'), 'lukasz');
+        expect(normalizeStringForSort('Øystein'), 'oystein');
+        expect(normalizeStringForSort('Ægon'), 'aegon');
+        expect(normalizeStringForSort('Þór'), 'thor');
+      });
+
+      test('strips decomposed combining marks (U+0300..U+036F)', () {
+        // 'e' + U+0301 (combining acute) — should decompose to 'e'.
+        expect(normalizeStringForSort('éowyn'), 'eowyn');
+      });
+    });
+
+    // Backend's `Normalize` early-exits on Japanese (Hiragana / Katakana),
+    // Thai, and Vietnamese-specific runes so they aren't touched by the
+    // diacritic-fold or combining-mark strip. We mirror that.
+    group('script preservation', () {
+      test('preserves Hiragana', () {
+        expect(normalizeStringForSort('こんにちは'), 'こんにちは');
+      });
+
+      test('preserves Katakana', () {
+        expect(normalizeStringForSort('カタカナ'), 'カタカナ');
+      });
+
+      test('preserves Thai (including combining marks in the Thai block)', () {
+        // Thai vowels ั / ี are combining marks (Unicode `Mn`) outside
+        // U+0300..U+036F, so they'd survive `diacritic` regardless, but the
+        // explicit preservation makes intent match backend.
+        expect(normalizeStringForSort('สวัสดี'), 'สวัสดี');
+      });
+
+      test('mixed script: Latin folds, Japanese passes through', () {
+        expect(normalizeStringForSort('Hi こんにちは'), 'hi こんにちは');
+      });
+
+      test('preserves Japanese combining sound marks (U+3099, U+309A)', () {
+        // U+3099 and U+309A are `Mn` category codepoints that live inside
+        // the Hiragana range — a decomposed `が` is `か` + U+3099. Without
+        // the Japanese-range early exit, an aggressive combining-mark
+        // strip would drop the sound mark and lose phonetic information.
+        const kaVoiced = 'が'; // か + combining voiced sound mark
+        const kaSemi = 'か゚'; // か + combining semi-voiced sound mark
+
+        expect(normalizeStringForSort(kaVoiced), kaVoiced);
+        expect(normalizeStringForSort(kaSemi), kaSemi);
+      });
+    });
+
+    group('trimming', () {
+      test('strips only U+0027 apostrophes from both ends', () {
+        expect(normalizeStringForSort("'Ali"), 'ali');
+        expect(normalizeStringForSort("Ali'"), 'ali');
+        expect(normalizeStringForSort("'Ali'"), 'ali');
+      });
+
+      test('curly Unicode apostrophes (U+2019) are not trimmed', () {
+        expect(normalizeStringForSort('’Ali'), '’ali');
+      });
+
+      test('trims surrounding whitespace after apostrophes', () {
+        expect(normalizeStringForSort('  Ali  '), 'ali');
+        // Backend runs `TrimApostrophe` before `TrimSpace` in a single pass,
+        // so surrounding whitespace shields inner apostrophes: the outer
+        // spaces prevent apostrophe trimming, then only the spaces get
+        // stripped. Client mirrors this exactly.
+        expect(normalizeStringForSort("  'Ali'  "), "'ali'");
+      });
+    });
+  });
+}


### PR DESCRIPTION
Backport of #2809 to `v9`.

## Summary

Fixes #2601 — client-side `SortOption` on `name` was ordering results differently from the server because `ComparableField` used a raw codepoint compare. Lowercase names and non-ASCII names (Polish `Ł`, Norwegian `Ø`, etc.) got pushed to the end instead of sorting alphabetically.

Route string comparisons through a new `normalizeStringForSort` helper that mirrors the backend's [`NormalizeName`](https://github.com/GetStream/chat/blob/b92bf7991752a29e9f67b6ffe69b0bc529f5c48c/lib/combined/utils/text.go#L88-L95) pipeline:

1. Fold Latin diacritics and ligatures (`é → e`, `Ł → l`, `Æ → ae`) via `package:diacritic`.
2. Preserve Japanese kana, Thai, and Vietnamese-specific runes unchanged.
3. Lowercase.
4. Trim leading/trailing ASCII apostrophes then whitespace.

Backend has no tie-breaker for `sort: name`, so we don't either — equal-normalized values compare as `0` and Dart's stable `List.sort` preserves input order.

## Backport notes

- v9 uses 80-char line length (master uses 120); the Vietnamese predicate is split one condition per line to fit.
- v9 uses `diacritic: ^0.1.5` (master uses `^0.1.6`); dep added at v9's version.
- Everything else applied cleanly.

## Test plan

- [x] `dart test` — 1275 tests pass in `stream_chat`.
- [x] `dart analyze --fatal-infos` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)