### PR TITLE
fix(ui): avoid spurious StreamTypingIndicator rebuilds on unchanged typing users

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed shadowed messages not hidden in channel list items.
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
 - Fixed dismissing the `StreamMessageListView` unread indicator being ignored while a channel is receiving a rapid burst of messages.
+- Fixed `StreamTypingIndicator` rebuilding on every typing event by comparing the typing users by id, so it only rebuilds when the set of typing users changes.
 
 ## 10.1.0
 

--- a/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
@@ -32,6 +33,17 @@ class StreamTypingIndicator extends StatelessWidget {
   /// Id of the parent message in case of a thread
   final String? parentId;
 
+  // Compares the typing users by id so the indicator only rebuilds when the
+  // set of typing users changes. The stream maps to a new lazy Iterable on
+  // every typing event (and on the stale-typing cleanup), so identity equality
+  // would rebuild even when the same users are still typing. Order-sensitive
+  // because only the first user is shown by name.
+  bool _typingUsersEquals(Iterable<User>? previous, Iterable<User>? current) {
+    final previousIds = previous?.map((it) => it.id).toList() ?? const <String>[];
+    final currentIds = current?.map((it) => it.id).toList() ?? const <String>[];
+    return const ListEquality<String>().equals(previousIds, currentIds);
+  }
+
   @override
   Widget build(BuildContext context) {
     final channelState = channel?.state ?? StreamChannel.of(context).channel.state!;
@@ -43,6 +55,7 @@ class StreamTypingIndicator extends StatelessWidget {
       stream: channelState.typingEventsStream.map(
         (typingEvents) => typingEvents.entries.where((element) => element.value.parentId == parentId).map((e) => e.key),
       ),
+      comparator: _typingUsersEquals,
       builder: (context, users) => AnimatedSwitcher(
         layoutBuilder: (currentChild, previousChildren) => Stack(
           children: <Widget>[

--- a/packages/stream_chat_flutter/test/src/indicators/typing_indicator_test.dart
+++ b/packages/stream_chat_flutter/test/src/indicators/typing_indicator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -6,93 +8,199 @@ import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 import '../mocks.dart';
 
 void main() {
-  testWidgets(
-    'it should show channel typing',
-    (WidgetTester tester) async {
-      final client = MockClient();
-      final clientState = MockClientState();
-      final channel = MockChannel();
-      final channelState = MockChannelState();
-      final lastMessageAt = DateTime.parse('2020-06-22 12:00:00');
+  late MockClient client;
+  late MockClientState clientState;
+  late MockChannel channel;
+  late MockChannelState channelState;
 
-      when(() => client.state).thenReturn(clientState);
-      when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
-      when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
-      when(() => channel.state).thenReturn(channelState);
-      when(() => channel.client).thenReturn(client);
-      when(() => channel.isMuted).thenReturn(false);
-      when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));
-      when(() => channel.extraDataStream).thenAnswer(
-        (i) => Stream.value({
-          'name': 'test',
-        }),
-      );
-      when(() => channel.extraData).thenReturn({
+  setUp(() {
+    client = MockClient();
+    clientState = MockClientState();
+    channel = MockChannel();
+    channelState = MockChannelState();
+    final lastMessageAt = DateTime.parse('2020-06-22 12:00:00');
+
+    when(() => client.state).thenReturn(clientState);
+    when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
+    when(() => channel.lastMessageAt).thenReturn(lastMessageAt);
+    when(() => channel.state).thenReturn(channelState);
+    when(() => channel.client).thenReturn(client);
+    when(() => channel.isMuted).thenReturn(false);
+    when(() => channel.isMutedStream).thenAnswer((i) => Stream.value(false));
+    when(() => channel.extraDataStream).thenAnswer(
+      (i) => Stream.value({
         'name': 'test',
-      });
-      when(() => channelState.membersStream).thenAnswer(
-        (i) => Stream.value([
-          Member(
-            userId: 'user-id',
-            user: User(id: 'user-id'),
-          ),
-        ]),
-      );
-      when(() => channelState.members).thenReturn([
+      }),
+    );
+    when(() => channel.extraData).thenReturn({
+      'name': 'test',
+    });
+    when(() => channelState.membersStream).thenAnswer(
+      (i) => Stream.value([
         Member(
           userId: 'user-id',
           user: User(id: 'user-id'),
         ),
-      ]);
-      when(() => channelState.messages).thenReturn([
+      ]),
+    );
+    when(() => channelState.members).thenReturn([
+      Member(
+        userId: 'user-id',
+        user: User(id: 'user-id'),
+      ),
+    ]);
+    when(() => channelState.messages).thenReturn([
+      Message(
+        text: 'hello',
+        user: User(id: 'other-user'),
+      ),
+    ]);
+    when(() => channelState.messagesStream).thenAnswer(
+      (i) => Stream.value([
         Message(
           text: 'hello',
           user: User(id: 'other-user'),
         ),
-      ]);
-      when(() => channelState.messagesStream).thenAnswer(
-        (i) => Stream.value([
-          Message(
-            text: 'hello',
-            user: User(id: 'other-user'),
-          ),
-        ]),
-      );
+      ]),
+    );
+  });
 
+  Widget buildTarget({Key? key}) {
+    return MaterialApp(
+      home: StreamChat(
+        client: client,
+        child: StreamChannel(
+          channel: channel,
+          child: Scaffold(
+            body: StreamTypingIndicator(
+              key: key,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'it should show channel typing',
+    (WidgetTester tester) async {
       when(() => channelState.typingEvents).thenAnswer(
         (i) => {
-          User(id: 'other-user', extraData: const {'name': 'demo'}): Event(type: EventType.typingStart),
+          User(id: 'other-user', name: 'demo'): Event(type: EventType.typingStart),
         },
       );
       when(() => channelState.typingEventsStream).thenAnswer(
         (i) => Stream.value({
-          User(id: 'other-user', extraData: const {'name': 'demo'}): Event(type: EventType.typingStart),
+          User(id: 'other-user', name: 'demo'): Event(type: EventType.typingStart),
         }),
       );
 
       const typingKey = Key('typing');
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: StreamChat(
-            client: client,
-            child: StreamChannel(
-              channel: channel,
-              child: const Scaffold(
-                body: StreamTypingIndicator(
-                  key: typingKey,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(buildTarget(key: typingKey));
 
       // wait for the initial state to be rendered.
       await tester.pump(Duration.zero);
 
       expect(find.byKey(typingKey), findsOneWidget);
       expect(find.byType(Flexible), findsOneWidget);
+    },
+  );
+
+  // Advances the stream event and the 300ms AnimatedSwitcher transition
+  // without settling (the typing dots animation repeats forever).
+  Future<void> emit(
+    WidgetTester tester,
+    StreamController<Map<User, Event>> controller,
+    Map<User, Event> typingEvents,
+  ) async {
+    controller.add(typingEvents);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  testWidgets(
+    'it updates as the set of typing users changes',
+    (WidgetTester tester) async {
+      final typingController = StreamController<Map<User, Event>>.broadcast();
+      addTearDown(typingController.close);
+
+      when(() => channelState.typingEvents).thenReturn(const {});
+      when(() => channelState.typingEventsStream).thenAnswer(
+        (_) => typingController.stream,
+      );
+
+      Event event() => Event(type: EventType.typingStart);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamTypingIndicator(channel: channel),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // No one is typing -> no typing row is shown.
+      expect(find.byType(Flexible), findsNothing);
+
+      // A single user is typing -> their name is shown.
+      await emit(tester, typingController, {
+        User(id: 'user-a', name: 'Alice'): event(),
+      });
+      expect(find.text('Alice is typing'), findsOneWidget);
+
+      // A second user joins -> the summarized text is shown.
+      await emit(tester, typingController, {
+        User(id: 'user-a', name: 'Alice'): event(),
+        User(id: 'user-b', name: 'Bob'): event(),
+      });
+      expect(find.text('Alice and 1 more are typing'), findsOneWidget);
+
+      // Everyone stops typing -> the typing row is removed again.
+      await emit(tester, typingController, const {});
+      expect(find.byType(Flexible), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'it only shows typing users matching its parentId',
+    (WidgetTester tester) async {
+      final typingController = StreamController<Map<User, Event>>.broadcast();
+      addTearDown(typingController.close);
+
+      when(() => channelState.typingEvents).thenReturn(const {});
+      when(() => channelState.typingEventsStream).thenAnswer(
+        (_) => typingController.stream,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamTypingIndicator(
+              channel: channel,
+              parentId: 'thread-1',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Typing in the main channel (no parentId) is ignored by a thread
+      // indicator.
+      await emit(tester, typingController, {
+        User(id: 'user-a', name: 'Alice'): Event(type: EventType.typingStart),
+      });
+      expect(find.byType(Flexible), findsNothing);
+
+      // Typing within the thread is shown.
+      await emit(tester, typingController, {
+        User(id: 'user-b', name: 'Bob'): Event(
+          type: EventType.typingStart,
+          parentId: 'thread-1',
+        ),
+      });
+      expect(find.text('Bob is typing'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: FLU-600

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

**Problem.** `StreamTypingIndicator` feeds a `BetterStreamBuilder<Iterable<User>>` a lazy `MappedIterable` (from `.where().map()`) with **no comparator**, so `BetterStreamBuilder` falls back to identity equality (`event == _lastEvent`). Every typing-stream emission produces a fresh `Iterable` identity — including repeated `typing.start` re-sends while a user keeps typing, the 1s stale-typing cleanup timer, and out-of-scope thread/main-channel events — forcing a rebuild even when the set of typing users hasn't changed.

**Fix.** Add a comparator to the `BetterStreamBuilder` that compares the typing users **by user id** (order-sensitive `ListEquality<String>`). Order-sensitivity is deliberate: the label renders `users.first`, so a reorder that changes who is first must still rebuild; a repeated `typing.start` for an already-typing user preserves insertion order and is therefore correctly suppressed. Comparing by id (rather than full `User` equality) also ignores unrelated churn such as presence updates on the same typing user.

**Impact.** Benchmarked against the real widget, before vs after, over an identical 43-event typing churn (one user typing → repeated re-emissions → a second user joins → more re-emissions → first stops):

| | Builds |
| --- | --- |
| Before (identity equality) | 42 |
| After (compare by id) | 3 |

~14× fewer builds — but the more important change is the *shape*: build count goes from **linear in the number of typing events** to **constant** (= the number of distinct typing-user sets), independent of how much churn the backend re-sends or how often the stale-cleanup timer ticks.

**Tests.** The component previously had a single render smoke test. Added widget tests covering `empty → one → many → empty` updates (driven through a real stream) and `parentId`/thread filtering, closing pre-existing coverage gaps.

**Breaking change.** None. Not source-breaking (no signature changes). Behavioral-only and benign — the indicator no longer re-renders for unrelated `User`-object churn (e.g. presence updates) while the same users keep typing.

## Screenshots / Videos

No UI changes. (Rendered output is identical; only the rebuild frequency changes.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typing indicators so they update only when the set of typing users changes.
  * Prevented unnecessary visual refreshes during repeated typing events.
  * Ensured typing indicators correctly filter events for the relevant conversation thread.

* **Tests**
  * Added coverage for user updates, empty typing states, and thread-specific typing indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->