### PR TITLE
fix(ci): drop internal group from TestFlight upload_to_testflight

### DIFF
--- a/sample_app/ios/fastlane/Fastfile
+++ b/sample_app/ios/fastlane/Fastfile
@@ -145,7 +145,6 @@ platform :ios do
       distribute_external: false,
       notify_external_testers: false,
       ipa: "#{root_path}/build/ios/ipa/ChatSample.ipa",
-      groups: ['Internal Testers'],
       changelog: 'Lots of amazing new features to test out!',
       skip_waiting_for_build_processing: true,
     )

--- a/sample_app/ios/fastlane/Fastfile
+++ b/sample_app/ios/fastlane/Fastfile
@@ -119,7 +119,7 @@ platform :ios do
       distribute_external: true,
       notify_external_testers: true,
       ipa: "#{root_path}/build/ios/ipa/ChatSample.ipa",
-      groups: ['Internal Testers', 'External Testers'],
+      groups: ['External Testers'],
       changelog: 'Lots of amazing new features to test out!',
       skip_waiting_for_build_processing: true,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TestFlight distribution so external uploads explicitly target the **External Testers** group.
  * Adjusted internal TestFlight distribution to proceed without assigning a specific tester group.
  * Kept existing settings for upload behavior, notifications, changelog, and build processing as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->