### PR TITLE
fix(core): Fix backwards pagination not working if channel was never opened

### DIFF
--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 🐞 Fixed
 
 - Fixed `StreamChannelListController` not handling `notification.channel_deleted` event.
+- Fixed backwards pagination not working if channel was never opened.
 
 ## 9.26.0
 

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -201,6 +201,10 @@ class StreamChannel extends StatefulWidget {
 
 // ignore: public_member_api_docs
 class StreamChannelState extends State<StreamChannel> {
+  // Anything before this is treated as the server's "never read" sentinel
+  // (Go's zero `time.Time{}` → `DateTime.utc(1, 1, 1)`).
+  static final _minValidLastRead = DateTime.utc(1970);
+
   /// Current channel
   Channel get channel => widget.channel;
 
@@ -877,8 +881,12 @@ class StreamChannelState extends State<StreamChannel> {
         }
       }
 
-      // Otherwise, load the channel at the last read date.
-      return loadChannelAtTimestamp(currentUserRead.lastRead);
+      // Skip the "never read" sentinel: the server ignores it as
+      // `created_at_around` and returns the tail, which would mis-infer
+      // `_topPaginationEnded = true`. Fall through to load-latest below.
+      if (currentUserRead.lastRead.isAfter(_minValidLastRead)) {
+        return loadChannelAtTimestamp(currentUserRead.lastRead);
+      }
     }
 
     // If nothing above applies, we just load the channel at the latest

--- a/packages/stream_chat_flutter_core/test/stream_channel_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_channel_test.dart
@@ -7,6 +7,30 @@ import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 
 import 'mocks.dart';
 
