### PR TITLE
fix(ui): replace get_thumbnail_video with the stream_thumbnail plugin

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -66,7 +66,6 @@ command:
       freezed_annotation: ^3.0.0
       gal: ^2.3.2
       geolocator: ^13.0.0
-      get_thumbnail_video: ^0.7.3
       go_router: ^14.6.2
       http_parser: ^4.1.2
       image_picker: ^1.2.2
@@ -108,6 +107,7 @@ command:
           url: https://github.com/GetStream/stream-core-flutter.git
           ref: 7d0421a2cc04480e0bd2fc404cf6dd5b051f7f42
           path: packages/stream_core_flutter
+      stream_thumbnail: ^0.1.0
       synchronized: ^3.4.0
       thumblr: ^0.0.4
       url_launcher: ^6.3.2

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
 - Fixed dismissing the `StreamMessageListView` unread indicator being ignored while a channel is receiving a rapid burst of messages.
 - Fixed `StreamTypingIndicator` rebuilding on every typing event by comparing the typing users by id, so it only rebuilds when the set of typing users changes.
+- Replaced the `get_thumbnail_video` dependency with Stream's own `stream_thumbnail` plugin, resolving the iOS duplicate-`VideoThumbnailPlugin`-symbol crash when an app also uses `video_thumbnail`/`video_editor` ([#2360](https://github.com/GetStream/stream-chat-flutter/issues/2360)).
 
 ## 10.1.0
 

--- a/packages/stream_chat_flutter/lib/src/video/video_service.dart
+++ b/packages/stream_chat_flutter/lib/src/video/video_service.dart
@@ -2,10 +2,9 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
-import 'package:get_thumbnail_video/index.dart';
-import 'package:get_thumbnail_video/video_thumbnail.dart';
 import 'package:stream_chat_flutter/src/utils/device_segmentation.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+import 'package:stream_thumbnail/stream_thumbnail.dart';
 import 'package:thumblr/thumblr.dart' as thumblr;
 
 ///
@@ -35,7 +34,7 @@ class _IVideoService {
   Future<Uint8List?> generateVideoThumbnail({
     String? video,
     Map<String, String>? headers,
-    ImageFormat imageFormat = ImageFormat.PNG,
+    StreamThumbnailFormat imageFormat = .png,
     int maxHeight = 0,
     int maxWidth = 0,
     int timeMs = 0,
@@ -60,8 +59,8 @@ class _IVideoService {
         return await generatePlaceholderThumbnail();
       }
 
-      // Otherwise, use the VideoThumbnail package to generate the thumbnail.
-      return await VideoThumbnail.thumbnailData(
+      // Otherwise, use the stream_thumbnail plugin to generate the thumbnail.
+      return await StreamThumbnail.thumbnailData(
         video: video,
         headers: headers,
         imageFormat: imageFormat,

--- a/packages/stream_chat_flutter/lib/src/video/video_thumbnail_image.dart
+++ b/packages/stream_chat_flutter/lib/src/video/video_thumbnail_image.dart
@@ -2,8 +2,8 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:get_thumbnail_video/index.dart';
 import 'package:stream_chat_flutter/src/video/video_service.dart';
+import 'package:stream_thumbnail/stream_thumbnail.dart';
 
 /// {@template video_thumbnail_image}
 /// A custom [ImageProvider] class for loading video thumbnails as images in
@@ -46,7 +46,7 @@ class StreamVideoThumbnailImage extends ImageProvider<StreamVideoThumbnailImage>
   const StreamVideoThumbnailImage({
     required this.video,
     this.headers,
-    this.imageFormat = ImageFormat.PNG,
+    this.imageFormat = .png,
     this.maxHeight = 0,
     this.maxWidth = 0,
     this.timeMs = 0,
@@ -61,7 +61,7 @@ class StreamVideoThumbnailImage extends ImageProvider<StreamVideoThumbnailImage>
   final Map<String, String>? headers;
 
   /// The format of the generated thumbnail image.
-  final ImageFormat imageFormat;
+  final StreamThumbnailFormat imageFormat;
 
   /// The maximum height of the generated thumbnail image.
   final int maxHeight;

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   flutter_portal: ^1.1.4
   flutter_svg: ^2.3.0
   gal: ^2.3.2
-  get_thumbnail_video: ^0.7.3
   http_parser: ^4.1.2
   image_picker: ^1.2.2
   image_size_getter: ^2.4.1
@@ -71,6 +70,7 @@ dependencies:
       url: https://github.com/GetStream/stream-core-flutter.git
       ref: 7d0421a2cc04480e0bd2fc404cf6dd5b051f7f42
       path: packages/stream_core_flutter
+  stream_thumbnail: ^0.1.0
   svg_icon_widget: ^0.0.1
   synchronized: ^3.4.0
   theme_extensions_builder_annotation: ^7.1.0


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #2360

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Replaces the `get_thumbnail_video` dependency with Stream's own `stream_thumbnail` plugin.

### Why

`get_thumbnail_video` ships an iOS `VideoThumbnailPlugin` symbol that collides with `video_thumbnail` / `video_editor`, causing a duplicate-symbol crash when an app depends on both alongside this SDK (#2360). It also lacks Swift Package Manager support, which will become a hard build error on upcoming Flutter versions.

`stream_thumbnail` (maintained in [stream-core-flutter](https://github.com/GetStream/stream-core-flutter)) uses a uniquely-named `StreamThumbnailPlugin` and ships SPM support, resolving both.

### What changed

- Swapped `get_thumbnail_video` → `stream_thumbnail` in `melos.yaml` and `stream_chat_flutter/pubspec.yaml`.
- Updated `video_service.dart` / `video_thumbnail_image.dart` to use `StreamThumbnail.thumbnailData(...)` and `StreamThumbnailFormat`.

### Non-breaking

The affected symbols (`imageFormat`, now typed `StreamThumbnailFormat`) live on `src/video/` classes that are **not exported** by the public barrel — no public API changes.

### Testing

`flutter analyze` is clean and thumbnail generation was verified end-to-end. The `stream_thumbnail` dep is pinned to a git ref until it is published to pub.dev; it must be swapped to a pub version (along with `stream_core_flutter`) before releasing.

## Screenshots / Videos

N/A — no visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an iOS crash related to duplicate video thumbnail plugin symbols.
  - Improved video thumbnail generation compatibility when other video packages are also included.

- **Updates**
  - Switched thumbnail generation to Stream’s thumbnail implementation.
  - Updated thumbnail format handling to use `StreamThumbnailFormat` (default remains PNG).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->