### PR TITLE
fix(ui): enrich link previews for uppercase URL schemes

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 🐞 Fixed
 
+- Fixed link preview enrichment failing for uppercase URL schemes (e.g. `HTTPS://`) by normalizing the scheme before enriching.
 - Fixed last-message preview flicker during channel-state reloads.
 - Fixed shadowed messages not hidden in channel list items.
 - Fixed `StreamMessageListView` firing `markThreadRead` on a reply-less parent, which produced a guaranteed 404 every time the thread view was opened before the first reply.

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
@@ -1293,19 +1293,22 @@ class DefaultStreamMessageComposerState extends State<DefaultStreamMessageCompos
     if (_lastSearchedContainsUrlText == value) return;
     _lastSearchedContainsUrlText = value;
 
-    final matchedUrls = _urlRegex.allMatches(value).where((it) {
-      final _parsedMatch = Uri.tryParse(it.group(0) ?? '')?.withScheme;
-      if (_parsedMatch == null) return false;
+    // Find the first url to preview, normalizing the scheme so links like
+    // `HTTPS://` enrich the same as `https://`.
+    String? firstMatchedUrl;
+    for (final match in _urlRegex.allMatches(value)) {
+      final url = Uri.tryParse(match.group(0) ?? '')?.withScheme;
+      if (url == null) continue;
+      if (!widget.props.ogPreviewFilter.call(url, value)) continue;
 
-      return widget.props.ogPreviewFilter.call(_parsedMatch, value);
-    }).toList();
-
-    // Reset the og attachment if the text doesn't contain any url
-    if (matchedUrls.isEmpty || !channel.canSendLinks) {
-      return _effectiveController.clearOGAttachment();
+      firstMatchedUrl = url.toString();
+      break;
     }
 
-    final firstMatchedUrl = matchedUrls.first.group(0)!;
+    // Reset the og attachment if the text doesn't contain any url
+    if (firstMatchedUrl == null || !channel.canSendLinks) {
+      return _effectiveController.clearOGAttachment();
+    }
 
     // If the parsed url matches the ogAttachment url, don't do anything
     if (_effectiveController.ogAttachment?.titleLink == firstMatchedUrl) {

--- a/packages/stream_chat_flutter/test/src/message_input/message_composer_url_enrichment_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/message_composer_url_enrichment_test.dart
@@ -1,0 +1,110 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:record/record.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../fakes.dart';
+import '../mocks.dart';
+
+void main() {
+  group('MessageComposer URL enrichment', () {
+    final originalRecordPlatform = RecordPlatform.instance;
+    setUp(() => RecordPlatform.instance = FakeRecordPlatform());
+    tearDown(() => RecordPlatform.instance = originalRecordPlatform);
+
+    late MockClient client;
+    late MockClientState clientState;
+    late MockChannel channel;
+    late MockChannelState channelState;
+
+    setUp(() {
+      registerFallbackValue(Message());
+
+      client = MockClient();
+      clientState = MockClientState();
+      channel = MockChannel(
+        ownCapabilities: const [
+          ChannelCapability.sendMessage,
+          ChannelCapability.sendLinks,
+        ],
+      );
+      channelState = MockChannelState();
+
+      when(() => client.state).thenReturn(clientState);
+      when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
+      when(() => clientState.currentUserStream).thenAnswer(
+        (_) => Stream.value(OwnUser(id: 'user-id')),
+      );
+
+      when(() => channel.state).thenReturn(channelState);
+      when(() => channel.client).thenReturn(client);
+      when(channel.getRemainingCooldown).thenReturn(0);
+
+      when(() => client.enrichUrl(any())).thenAnswer(
+        (invocation) async => OGAttachmentResponse()..ogScrapeUrl = invocation.positionalArguments.first as String,
+      );
+    });
+
+    Future<Object?> enrichUrlFrom(WidgetTester tester, String text) async {
+      // Enrichment runs behind a real-clock debounce, so drive the flow with
+      // real timers via runAsync.
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StreamChat(
+              client: client,
+              connectivityStream: Stream.value([ConnectivityResult.mobile]),
+              child: StreamChannel(
+                channel: channel,
+                child: Scaffold(body: StreamMessageComposer()),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextField), text);
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
+      });
+
+      return verify(() => client.enrichUrl(captureAny())).captured.single;
+    }
+
+    // The scheme (and host) are normalized to lowercase before enriching so a
+    // backend that only handles lowercase schemes receives a consistent url.
+    // Case-sensitive path and query parts must be preserved as-is.
+    final cases = <String, (String, String)>{
+      'uppercase HTTPS scheme': ('HTTPS://example.com', 'https://example.com'),
+      'uppercase HTTP scheme': ('HTTP://example.com', 'http://example.com'),
+      'mixed-case scheme': ('HtTpS://example.com', 'https://example.com'),
+      'mixed-case host': ('HTTPS://Example.COM', 'https://example.com'),
+      'preserves case-sensitive path and query': (
+        'HTTPS://example.com/Path?Q=AbC',
+        'https://example.com/Path?Q=AbC',
+      ),
+      'uppercase scheme with www and path': (
+        'HTTPS://www.example.com/foo',
+        'https://www.example.com/foo',
+      ),
+      'url embedded in surrounding text': (
+        'look at HTTPS://example.com now',
+        'https://example.com',
+      ),
+      'lowercase https scheme unchanged': (
+        'https://example.com',
+        'https://example.com',
+      ),
+    };
+
+    for (final entry in cases.entries) {
+      final (input, expected) = entry.value;
+      testWidgets('enriches ${entry.key}', (tester) async {
+        expect(await enrichUrlFrom(tester, input), expected);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Fixes [FLU-625](https://linear.app/stream/issue/FLU-625). URLs with an uppercase scheme (e.g. `HTTPS://example.com`) were not enriched into link previews, while lowercase `https://` worked.

The composer's URL regex already matched uppercase schemes, but the raw matched text was forwarded to `client.enrichUrl(...)` verbatim — so the `/og` endpoint received `HTTPS://…` and failed to enrich. The fix normalizes the scheme (via `Uri.parse`, which lowercases it) before enriching, so `HTTPS://` behaves the same as `https://`.

Flutter counterpart to the React ([#3226](https://github.com/GetStream/stream-chat-react/pull/3226)) and Angular ([#734](https://github.com/GetStream/stream-chat-angular/pull/734)) fixes.

## Scope

This fixes the composer link-preview **enrichment** path. Display-side linkification of uppercase schemes in rendered message text lives in `stream_core_flutter` and is out of scope here.

## Testing

Added `message_composer_url_enrichment_test.dart` — asserts `enrichUrl` is called with the normalized `https://example.com` for both uppercase and lowercase input. Fails before the fix, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed link-preview (OG) enrichment when URL schemes are uppercase (e.g., `HTTPS://`) by normalizing the scheme before enrichment.
  - Improves preview selection by choosing the first eligible URL found in the message.
  - Clears any existing link-preview attachment when no qualifying preview candidate is available or link sending isn’t allowed.

- **Tests**
  - Expanded widget tests with table-driven cases covering multiple scheme/host casing combinations and URLs embedded in surrounding text, ensuring the normalized URL is used for enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->