+Future<StreamChannelState> _pumpStreamChannel(
+  WidgetTester tester,
+  Channel channel,
+) async {
+  StreamChannelState? channelState;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: StreamChannel(
+          channel: channel,
+          child: Builder(
+            builder: (context) {
+              channelState = StreamChannel.of(context);
+              return const Text('Channel Content');
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return channelState!;
+}
+
 void main() {
   group('StreamChannel.of()', () {
     testWidgets(
@@ -515,34 +539,6 @@ void main() {
 
     tearDown(() => reset(mockChannel));
 
-    Future<StreamChannelState> _pumpStreamChannel(WidgetTester tester) async {
-      StreamChannelState? channelState;
-
-      // Build a widget that accesses the channel state
-      final testWidget = MaterialApp(
-        home: Scaffold(
-          body: StreamChannel(
-            channel: mockChannel,
-            child: Builder(
-              builder: (context) {
-                // Access the channel state
-                channelState = StreamChannel.of(context);
-                return const Text('Channel Content');
-              },
-            ),
-          ),
-        ),
-      );
-
-      await tester.pumpWidget(testWidget);
-      await tester.pumpAndSettle();
-
-      // Verify we can access the channel state
-      expect(channelState, isNotNull);
-
-      return channelState!;
-    }
-
     testWidgets(
       'Returns null when messages list is empty',
       (tester) async {
@@ -550,7 +546,7 @@ void main() {
         when(() => mockChannel.state.unreadCount).thenReturn(0);
         when(() => mockChannel.state.isUpToDate).thenReturn(true);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         expect(streamChannel.getFirstUnreadMessage(), isNull);
       },
@@ -579,7 +575,7 @@ void main() {
         when(() => mockChannel.state.currentUserRead).thenReturn(mockRead);
         when(() => mockChannel.state.isUpToDate).thenReturn(true);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         expect(streamChannel.getFirstUnreadMessage(mockRead), isNull);
       },
@@ -614,7 +610,7 @@ void main() {
         when(() => mockChannel.state.messages).thenReturn(messages);
         when(() => mockChannel.state.currentUserRead).thenReturn(mockRead);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         expect(streamChannel.getFirstUnreadMessage(), isNull);
       },
@@ -655,7 +651,7 @@ void main() {
         when(() => mockChannel.state.messages).thenReturn(messages);
         when(() => mockChannel.state.currentUserRead).thenReturn(mockRead);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         expect(streamChannel.getFirstUnreadMessage(), equals(unreadMessage));
       },
@@ -703,7 +699,7 @@ void main() {
         when(() => mockChannel.state.messages).thenReturn(messages);
         when(() => mockChannel.state.currentUserRead).thenReturn(mockRead);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         expect(
           streamChannel.getFirstUnreadMessage(),
@@ -750,7 +746,7 @@ void main() {
         when(() => mockChannel.state.messages).thenReturn(messages);
         when(() => mockChannel.state.currentUserRead).thenReturn(defaultRead);
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         // With default read - should return null
         expect(streamChannel.getFirstUnreadMessage(), isNull);
@@ -764,6 +760,132 @@ void main() {
     );
   });
 
+  group('_maybeInitChannel', () {
+    final mockChannel = MockChannel();
+    tearDownAll(mockChannel.dispose);
+
+    setUp(() {
+      when(() => mockChannel.cid).thenReturn('test:channel1');
+      when(() => mockChannel.state.messages).thenReturn(const <Message>[]);
+      when(() => mockChannel.state.isUpToDate).thenReturn(true);
+      when(
+        () => mockChannel.query(
+          preferOffline: any(named: 'preferOffline'),
+          messagesPagination: any(named: 'messagesPagination'),
+        ),
+      ).thenAnswer((_) async => const ChannelState());
+    });
+
+    tearDown(() => reset(mockChannel));
+
+    testWidgets(
+      'queries idAround=lastReadMessageId when lastReadMessageId is set',
+      (tester) async {
+        final read = Read(
+          user: User(id: 'testUserId'),
+          lastRead: DateTime.now(),
+          unreadMessages: 100,
+          lastReadMessageId: 'last-read-msg',
+        );
+        when(() => mockChannel.state.unreadCount).thenReturn(100);
+        when(() => mockChannel.state.currentUserRead).thenReturn(read);
+
+        await _pumpStreamChannel(tester, mockChannel);
+
+        final captured = verify(
+          () => mockChannel.query(
+            preferOffline: any(named: 'preferOffline'),
+            messagesPagination: captureAny(named: 'messagesPagination'),
+          ),
+        ).captured.single as PaginationParams;
+
+        expect(captured.idAround, equals('last-read-msg'));
+        expect(captured.createdAtAround, isNull);
+      },
+    );
+
+    testWidgets(
+      'queries createdAtAround=lastRead when lastReadMessageId is null and '
+      'lastRead is a real timestamp',
+      (tester) async {
+        final lastRead = DateTime.utc(2026, 6, 26, 12);
+        final read = Read(
+          user: User(id: 'testUserId'),
+          lastRead: lastRead,
+          unreadMessages: 100,
+        );
+        when(() => mockChannel.state.unreadCount).thenReturn(100);
+        when(() => mockChannel.state.currentUserRead).thenReturn(read);
+
+        await _pumpStreamChannel(tester, mockChannel);
+
+        final captured = verify(
+          () => mockChannel.query(
+            preferOffline: any(named: 'preferOffline'),
+            messagesPagination: captureAny(named: 'messagesPagination'),
+          ),
+        ).captured.single as PaginationParams;
+
+        expect(captured.idAround, isNull);
+        expect(captured.createdAtAround, equals(lastRead.toUtc()));
+      },
+    );
+
+    testWidgets(
+      'does not query around when lastReadMessageId is null and lastRead is '
+      'the Go zero-time sentinel',
+      (tester) async {
+        final read = Read(
+          user: User(id: 'testUserId'),
+          // Go `time.Time{}` deserializes to `0001-01-01T00:00:00Z`.
+          lastRead: DateTime.utc(1),
+          unreadMessages: 100,
+        );
+        when(() => mockChannel.state.unreadCount).thenReturn(100);
+        when(() => mockChannel.state.currentUserRead).thenReturn(read);
+
+        await _pumpStreamChannel(tester, mockChannel);
+
+        // `isUpToDate` is true (setUp), so the catch-all "load latest" path
+        // at the end of `_maybeInitChannel` does not fire either — no query
+        // should happen at all.
+        verifyNever(
+          () => mockChannel.query(
+            preferOffline: any(named: 'preferOffline'),
+            messagesPagination: any(named: 'messagesPagination'),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'queries latest page (no around-anchor) when lastRead is the Go '
+      'zero-time sentinel and channel is stale',
+      (tester) async {
+        when(() => mockChannel.state.isUpToDate).thenReturn(false);
+        final read = Read(
+          user: User(id: 'testUserId'),
+          lastRead: DateTime.utc(1),
+          unreadMessages: 100,
+        );
+        when(() => mockChannel.state.unreadCount).thenReturn(100);
+        when(() => mockChannel.state.currentUserRead).thenReturn(read);
+
+        await _pumpStreamChannel(tester, mockChannel);
+
+        final captured = verify(
+          () => mockChannel.query(
+            preferOffline: any(named: 'preferOffline'),
+            messagesPagination: captureAny(named: 'messagesPagination'),
+          ),
+        ).captured.single as PaginationParams;
+
+        expect(captured.idAround, isNull);
+        expect(captured.createdAtAround, isNull);
+      },
+    );
+  });
+
   group('pruneOldest', () {
     final mockChannel = MockChannel();
     tearDownAll(mockChannel.dispose);
@@ -771,27 +893,6 @@ void main() {
     // Mutable backing for state.messages so the mocked pruneOldest can
     // modify the value subsequent stubs return.
     var stateMessages = <Message>[];
-
-    Future<StreamChannelState> _pumpStreamChannel(WidgetTester tester) async {
-      StreamChannelState? channelState;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: StreamChannel(
-              channel: mockChannel,
-              child: Builder(
-                builder: (context) {
-                  channelState = StreamChannel.of(context);
-                  return const Text('Channel Content');
-                },
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-      return channelState!;
-    }
 
     List<Message> _generateMessages(int count) => List.generate(
           count,
@@ -823,7 +924,7 @@ void main() {
     testWidgets('delegates to channel.state.pruneOldest', (tester) async {
       stateMessages = _generateMessages(10);
 
-      final streamChannel = await _pumpStreamChannel(tester);
+      final streamChannel = await _pumpStreamChannel(tester, mockChannel);
       streamChannel.pruneOldest(4);
 
       verify(() => mockChannel.state.pruneOldest(4)).called(1);
@@ -846,7 +947,7 @@ void main() {
           (_) async => ChannelState(messages: _generateMessages(2)),
         );
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         await streamChannel.queryMessages();
         await streamChannel.queryMessages();
@@ -888,7 +989,7 @@ void main() {
           (_) async => ChannelState(messages: _generateMessages(2)),
         );
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         await streamChannel.queryMessages();
 
@@ -958,31 +1059,10 @@ void main() {
       reset(mockChannel);
     });
 
-    Future<StreamChannelState> _pumpStreamChannel(WidgetTester tester) async {
-      StreamChannelState? channelState;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: StreamChannel(
-              channel: mockChannel,
-              child: Builder(
-                builder: (context) {
-                  channelState = StreamChannel.of(context);
-                  return const Text('Channel Content');
-                },
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-      return channelState!;
-    }
-
     testWidgets(
       'truncates the existing window before querying the latest messages',
       (tester) async {
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         await streamChannel.reloadChannel();
 
@@ -999,7 +1079,7 @@ void main() {
     testWidgets(
       'queries with no around-anchor (loads the latest page)',
       (tester) async {
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
 
         await streamChannel.reloadChannel();
 
@@ -1023,7 +1103,7 @@ void main() {
         // would have produced.
         stateMessages = _generateMessages(30, prefix: 'old');
 
-        final streamChannel = await _pumpStreamChannel(tester);
+        final streamChannel = await _pumpStreamChannel(tester, mockChannel);
         await streamChannel.reloadChannel();
 
         // Without the truncate the merge would land us on 60 messages


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-563

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

**Backport of `master` → `v9`** of commit `1a90e921105fa9edad3985828868fadc22f39d2d` (PR #2789, Fixes FLU-563).

### The bug
When a user enters a channel with `unread_count > 0` but the server-side read state is the "never explicitly read" sentinel (`last_read_message_id = null` and `last_read = 0001-01-01T00:00:00Z` — Go's `time.Time{}` zero value), `StreamChannelState._maybeInitChannel` unconditionally called `loadChannelAtTimestamp(currentUserRead.lastRead)`.

The backend silently ignores the zero-time `created_at_around` (via `IsZero()`) and returns the channel tail. The client then mis-infers boundaries via `_inferBoundariesFromAnchorTimestamp`: because year-1 precedes every loaded message, it concludes `endOfPrependReached: true`, sets `_topPaginationEnded = true`, and backwards pagination is permanently dead on the channel.

### The fix
Guard the timestamp branch on `currentUserRead.lastRead.isAfter(_minValidLastRead)` (`DateTime.utc(1970)`). When it's the zero sentinel, the code falls through to the existing catch-all — stay on the cached latest window if up-to-date, otherwise reload the latest page.

Adds a `_maybeInitChannel` test group with four regression guards: `idAround` for `lastReadMessageId`, `createdAtAround` for real timestamps, no query for the Go zero-time case when up-to-date, and a latest-page reload for the Go zero-time case when stale.

### Backport notes
- **Manual port, not a clean cherry-pick.** The `_maybeInitChannel` logic on `v9` was byte-for-byte identical to master's pre-fix state, but `v9` and `master` diverge in `analysis_options.yaml`: `v9` drops the `page_width: 120` formatter block (reverting to the 80-col default) and enables the `avoid_redundant_argument_values` lint. A raw cherry-pick would have imported master's formatting/lint style.
- **v9-specific adaptation:** master's `DateTime.utc(1970, 1, 1)` / `DateTime.utc(1, 1, 1)` are written as `DateTime.utc(1970)` / `DateTime.utc(1)` here (semantically identical) to satisfy v9's enabled `avoid_redundant_argument_values` lint.
- Verified test-first: confirmed the two Go-zero-time tests fail on `v9` before the fix, then pass after. `dart format`, `dart analyze --fatal-infos`, and all 30 tests in `stream_channel_test.dart` are green.

## Screenshots / Videos

No UI changes. (See the before/after videos on the original master PR #2789.)