### PR TITLE
feat(llc): increase default connect and receive timeout to 30s

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 🔄 Changed
 
+- Increased the default `StreamChatClient` `connectTimeout` and `receiveTimeout` from 6s to 30s.
 - `StreamChatClient.updateSystemEnvironment` now sanitizes the passed `SystemEnvironment`: `sdkName`, `sdkVersion`, and `osName` are locked to internal defaults, and `sdkIdentifier` only accepts the `dart` → `flutter` promotion (other values, including a `flutter` → `dart` demotion, are ignored). `appName`, `appVersion`, `osVersion`, and `deviceModel` continue to pass through as-is.
 
 ⚠️ Deprecated

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -82,8 +82,8 @@ class StreamChatClient {
     RetryPolicy? retryPolicy,
     String? baseURL,
     String? baseWsUrl,
-    Duration connectTimeout = const Duration(seconds: 6),
-    Duration receiveTimeout = const Duration(seconds: 6),
+    Duration connectTimeout = kDefaultConnectTimeout,
+    Duration receiveTimeout = kDefaultReceiveTimeout,
     StreamChatApi? chatApi,
     WebSocket? ws,
     AttachmentFileUploaderProvider attachmentFileUploaderProvider =

--- a/packages/stream_chat/lib/src/core/http/stream_http_client_options.dart
+++ b/packages/stream_chat/lib/src/core/http/stream_http_client_options.dart
@@ -2,13 +2,19 @@ part of 'stream_http_client.dart';
 
 const _defaultBaseURL = 'https://chat.stream-io-api.com';
 
+/// The default connect timeout for the api request
+const kDefaultConnectTimeout = Duration(seconds: 30);
+
+/// The default receive timeout for the api request
+const kDefaultReceiveTimeout = Duration(seconds: 30);
+
 /// Client options to modify [StreamHttpClient]
 class StreamHttpClientOptions {
   /// Instantiates a new [StreamHttpClientOptions]
   const StreamHttpClientOptions({
     String? baseUrl,
-    this.connectTimeout = const Duration(seconds: 30),
-    this.receiveTimeout = const Duration(seconds: 30),
+    this.connectTimeout = kDefaultConnectTimeout,
+    this.receiveTimeout = kDefaultReceiveTimeout,
     this.queryParameters = const {},
     this.headers = const {},
   }) : baseUrl = baseUrl ?? _defaultBaseURL;


### PR DESCRIPTION
## Summary

Ports the connect/receive timeout changes from `master` to `v9`.

The timeout change on `master` is embedded inside the large design-refresh commit (`210ff93f9`), so it cannot be cherry-picked cleanly — the relevant bits are applied manually here:

- Extract `kDefaultConnectTimeout` / `kDefaultReceiveTimeout` (both `Duration(seconds: 30)`) constants in `stream_http_client_options.dart` and use them as the `StreamHttpClientOptions` defaults.
- Bump the `StreamChatClient` constructor `connectTimeout` / `receiveTimeout` defaults from `6s` to those constants (`30s`), aligning the client defaults with the HTTP options defaults.

## Behavior change

The default request connect/receive timeout for `StreamChatClient` goes from **6s → 30s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)