### PR TITLE
fix(llc, core): Fix wrong changelog entries

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,8 +1,17 @@
 ## Upcoming
 
+✅ Added
+
+- Added support for predefined filters for `QueryChannels` on `StreamChatClient` (`StreamChatClient.queryChannels` and `StreamChatClient.queryChannelsWithResult`).
+- Added `ChatPersistenceClient.queryChannelStates` and `ChatPersistenceClient.saveChannelQueries` as the unified read/write methods for channel-query persistence. Both accept standard and predefined-filter parameters and internally dispatch.
+
 🔄 Changed
 
 - `StreamChatClient.updateSystemEnvironment` now sanitizes the passed `SystemEnvironment`: `sdkName`, `sdkVersion`, and `osName` are locked to internal defaults, and `sdkIdentifier` only accepts the `dart` → `flutter` promotion (other values, including a `flutter` → `dart` demotion, are ignored). `appName`, `appVersion`, `osVersion`, and `deviceModel` continue to pass through as-is.
+
+⚠️ Deprecated
+
+- Deprecated `ChatPersistenceClient.getChannelStates` and `ChatPersistenceClient.updateChannelQueries` in favor of the unified `queryChannelStates` / `saveChannelQueries`. The deprecated methods stay overridable so downstream subclasses keep working unchanged.
 
 🐞 Fixed
 
@@ -10,15 +19,7 @@
 
 ## 9.26.0
 
-✅ Added
-
-- Added support for predefined filters for `QueryChannels` on `StreamChatClient` (`StreamChatClient.queryChannels` and `StreamChatClient.queryChannelsWithResult`).
-- Added `ChatPersistenceClient.queryChannelStates` and `ChatPersistenceClient.saveChannelQueries` as the unified read/write methods for channel-query persistence. Both accept standard and predefined-filter parameters and internally dispatch.
 - Added `StreamChatClient.pauseReconnect` / `resumeReconnect` to suspend the WebSocket's auto-retry loop without tearing down the user session.
-
-⚠️ Deprecated
-
-- Deprecated `ChatPersistenceClient.getChannelStates` and `ChatPersistenceClient.updateChannelQueries` in favor of the unified `queryChannelStates` / `saveChannelQueries`. The deprecated methods stay overridable so downstream subclasses keep working unchanged.
 
 🐞 Fixed
 

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 9.26.0
+## Upcoming
 
 ✅ Added
 
 - Added support for predefined filters on `StreamChannelListController`.
+
+## 9.26.0
 
 🐞 Fixed
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Several `## Upcoming` changelog entries were mistakenly filed under the already-released `## 9.26.0` section. This PR moves them back to `## Upcoming` where they belong.

**`stream_chat` (llc)** — moved into `## Upcoming`:
- ✅ Added: predefined filters for `QueryChannels` on `StreamChatClient` (`queryChannels` / `queryChannelsWithResult`).
- ✅ Added: `ChatPersistenceClient.queryChannelStates` / `saveChannelQueries` as the unified read/write methods for channel-query persistence.
- ⚠️ Deprecated: `ChatPersistenceClient.getChannelStates` / `updateChannelQueries` in favor of the unified methods.

**`stream_chat_flutter_core` (core)** — moved into `## Upcoming`:
- ✅ Added: predefined filters on `StreamChannelListController`.

Documentation-only change (CHANGELOG.md files); no code changes.

## Screenshots / Videos

No UI changes.