### PR TITLE
fix(llc): reduce default thread participant and member limits

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 🔄 Changed
 
+- Reduced the default `participantLimit` and `memberLimit` on `ThreadOptions` from `100` to `10`.
 - `StreamChatClient.updateSystemEnvironment` now sanitizes the passed `SystemEnvironment`: `sdkName`, `sdkVersion`, and `osName` are locked to internal defaults, and `sdkIdentifier` only accepts the `dart` → `flutter` promotion (other values, including a `flutter` → `dart` demotion, are ignored). `appName`, `appVersion`, `osVersion`, and `deviceModel` continue to pass through as-is.
 
 🐞 Fixed

--- a/packages/stream_chat/lib/src/core/api/requests.dart
+++ b/packages/stream_chat/lib/src/core/api/requests.dart
@@ -176,8 +176,8 @@ class ThreadOptions extends Equatable {
   const ThreadOptions({
     this.watch = true,
     this.replyLimit = 2,
-    this.participantLimit = 100,
-    this.memberLimit = 100,
+    this.participantLimit = 10,
+    this.memberLimit = 10,
   });
 
   /// If true, the client will watch for changes in the thread.
@@ -192,12 +192,12 @@ class ThreadOptions extends Equatable {
 
   /// The number of thread participants to return per thread.
   ///
-  /// Defaults to 100.
+  /// Defaults to 10.
   final int participantLimit;
 
   /// The number of members to return per thread.
   ///
-  /// Defaults to 100.
+  /// Defaults to 10.
   final int memberLimit;
 
   /// Serialize model to json

--- a/packages/stream_chat/test/src/core/api/requests_test.dart
+++ b/packages/stream_chat/test/src/core/api/requests_test.dart
@@ -71,5 +71,30 @@ void main() {
         expect(newParams.idAround, newTestString);
       });
     });
+
+    group('ThreadOptions', () {
+      test('default', () {
+        const options = ThreadOptions();
+        final j = options.toJson();
+        expect(j, containsPair('watch', true));
+        expect(j, containsPair('reply_limit', 2));
+        expect(j, containsPair('participant_limit', 10));
+        expect(j, containsPair('member_limit', 10));
+      });
+
+      test('serializes provided values', () {
+        const options = ThreadOptions(
+          watch: false,
+          replyLimit: 5,
+          participantLimit: 20,
+          memberLimit: 20,
+        );
+        final j = options.toJson();
+        expect(j, containsPair('watch', false));
+        expect(j, containsPair('reply_limit', 5));
+        expect(j, containsPair('participant_limit', 20));
+        expect(j, containsPair('member_limit', 20));
+      });
+    });
   });
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-595

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Reduces the default `participantLimit` and `memberLimit` on `ThreadOptions` from `100` to `10`, cutting data usage when querying threads. These defaults apply to `StreamChatClient.queryThreads` / `getThread` and, transitively, to `StreamThreadListController`.

Context:
- Matches the iOS SDK, where `ThreadListQuery.participantLimit` defaults to `10` (verified against `stream-chat-swift` `develop`). iOS has no `member_limit` on the thread query at all; Flutter keeps the field and lowers its default to `10`.
- `replyLimit` is left unchanged at `2` (already stricter than iOS's `3`).
- The stock thread list UI renders at most a few participant avatars (`StreamUserAvatarStack(max: 3)`) and no thread members, so there is no visible change by default. The message-list thread footer uses `message.threadParticipants` (a separate `Message` field), which is unaffected.
- Threads are not persisted, so there is no cached data to reconcile.

Not a source-breaking change (no signatures change). Callers relying on the old counts can pass an explicit `ThreadOptions(participantLimit: 100, memberLimit: 100)`.

Test instructions: `cd packages/stream_chat && dart test test/src/core/api/requests_test.dart` — added a `ThreadOptions` group covering default and explicit serialization.

## Screenshots / Videos

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reduced the default thread pagination limits for participants and members from 100 to 10.
  * Updated related documentation to reflect the new defaults.

* **Tests**
  * Added coverage confirming default and explicitly configured thread options are serialized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->