### PR TITLE
fix(ui): Mark channel read immediately when the unread indicator is dismissed

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed last-message preview flicker during channel-state reloads.
 - Fixed shadowed messages not hidden in channel list items.
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
+- Fixed dismissing the `StreamMessageListView` unread indicator being ignored while a channel is receiving a rapid burst of messages.
 
 ## 10.1.0
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -920,6 +920,16 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
 
   Future<void> _markMessagesAsRead() async {
     if (widget.parentMessage case final parent?) {
+      // If we are in a thread, mark the thread as read immediately.
+      await streamChannel?.channel.markThreadRead(parent.id);
+    } else {
+      // Otherwise, mark the channel as read immediately.
+      await streamChannel?.channel.markRead();
+    }
+  }
+
+  Future<void> _markMessagesAsReadDebounced() async {
+    if (widget.parentMessage case final parent?) {
       // If we are in a thread, mark the thread as read.
       debouncedMarkThreadRead.call([parent.id]);
     } else {
@@ -1230,7 +1240,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (!isInThread && !hasUnread) return;
 
     // Mark messages as read if it's allowed.
-    return _markMessagesAsRead();
+    return _markMessagesAsReadDebounced();
   }
 
   void _getOnThreadTap() {

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -922,13 +922,14 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (widget.parentMessage case final parent?) {
       // If we are in a thread, mark the thread as read immediately.
       await streamChannel?.channel.markThreadRead(parent.id);
-    } else {
-      // Otherwise, mark the channel as read immediately.
-      await streamChannel?.channel.markRead();
+      return;
     }
+
+    // Otherwise, mark the channel as read immediately.
+    await streamChannel?.channel.markRead();
   }
 
-  Future<void> _markMessagesAsReadDebounced() async {
+  Future<void> _debouncedMarkMessagesAsRead() async {
     if (widget.parentMessage case final parent?) {
       // If we are in a thread, mark the thread as read.
       debouncedMarkThreadRead.call([parent.id]);
@@ -1240,7 +1241,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (!isInThread && !hasUnread) return;
 
     // Mark messages as read if it's allowed.
-    return _markMessagesAsReadDebounced();
+    return _debouncedMarkMessagesAsRead();
   }
 
   void _getOnThreadTap() {

--- a/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
@@ -324,4 +324,61 @@ void main() {
       },
     );
   });
+
+  group('unread indicator dismiss', () {
+    testWidgets(
+      'marks the channel read immediately when tapped',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages = generateConversation(20, users: [other]);
+
+        await pumpMessageList(
+          tester,
+          messages: messages,
+          isUpToDate: true,
+          unreadCount: 5,
+          markReadWhenAtTheBottom: false,
+        );
+
+        // Nothing has marked the channel read yet.
+        verifyNever(() => channel.markRead(messageId: any(named: 'messageId')));
+
+        final indicator = tester.widget<UnreadIndicatorButton>(
+          find.byType(UnreadIndicatorButton),
+        );
+        await indicator.onDismissTap();
+
+        verify(() => channel.markRead(messageId: any(named: 'messageId'))).called(1);
+      },
+    );
+
+    testWidgets(
+      'fires markRead on every tap (not debounced)',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages = generateConversation(20, users: [other]);
+
+        await pumpMessageList(
+          tester,
+          messages: messages,
+          isUpToDate: true,
+          unreadCount: 5,
+          markReadWhenAtTheBottom: false,
+        );
+
+        final indicator = tester.widget<UnreadIndicatorButton>(
+          find.byType(UnreadIndicatorButton),
+        );
+
+        // Three taps in quick succession, well within the 1s debounce window.
+        // A debounced dismiss (leading: true) would collapse these into a
+        // single immediate call; the fix fires one markRead per tap.
+        await indicator.onDismissTap();
+        await indicator.onDismissTap();
+        await indicator.onDismissTap();
+
+        verify(() => channel.markRead(messageId: any(named: 'messageId'))).called(3);
+      },
+    );
+  });
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-551

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

**Problem:** When a channel is being spammed with messages while the user sits at the bottom, tapping the close (X) on `StreamMessageListView`'s jump-to-unread indicator appears to do nothing — the badge stays / immediately reappears and the dismiss is effectively ignored.

**Root cause:** The dismiss (`onDismissTap`) was routed through the same `debounce`d mark-read used by the auto-mark-read-at-the-bottom path (`leading: true`, 1s). During a burst, the auto-mark-read continuously holds the debounce window open, so its leading edge is already consumed. The dismiss tap then lands *inside* the window and is suppressed — it never fires a `markRead` call.

**Fix:** The dismiss now bypasses the debouncer and calls `channel.markRead()` / `channel.markThreadRead()` **immediately**, so it can never be swallowed regardless of what the auto-mark-read window is doing. The debounced path is unchanged and still used by the auto-mark-read-at-the-bottom flow. Error handling and null-safety match the debounced path exactly.

**Tests:** Added regression tests in `mark_read_test.dart` under `unread indicator dismiss`:
- Dismiss marks the channel read immediately (single `markRead` call).
- Repeated dismiss taps each fire `markRead` (proves the action is no longer debounced — verified this test fails if wired back to the debounced path).

## Screenshots / Videos

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7ff462f2-41ae-4fe2-aec6-9f37a9016d56"></video> | <video src="https://github.com/user-attachments/assets/745c4e28-8c39-4cb4-8d93-52bfea51c6f8"></video> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread indicator dismissal in `StreamMessageListView` so it consistently marks messages as read, even when channels receive rapid bursts of new messages.
  * Ensured repeated dismiss taps trigger read marking immediately (not debounced/ignored), reflecting one mark action per tap when configured.
  * Kept debounced read marking for automatic bottom-of-list and visibility-based behavior.
* **Tests**
  * Added coverage for unread indicator dismissal behavior, including repeated-tap call counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->