### PR TITLE
chore(samples): migrate from flutter_app_badger to app_badge_plus

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -54,7 +54,7 @@ command:
       firebase_messaging: '>=16.0.0 <16.4.2'
       file_picker: ^11.0.0
       file_selector: ^1.1.0
-      flutter_app_badger: ^1.5.0
+      app_badge_plus: ^1.3.2
       flutter_local_notifications: ^21.0.0
       flutter_map: ^8.1.1
       flutter_map_animations: ^0.9.0

--- a/sample_app/lib/main.dart
+++ b/sample_app/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:sample_app/app.dart';
 import 'package:sample_app/firebase_options.dart';
-import 'package:sample_app/utils/firebase_support.dart';
+import 'package:sample_app/utils/platform_support.dart';
 
 Future<void> main() async {
   // In debug mode, initialize the Marionette binding so AI agents can drive

--- a/sample_app/lib/notification/notification_service.dart
+++ b/sample_app/lib/notification/notification_service.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart' hide Message;
 import 'package:sample_app/notification/notification.dart';
 import 'package:sample_app/notification/notification_background_handler.dart';
-import 'package:sample_app/utils/firebase_support.dart';
+import 'package:sample_app/utils/platform_support.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// The Android notification-channel id used for all chat notifications.

--- a/sample_app/lib/pages/channel_list_page.dart
+++ b/sample_app/lib/pages/channel_list_page.dart
@@ -2,8 +2,8 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:app_badge_plus/app_badge_plus.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sample_app/auth/auth_controller.dart';
 import 'package:sample_app/config/sample_app_config.dart';
@@ -120,7 +120,9 @@ class _ChannelListPageState extends State<ChannelListPage> {
   @override
   void initState() {
     super.initState();
-    if (!CurrentPlatform.isWeb) {
+    // app_badge_plus only supports Android, iOS, and macOS.
+    final supportsAppBadge = CurrentPlatform.isAndroid || CurrentPlatform.isIos || CurrentPlatform.isMacOS;
+    if (supportsAppBadge) {
       badgeListener = StreamChat.of(context).client.state.totalUnreadCountStream.listen((count) {
         if (count > 0) {
           AppBadgePlus.updateBadge(count);

--- a/sample_app/lib/pages/channel_list_page.dart
+++ b/sample_app/lib/pages/channel_list_page.dart
@@ -12,6 +12,7 @@ import 'package:sample_app/pages/draft_list_page.dart';
 import 'package:sample_app/pages/reminders_page.dart';
 import 'package:sample_app/pages/thread_list_page.dart';
 import 'package:sample_app/routes/routes.dart';
+import 'package:sample_app/utils/platform_support.dart';
 import 'package:sample_app/utils/shared_location_service.dart';
 import 'package:sample_app/widgets/channel_list.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
@@ -120,9 +121,7 @@ class _ChannelListPageState extends State<ChannelListPage> {
   @override
   void initState() {
     super.initState();
-    // app_badge_plus only supports Android, iOS, and macOS.
-    final supportsAppBadge = CurrentPlatform.isAndroid || CurrentPlatform.isIos || CurrentPlatform.isMacOS;
-    if (supportsAppBadge) {
+    if (isAppBadgeSupported) {
       badgeListener = StreamChat.of(context).client.state.totalUnreadCountStream.listen((count) {
         if (count > 0) {
           AppBadgePlus.updateBadge(count);

--- a/sample_app/lib/pages/channel_list_page.dart
+++ b/sample_app/lib/pages/channel_list_page.dart
@@ -3,7 +3,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_app_badger/flutter_app_badger.dart';
+import 'package:app_badge_plus/app_badge_plus.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sample_app/auth/auth_controller.dart';
 import 'package:sample_app/config/sample_app_config.dart';
@@ -123,9 +123,9 @@ class _ChannelListPageState extends State<ChannelListPage> {
     if (!CurrentPlatform.isWeb) {
       badgeListener = StreamChat.of(context).client.state.totalUnreadCountStream.listen((count) {
         if (count > 0) {
-          FlutterAppBadger.updateBadgeCount(count);
+          AppBadgePlus.updateBadge(count);
         } else {
-          FlutterAppBadger.removeBadge();
+          AppBadgePlus.updateBadge(0);
         }
       });
     }

--- a/sample_app/lib/pages/channel_list_page.dart
+++ b/sample_app/lib/pages/channel_list_page.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: deprecated_member_use
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:app_badge_plus/app_badge_plus.dart';
 import 'package:flutter/material.dart';
@@ -122,12 +123,9 @@ class _ChannelListPageState extends State<ChannelListPage> {
   void initState() {
     super.initState();
     if (isAppBadgeSupported) {
-      badgeListener = StreamChat.of(context).client.state.totalUnreadCountStream.listen((count) {
-        if (count > 0) {
-          AppBadgePlus.updateBadge(count);
-        } else {
-          AppBadgePlus.updateBadge(0);
-        }
+      final client = StreamChat.of(context).client;
+      badgeListener = client.state.totalUnreadCountStream.listen((count) {
+        AppBadgePlus.updateBadge(math.max(0, count));
       });
     }
 

--- a/sample_app/lib/utils/platform_support.dart
+++ b/sample_app/lib/utils/platform_support.dart
@@ -16,3 +16,8 @@ bool get isFirebaseSupported =>
 /// so `main()` skips wiring Crashlytics collection and error reporting there
 /// while still initializing Firebase Core and FCM.
 bool get isCrashlyticsSupported => CurrentPlatform.isAndroid || CurrentPlatform.isIos || CurrentPlatform.isMacOS;
+
+/// Whether app icon badges are supported on the current platform.
+///
+/// `app_badge_plus` only implements Android, iOS, and macOS.
+bool get isAppBadgeSupported => CurrentPlatform.isAndroid || CurrentPlatform.isIos || CurrentPlatform.isMacOS;

--- a/sample_app/pubspec.yaml
+++ b/sample_app/pubspec.yaml
@@ -20,6 +20,7 @@ environment:
   flutter: ">=3.41.0"
 
 dependencies:
+  app_badge_plus: ^1.3.2
   avatar_glow: ^3.0.0
   collection: ^1.19.1
   firebase_core: ^4.0.0
@@ -27,7 +28,6 @@ dependencies:
   firebase_messaging: ">=16.0.0 <16.4.2"
   flutter:
     sdk: flutter
-  flutter_app_badger: ^1.5.0
   flutter_local_notifications: ^21.0.0
   flutter_map: ^8.1.1
   flutter_map_animations: ^0.9.0


### PR DESCRIPTION
Fixes [FLU-623](https://linear.app/stream/issue/FLU-623/add-spm-support-for-flutter-app-badger)

## Summary

Migrates the sample app's badge handling from the unmaintained, pod-only [`flutter_app_badger`](https://pub.dev/packages/flutter_app_badger) to [`app_badge_plus`](https://pub.dev/packages/app_badge_plus) (`^1.3.2`).

`flutter_app_badger` does not support Swift Package Manager (FLU-623). `app_badge_plus` is a maintained drop-in replacement that ships **SPM** support (`Package.swift` for both iOS and macOS), aligning with the ongoing SPM migration effort. After the swap, `flutter pub get` confirms it no longer appears in Flutter's "plugins that do not support SPM" warning list.

## Changes

**Dependency swap**
- `melos.yaml` / `sample_app/pubspec.yaml` — `flutter_app_badger: ^1.5.0` → `app_badge_plus: ^1.3.2`

**API update** (`channel_list_page.dart`)
- `FlutterAppBadger.updateBadgeCount(count)` / `removeBadge()` → `AppBadgePlus.updateBadge(math.max(0, count))`

**Platform guard** — extracted into an `isAppBadgeSupported` getter in `platform_support.dart` (renamed from `firebase_support.dart`, since it now holds platform-capability flags beyond Firebase). `app_badge_plus` only implements Android, iOS, and macOS.

## Notes

- **No Android manifest changes needed.** The manufacturer launcher permissions (Samsung, HTC, Sony, Apex, Solid, Huawei, Honor, Vivo) are declared in `app_badge_plus`'s own plugin manifest and merged in automatically by the Android manifest merger — no manual declaration required. (This differs from `flutter_app_badger`, whose permissions came transitively from the bundled ShortcutBadger AAR.)
- **iOS `UIBackgroundModes` / `remote-notification`** in `Info.plist` is retained — required by `firebase_messaging`, not the badge plugin.
- **Notification permission** (which `app_badge_plus` needs before setting a badge) is already handled via `FirebaseMessaging.instance.requestPermission()`; `POST_NOTIFICATIONS` merges in transitively via `firebase_messaging`.

## Testing

- `flutter pub get` in `sample_app` resolves cleanly (`flutter_app_badger` dropped, `app_badge_plus` added).
- iOS simulator: badge sets correctly; note that `UNUserNotificationCenter.setBadgeCount` persistence on the **simulator** is unreliable — verify numeric badges on a physical device.
- Android numeric badges only render on manufacturer launchers (Samsung/MIUI/etc.); the stock Pixel launcher is unsupported by design and shows only notification dots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)