### PR TITLE
fix(ui): preserve last-message preview during channel-state reloads

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
 - Fixed shadowed messages not hidden in channel list items.
+- Fixed last-message preview flicker during channel-state reloads.
 
 ## 9.26.0
 

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_tile.dart
@@ -421,7 +421,18 @@ class _ChannelLastMessageTextState extends State<ChannelLastMessageText> {
 
         // Otherwise, show the channel last message if it exists.
         final message = messages.lastWhereOrNull(widget.lastMessagePredicate);
-        final latestLastMessage = [message, _currentLastMessage].latest;
+        // `_currentLastMessage` holds the most recent message seen while the
+        // channel has the latest messages (isUpToDate).
+        // While isUpToDate is false (e.g. Channel.query(idAround:) truncates
+        // state mid-load), fall back to it so the preview shows the actual
+        // latest message.
+        final Message? latestLastMessage;
+        if (channelState.isUpToDate) {
+          latestLastMessage = message;
+          _currentLastMessage = latestLastMessage;
+        } else {
+          latestLastMessage = [message, _currentLastMessage].latest;
+        }
 
         if (latestLastMessage == null) {
           return Text(

--- a/packages/stream_chat_flutter/test/src/scroll_view/channel_scroll_view/stream_channel_list_tile_test.dart
+++ b/packages/stream_chat_flutter/test/src/scroll_view/channel_scroll_view/stream_channel_list_tile_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,6 +9,9 @@ import '../../mocks.dart';
 
 void main() {
   const currentUserId = 'me';
+
+  // The default English translation; matches `emptyMessagesText`.
+  const emptyText = 'There are no messages currently';
 
   late MockClient client;
   late MockClientState clientState;
@@ -163,6 +168,153 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('shadowed by other'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'preserves the last-known message when state is not up-to-date and '
+    'emits empty',
+    (tester) async {
+      final other = User(id: 'other');
+      final msg1 = Message(id: 'm1', text: 'hello', user: other);
+
+      final controller = StreamController<List<Message>>.broadcast();
+      addTearDown(controller.close);
+
+      var isUpToDate = true;
+      when(() => channelState.isUpToDate).thenAnswer((_) => isUpToDate);
+      when(() => channelState.messages).thenReturn([msg1]);
+      when(() => channelState.messagesStream)
+          .thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: Scaffold(
+              body: ChannelLastMessageText(channel: channel),
+            ),
+          ),
+        ),
+      );
+      controller.add([msg1]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('hello'), findsOneWidget);
+      expect(find.text(emptyText), findsNothing);
+
+      // While loading a historical window, isUpToDate flips false and the
+      // intermediate state emits an empty messages list.
+      isUpToDate = false;
+      controller.add([]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('hello'), findsOneWidget);
+      expect(find.text(emptyText), findsNothing);
+
+      // The loaded window arrives; isUpToDate restored.
+      final msg2 = Message(id: 'm2', text: 'world', user: other);
+      isUpToDate = true;
+      controller.add([msg1, msg2]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('world'), findsOneWidget);
+      expect(find.text(emptyText), findsNothing);
+    },
+  );
+
+  testWidgets(
+    "rebinding the widget to a different channel shows that channel's "
+    "state, not the previous one's",
+    (tester) async {
+      // List reordering reuses the underlying State across channels (no key
+      // on the list item). Channel B is empty; channel A had a message —
+      // the cell must render B's empty state, not A's last message.
+      final other = User(id: 'other');
+      final msgA = Message(id: 'ma', text: 'channel-a-message', user: other);
+
+      when(() => channelState.messages).thenReturn([msgA]);
+      when(() => channelState.messagesStream)
+          .thenAnswer((_) => Stream.value([msgA]));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: Scaffold(
+              body: ChannelLastMessageText(channel: channel),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('channel-a-message'), findsOneWidget);
+
+      final channelB = MockChannel(id: 'b', type: 'messaging');
+      final channelStateB = MockChannelState();
+      when(() => channelB.client).thenReturn(client);
+      when(() => channelB.state).thenReturn(channelStateB);
+      when(() => channelStateB.draft).thenReturn(null);
+      when(() => channelStateB.draftStream)
+          .thenAnswer((_) => Stream.value(null));
+      when(() => channelStateB.channelState).thenReturn(const ChannelState());
+      when(() => channelStateB.messages).thenReturn([]);
+      when(() => channelStateB.messagesStream)
+          .thenAnswer((_) => Stream.value(<Message>[]));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: Scaffold(
+              body: ChannelLastMessageText(channel: channelB),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('channel-a-message'), findsNothing);
+      expect(find.text(emptyText), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'shows the empty-state when the channel is truncated while up-to-date',
+    (tester) async {
+      // A channel.truncated event clears messages but leaves isUpToDate true.
+      // The preview must reflect the now-empty channel.
+      final other = User(id: 'other');
+      final msg1 = Message(id: 'm1', text: 'hello', user: other);
+
+      final controller = StreamController<List<Message>>.broadcast();
+      addTearDown(controller.close);
+
+      when(() => channelState.messages).thenReturn([msg1]);
+      when(() => channelState.messagesStream)
+          .thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: Scaffold(
+              body: ChannelLastMessageText(channel: channel),
+            ),
+          ),
+        ),
+      );
+      controller.add([msg1]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('hello'), findsOneWidget);
+
+      controller.add([]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('hello'), findsNothing);
+      expect(find.text(emptyText), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-549

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Backport of master commit `36d8a1c94ab74448680c67531460ac10977f7d8a` — _"fix(ui): preserve last-message preview during channel-state reloads (#2774)"_.

### Why

The same last-message-preview flicker exists on `v9`. When opening a channel with unreads, `Channel.query(idAround:)` runs `state.truncate()` (emits an empty `messages` list) immediately followed by `updateChannelState()` (emits the populated state), so the channel-list cell briefly flashes the empty-state text (_"There are no messages currently"_) before snapping to the real preview.

The preview widget already had a `_currentLastMessage` cache field meant to absorb that transient empty emission, but in `_ChannelLastMessageTextState` it was **declared and never assigned** — making the absorber a no-op, so the flash was visible.

### The fix

Assign `_currentLastMessage = message` on every build, gated on `channelState.isUpToDate`, and compute it **before** `.latest` so the freshly-stored value participates in the selector:

- While `isUpToDate` is `false` (the `idAround` truncate mid-load), fall back to the cached message so the preview keeps showing the real latest message.
- A real `channel.truncated` event keeps `isUpToDate == true`, so the cache correctly clears and the empty-state surfaces.

### Manual port (not a clean cherry-pick)

- The source file was **renamed** on master (`stream_channel_list_item.dart`) vs `v9` (`stream_channel_list_tile.dart`).
- Master applied the same fix to **two** widgets (`_ChannelLastMessageWithStatus` and `ChannelLastMessageText`). `_ChannelLastMessageWithStatus` does **not** exist on `v9`, so only the `ChannelLastMessageText` hunk was ported (there is no cache to fix in v9's inline sending-indicator path).
- The regression tests were **extended into the existing** `v9` `stream_channel_list_tile_test.dart` (which already covers this widget) rather than the standalone file master added. Three scenarios were added: preserves the last-known message while not up-to-date and emitting empty, rebinding to a different channel shows that channel's state, and shows the empty-state on truncate while up-to-date.
- The empty-state string differs on `v9` (_"There are no messages currently"_ vs master's _"No messages yet"_), so the test constant was adapted accordingly.

### Verification

- `melos run format` → 0 changed
- `dart analyze --fatal-infos` → no issues
- 8/8 tests pass in `stream_channel_list_tile_test.dart` (5 existing + 3 new)

## Screenshots / Videos

No UI changes. (Backport of an already-reviewed fix; behaviour verified via the added regression tests.)