### PR TITLE
fix(samples): cap firebase plugins below broken 16.4.2/5.2.5 releases

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -47,8 +47,11 @@ command:
       equatable: ^2.0.8
       ezanimation: ^0.6.0
       firebase_core: ^4.0.0
-      firebase_crashlytics: ^5.2.0
-      firebase_messaging: ^16.0.0
+      # Capped below 5.2.5 / 16.4.2: those releases import `FirebasePlugin` from
+      # firebase_core_platform_interface, which no longer exposes it. Remove the
+      # upper bounds once FlutterFire ships a fixed release.
+      firebase_crashlytics: '>=5.2.0 <5.2.5'
+      firebase_messaging: '>=16.0.0 <16.4.2'
       file_picker: ^11.0.0
       file_selector: ^1.1.0
       flutter_app_badger: ^1.5.0

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
   avatar_glow: ^3.0.0
   collection: ^1.19.1
   firebase_core: ^4.0.0
-  firebase_crashlytics: ^5.2.0
-  firebase_messaging: ^16.0.0
+  firebase_crashlytics: ">=5.2.0 <5.2.5"
+  firebase_messaging: ">=16.0.0 <16.4.2"
   flutter:
     sdk: flutter
   flutter_app_badger: ^1.5.0


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The `sample_app` CI build (both Android and iOS) started failing at Dart compile time inside the Firebase plugins:

```
firebase_crashlytics-5.2.5/lib/src/firebase_crashlytics.dart: Error: Type 'FirebasePlugin' not found.
firebase_messaging-16.4.2/lib/src/messaging.dart: Error: Type 'FirebasePlugin' not found.
... The getter 'pluginConstants' isn't defined ...
```

### Root cause

`firebase_messaging 16.4.2` and `firebase_crashlytics 5.2.5` (both published ~2026-07-13) do `import '...firebase_core_platform_interface...' show FirebasePlugin;`, but no version of `firebase_core_platform_interface` exposes `FirebasePlugin` anymore — it was renamed to `FirebasePluginPlatform`. These are broken upstream releases that can't compile against the interface version they themselves depend on (`^7.1.0`).

Because `sample_app/pubspec.lock` is gitignored, CI re-resolves on every build and floated straight onto these broken releases the moment they were published — which is why the build went red with no relevant code change.

### Fix

Cap the two plugins below the broken releases in `melos.yaml` (the single source of truth for shared dependency versions); `melos bootstrap` syncs the constraints into `sample_app/pubspec.yaml`:

- `firebase_crashlytics: '>=5.2.0 <5.2.5'`
- `firebase_messaging: '>=16.0.0 <16.4.2'`

Resolution now lands on the last-good set (`firebase_messaging 16.4.1`, `firebase_crashlytics 5.2.4`). Remove the upper bounds once FlutterFire ships a fixed `16.4.3` / `5.2.6`.

### Test plan

- `melos bootstrap` re-resolves `sample_app` to `firebase_messaging 16.4.1` / `firebase_crashlytics 5.2.4`.
- `flutter build apk --release` in `sample_app` succeeds (`✓ Built app-release.apk`) — the `FirebasePlugin` / `kernel_snapshot` errors are gone.

## Screenshots / Videos

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented compatibility issues by restricting Firebase Crashlytics and Firebase Messaging to supported version ranges.
  * Improved build reliability until compatible upstream releases are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->