### PR TITLE
fix(ui): Mark channel read immediately when the unread indicator is dismissed

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.
 - Fixed shadowed messages not hidden in channel list items.
 - Fixed last-message preview flicker during channel-state reloads.
+- Fixed dismissing the `StreamMessageListView` unread indicator being ignored while a channel is receiving a rapid burst of messages.
 
 ## 9.26.0
 

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -944,6 +944,17 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
 
   Future<void> _markMessagesAsRead() async {
     if (widget.parentMessage case final parent?) {
+      // If we are in a thread, mark the thread as read immediately.
+      await streamChannel?.channel.markThreadRead(parent.id);
+      return;
+    }
+
+    // Otherwise, mark the channel as read immediately.
+    await streamChannel?.channel.markRead();
+  }
+
+  Future<void> _debouncedMarkMessagesAsRead() async {
+    if (widget.parentMessage case final parent?) {
       // If we are in a thread, mark the thread as read.
       debouncedMarkThreadRead.call([parent.id]);
     } else {
@@ -1479,7 +1490,7 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
     if (!isInThread && !hasUnread) return;
 
     // Mark messages as read if it's allowed.
-    return _markMessagesAsRead();
+    return _debouncedMarkMessagesAsRead();
   }
 
   void _getOnThreadTap() {

--- a/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_list_view/mark_read_test.dart
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/src/message_list_view/unread_indicator_button.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 import '../../test_utils/data_generator.dart';
@@ -337,6 +338,65 @@ void main() {
 
         // The default scroll-to-bottom button is a FloatingActionButton.
         expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+  });
+
+  group('unread indicator dismiss', () {
+    testWidgets(
+      'marks the channel read immediately when tapped',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages = generateConversation(20, users: [other]);
+
+        await pumpMessageList(
+          tester,
+          messages: messages,
+          isUpToDate: true,
+          unreadCount: 5,
+          markReadWhenAtTheBottom: false,
+        );
+
+        // Nothing has marked the channel read yet.
+        verifyNever(() => channel.markRead(messageId: any(named: 'messageId')));
+
+        final indicator = tester.widget<UnreadIndicatorButton>(
+          find.byType(UnreadIndicatorButton),
+        );
+        await indicator.onDismissTap();
+
+        verify(() => channel.markRead(messageId: any(named: 'messageId')))
+            .called(1);
+      },
+    );
+
+    testWidgets(
+      'fires markRead on every tap (not debounced)',
+      (tester) async {
+        final other = User(id: 'otherid');
+        final messages = generateConversation(20, users: [other]);
+
+        await pumpMessageList(
+          tester,
+          messages: messages,
+          isUpToDate: true,
+          unreadCount: 5,
+          markReadWhenAtTheBottom: false,
+        );
+
+        final indicator = tester.widget<UnreadIndicatorButton>(
+          find.byType(UnreadIndicatorButton),
+        );
+
+        // Three taps in quick succession, well within the 1s debounce window.
+        // A debounced dismiss (leading: true) would collapse these into a
+        // single immediate call; the fix fires one markRead per tap.
+        await indicator.onDismissTap();
+        await indicator.onDismissTap();
+        await indicator.onDismissTap();
+
+        verify(() => channel.markRead(messageId: any(named: 'messageId')))
+            .called(3);
       },
     );
   });


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-551

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Backport of master commit e8e0466dc ([#2819](https://github.com/GetStream/stream-chat-flutter/pull/2819)) to `v9`.

**Problem:** Dismissing the `StreamMessageListView` unread indicator was routed through the same 1s leading-edge mark-read debouncer used by the auto-mark-read-at-the-bottom flow. While a channel receives a rapid burst of messages, the auto path holds the debounce window open, so the dismiss tap lands inside the window and is silently swallowed.

**Fix:** The dismiss now calls `channel.markRead()` / `channel.markThreadRead()` immediately, bypassing the debouncer. The debounced path (`_debouncedMarkMessagesAsRead`) is unchanged and still used by the auto-mark-read-at-the-bottom flow.

**Port notes:** Clean cherry-pick, with two v9-specific adjustments:
- The `CHANGELOG.md` entry was resolved manually into v9's changelog format.
- The regression tests import `UnreadIndicatorButton` via a direct `src/` import, since it is not barrel-exported on v9 (the export on master came with the design refresh).

**Tests:** The two regression tests from the original PR (`mark_read_test.dart` → `unread indicator dismiss`): dismiss marks the channel read immediately, and repeated taps each fire `markRead` (proving the action is no longer debounced).

## Screenshots / Videos

No UI changes. Before/after videos are in the original PR: https://github.com/GetStream/stream-chat-flutter/pull/2819