### PR TITLE
fix(samples): add NSLocationAlwaysAndWhenInUseUsageDescription to Info.plist

### DIFF
--- a/sample_app/ios/Runner/Info.plist
+++ b/sample_app/ios/Runner/Info.plist
@@ -47,7 +47,9 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>We need access to your location to share it in the chat.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-    <string>We need access to your location to share it in the chat.</string>
+	<string>We need access to your location to share it in the chat.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>We need access to your location to share it in the chat.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Used to send message attachments</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
## Summary

Resolves App Store validation error **90683** (*Missing purpose string in Info.plist*) for the sample app.

The `sample_app` Info.plist already declared `NSLocationWhenInUseUsageDescription` and `NSLocationAlwaysUsageDescription`, but was missing the combined `NSLocationAlwaysAndWhenInUseUsageDescription` key. iOS 11+ requires this combined key whenever `NSLocationAlwaysUsageDescription` is present, and App Store Connect rejects the upload without it.

## Changes

- Add `NSLocationAlwaysAndWhenInUseUsageDescription` to `sample_app/ios/Runner/Info.plist` with the same purpose string as the existing location keys.
- Normalize the neighboring `NSLocationAlwaysUsageDescription` value's indentation (4 spaces → tab) to match surrounding entries.

## Verification

- `plutil -lint sample_app/ios/Runner/Info.plist` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS location permission messaging to clearly explain why continuous location access is needed for sharing location in chat.
  * Added the missing “Always and When In Use” location permission description so iOS shows the correct prompt text.
  * Adjusted the existing continuous location permission text to improve consistency across iOS prompt variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->