### PR TITLE
fix(ui): filter StreamTypingIndicator initial data by parentId

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `StreamTypingIndicator` briefly showing typing users from a different context (main channel vs. thread) on its first frame.
+
 ## 10.2.0
 
 ⚠️ Changed

--- a/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
@@ -34,20 +34,20 @@ class StreamTypingIndicator extends StatelessWidget {
   final String? parentId;
 
   // Compares the typing users by id so the indicator only rebuilds when the
-  // set of typing users changes. The stream maps to a new lazy Iterable on
-  // every typing event (and on the stale-typing cleanup), so identity equality
-  // would rebuild even when the same users are still typing. Order-sensitive
-  // because only the first user is shown by name.
-  bool _typingUsersEquals(Iterable<User>? previous, Iterable<User>? current) {
-    final previousIds = previous?.map((it) => it.id).toList() ?? const <String>[];
-    final currentIds = current?.map((it) => it.id).toList() ?? const <String>[];
-    return const ListEquality<String>().equals(previousIds, currentIds);
+  // set of typing users changes. The stream maps to a new list on every typing
+  // event (and on the stale-typing cleanup), so identity equality would rebuild
+  // even when the same users are still typing. Order-sensitive because only the
+  // first user is shown by name.
+  bool _typingUsersEquals(List<User>? previous, List<User>? current) {
+    final previousIds = previous?.map((it) => it.id) ?? const <String>[];
+    final currentIds = current?.map((it) => it.id) ?? const <String>[];
+    return const IterableEquality<String>().equals(previousIds, currentIds);
   }
 
   // Keeps only the users typing in the same context as this indicator: the
   // thread identified by [parentId], or the main channel when it's null.
-  Iterable<User> _typingUsers(Map<User, Event> typingEvents) {
-    return typingEvents.entries.where((element) => element.value.parentId == parentId).map((e) => e.key);
+  List<User> _typingUsers(Map<User, Event> typingEvents) {
+    return typingEvents.entries.where((element) => element.value.parentId == parentId).map((e) => e.key).toList();
   }
 
   @override
@@ -56,7 +56,7 @@ class StreamTypingIndicator extends StatelessWidget {
 
     final altWidget = alternativeWidget ?? const Empty();
 
-    return BetterStreamBuilder<Iterable<User>>(
+    return BetterStreamBuilder<List<User>>(
       initialData: _typingUsers(channelState.typingEvents),
       stream: channelState.typingEventsStream.map(_typingUsers),
       comparator: _typingUsersEquals,

--- a/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
+++ b/packages/stream_chat_flutter/lib/src/indicators/typing_indicator.dart
@@ -44,6 +44,12 @@ class StreamTypingIndicator extends StatelessWidget {
     return const ListEquality<String>().equals(previousIds, currentIds);
   }
 
+  // Keeps only the users typing in the same context as this indicator: the
+  // thread identified by [parentId], or the main channel when it's null.
+  Iterable<User> _typingUsers(Map<User, Event> typingEvents) {
+    return typingEvents.entries.where((element) => element.value.parentId == parentId).map((e) => e.key);
+  }
+
   @override
   Widget build(BuildContext context) {
     final channelState = channel?.state ?? StreamChannel.of(context).channel.state!;
@@ -51,10 +57,8 @@ class StreamTypingIndicator extends StatelessWidget {
     final altWidget = alternativeWidget ?? const Empty();
 
     return BetterStreamBuilder<Iterable<User>>(
-      initialData: channelState.typingEvents.keys,
-      stream: channelState.typingEventsStream.map(
-        (typingEvents) => typingEvents.entries.where((element) => element.value.parentId == parentId).map((e) => e.key),
-      ),
+      initialData: _typingUsers(channelState.typingEvents),
+      stream: channelState.typingEventsStream.map(_typingUsers),
       comparator: _typingUsersEquals,
       builder: (context, users) => AnimatedSwitcher(
         layoutBuilder: (currentChild, previousChildren) => Stack(

--- a/packages/stream_chat_flutter/test/src/indicators/typing_indicator_test.dart
+++ b/packages/stream_chat_flutter/test/src/indicators/typing_indicator_test.dart
@@ -169,7 +169,11 @@ void main() {
       final typingController = StreamController<Map<User, Event>>.broadcast();
       addTearDown(typingController.close);
 
-      when(() => channelState.typingEvents).thenReturn(const {});
+      // A main-channel (no parentId) typing event is already present when the
+      // indicator mounts.
+      when(() => channelState.typingEvents).thenReturn({
+        User(id: 'user-a', name: 'Alice'): Event(type: EventType.typingStart),
+      });
       when(() => channelState.typingEventsStream).thenAnswer(
         (_) => typingController.stream,
       );
@@ -185,6 +189,10 @@ void main() {
         ),
       );
       await tester.pump();
+
+      // The pre-existing main-channel typer is filtered out of the initial
+      // data, so the first frame shows nothing.
+      expect(find.byType(Flexible), findsNothing);
 
       // Typing in the main channel (no parentId) is ignored by a thread
       // indicator.


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-614

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`StreamTypingIndicator` seeded its `BetterStreamBuilder.initialData` from the **unfiltered** `typingEvents` map, while its stream filters typing events by `parentId`. As a result the very first frame could show typing users from the wrong context — main-channel typers in a thread header (`ThreadHeader`), or thread typers in a channel list tile — until the first stream emission corrected it (visible as a brief flash, stretched by the 300ms `AnimatedSwitcher` fade).

This PR extracts a shared `_typingUsers` helper that applies the `parentId` predicate and uses it for **both** `initialData` and the stream `map`, so the two can no longer diverge.

**Breaking-change verdict:** behavioral fix only — no signature changes, not source-breaking, no opt-out needed (nothing can reasonably depend on the transient wrong-user flash).

**Testing:** extended the existing `'it only shows typing users matching its parentId'` widget test to mount the indicator with a pre-existing main-channel typing event and assert the first frame shows nothing. Verified the new assertion fails without the fix. Also manually verified in the sample app (thread header no longer flashes main-channel typers).

## Screenshots / Videos

No UI changes (the fix removes a transient first-frame flash of wrong typing users; steady-state UI is unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the typing indicator so it only displays users typing in the current channel or thread context.
  * Prevented typing users from briefly showing from the wrong context on the indicator’s first frame by applying consistent filtering to both initial and live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->