### PR TITLE
fix(llc, core, ui, localization): hide raw StreamChannel errors behind themed, connection-aware states

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -42,7 +42,7 @@ command:
       device_info_plus: '>=12.4.0 <14.0.0'
       device_preview: ^1.2.0
       diacritic: ^0.1.6
-      dio: ^5.9.2
+      dio: ^5.11.0
       drift: ^2.33.0
       equatable: ^2.0.8
       ezanimation: ^0.6.0

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Deprecated `StreamChatNetworkError.isRequestCancelledError` in favor of `type == StreamChatNetworkErrorType.cancel`.
 
+🔄 Changed
+
+- Raised the minimum `dio` version to `^5.11.0`.
+
 🐞 Fixed
 
 - Fixed `StreamWebSocketError.toString()` using a `WebSocketError(...)` prefix instead of the class name; it now also includes `code`, and `StreamChatNetworkError.toString()` now surfaces the transport `type` when known.

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -3,11 +3,19 @@
 ✅ Added
 
 - Added `Event.watcherCount`, exposing the server-provided `watcher_count` field on events (e.g. `user.watching.start`, `user.watching.stop`, `message.new`).
+- Added `StreamChatNetworkError.type` (a `StreamChatNetworkErrorType` capturing the transport failure kind — connection error, timeout, cancellation, etc.).
+
+⚠️ Deprecated
+
+- Deprecated `StreamChatNetworkError.isRequestCancelledError` in favor of `type == StreamChatNetworkErrorType.cancel`.
 
 🐞 Fixed
 
+- Fixed `StreamWebSocketError.toString()` using a `WebSocketError(...)` prefix instead of the class name; it now also includes `code`, and `StreamChatNetworkError.toString()` now surfaces the transport `type` when known.
 - Fixed `ChannelClientState.watcherCount` staying stale during a session.
 - Fixed watchers not being removed from `ChannelClientState.watchers` on `user.watching.stop`.
+- Fixed `Channel.name`/`image`/`extraData` setters throwing after a *failed* initialization; they now only throw once the channel is successfully initialized.
+- Fixed `Channel.initialized` staying errored after a failed init; it now reflects a subsequent successful (re)initialization.
 
 ## 10.2.0
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -111,7 +111,7 @@ class Channel {
   ///
   /// {@macro name}
   set name(String? name) {
-    if (_initializedCompleter.isCompleted) {
+    if (_isInitialized) {
       throw StateError(
         'Once the channel is initialized you should use `channel.updateName` '
         'to update the channel name',
@@ -124,7 +124,7 @@ class Channel {
   ///
   /// {@macro image}
   set image(String? image) {
-    if (_initializedCompleter.isCompleted) {
+    if (_isInitialized) {
       throw StateError(
         'Once the channel is initialized you should use `channel.updateImage` '
         'to update the channel image',
@@ -134,7 +134,7 @@ class Channel {
   }
 
   set extraData(Map<String, Object?> extraData) {
-    if (_initializedCompleter.isCompleted) {
+    if (_isInitialized) {
       throw StateError(
         'Once the channel is initialized you should use `channel.update` '
         'to update channel data',
@@ -569,13 +569,16 @@ class Channel {
   StreamChatClient get client => _client;
   final StreamChatClient _client;
 
-  final Completer<bool> _initializedCompleter = Completer();
+  Completer<bool> _initializedCompleter = Completer();
 
   /// True if this is initialized.
   ///
   /// Call [watch] to initialize the client or instantiate it using
   /// [Channel.fromState].
   Future<bool> get initialized => _initializedCompleter.future;
+
+  // Whether the channel is successfully initialized and not disposed.
+  bool get _isInitialized => _initializedCompleter.isCompleted && state != null;
 
   final _cancelableAttachmentUploadRequest = <String, CancelToken>{};
   final _messageAttachmentsUploadCompleter = <String, Completer<Message>>{};
@@ -713,7 +716,7 @@ class Channel {
               }
             })
             .catchError((e, stk) {
-              if (e is StreamChatNetworkError && e.isRequestCancelledError) {
+              if (e is StreamChatNetworkError && e.type == .cancel) {
                 client.logger.info('Attachment ${it.id} upload cancelled');
 
                 // remove attachment from message if cancelled.
@@ -2042,6 +2045,14 @@ class Channel {
     PaginationParams? watchersPagination,
     bool preferOffline = false,
   }) async {
+    // A prior failed init left the completer errored; reset it so this attempt
+    // owns the `initialized` result. Must stay before the first `await` so a
+    // caller reading `initialized` right after `query()`/`watch()` begins sees
+    // the fresh completer.
+    if (_initializedCompleter.isCompleted && this.state == null) {
+      _initializedCompleter = Completer<bool>();
+    }
+
     ChannelState? channelState;
 
     try {
@@ -2376,7 +2387,7 @@ class Channel {
   }
 
   void _checkInitialized() {
-    if (_initializedCompleter.isCompleted && state != null) return;
+    if (_isInitialized) return;
 
     throw StateError(
       "Channel $cid hasn't been initialized yet or has been disposed. "

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -165,7 +165,7 @@ class StreamChatNetworkError extends StreamChatError {
   bool get isRetriable => data == null;
 
   @override
-  List<Object?> get props => [...super.props, code, statusCode];
+  List<Object?> get props => [...super.props, code, statusCode, type];
 
   @override
   String toString({bool printStackTrace = false}) {

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -4,12 +4,17 @@ import 'package:equatable/equatable.dart';
 import 'package:stream_chat/stream_chat.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+/// Base class for all errors surfaced by the Stream Chat SDK.
 ///
+/// See also:
+///
+///  * [StreamChatNetworkError], raised by failed HTTP requests.
+///  * [StreamWebSocketError], raised on the realtime connection.
 class StreamChatError extends Equatable implements Exception {
-  ///
+  /// Creates a new [StreamChatError] with the given [message].
   const StreamChatError(this.message);
 
-  /// Error message
+  /// A human-readable description of what went wrong.
   final String message;
 
   @override
@@ -19,22 +24,22 @@ class StreamChatError extends Equatable implements Exception {
   String toString() => 'StreamChatError(message: $message)';
 }
 
-///
+/// An error received over the realtime (WebSocket) connection.
 class StreamWebSocketError extends StreamChatError {
-  ///
+  /// Creates a new [StreamWebSocketError] with the given [message].
   const StreamWebSocketError(
     super.message, {
     this.data,
   });
 
-  ///
+  /// Creates a [StreamWebSocketError] from a Stream error payload.
   factory StreamWebSocketError.fromStreamError(Map<String, Object?> error) {
     final data = ErrorResponse.fromJson(error);
     final message = data.message ?? '';
     return StreamWebSocketError(message, data: data);
   }
 
-  ///
+  /// Creates a [StreamWebSocketError] from a [WebSocketChannelException].
   factory StreamWebSocketError.fromWebSocketChannelError(
     WebSocketChannelException error,
   ) {
@@ -42,20 +47,20 @@ class StreamWebSocketError extends StreamChatError {
     return StreamWebSocketError(message);
   }
 
-  ///
+  /// The structured error returned by the server, if any.
+  final ErrorResponse? data;
+
+  /// The Stream error code, if one was provided.
   int? get code => data?.code;
 
-  ///
+  /// The [ChatErrorCode] for this error, or null if unrecognised.
   ChatErrorCode? get errorCode {
     final code = this.code;
     if (code == null) return null;
     return chatErrorCodeFromCode(code);
   }
 
-  /// Response body. please refer to [ErrorResponse].
-  final ErrorResponse? data;
-
-  ///
+  /// Whether the operation can be retried.
   bool get isRetriable => data == null;
 
   @override
@@ -64,37 +69,42 @@ class StreamWebSocketError extends StreamChatError {
   @override
   String toString() {
     var params = 'message: $message';
+    if (code case final code?) params = 'code: $code, $params';
     if (data != null) params += ', data: $data';
-    return 'WebSocketError($params)';
+    return 'StreamWebSocketError($params)';
   }
 }
 
-///
+/// An error raised when a network request to Stream fails.
 class StreamChatNetworkError extends StreamChatError {
-  ///
+  /// Creates a [StreamChatNetworkError] for a known [errorCode].
   StreamChatNetworkError(
     ChatErrorCode errorCode, {
     int? statusCode,
     this.data,
     StackTrace? stacktrace,
-    this.isRequestCancelledError = false,
+    @Deprecated('Set type to StreamChatNetworkErrorType.cancel instead') bool? isRequestCancelledError,
+    this.type = .unknown,
   }) : code = errorCode.code,
        statusCode = statusCode ?? data?.statusCode,
        stackTrace = stacktrace ?? StackTrace.current,
+       _isRequestCancelledError = isRequestCancelledError,
        super(errorCode.message);
 
-  ///
+  /// Creates a [StreamChatNetworkError] from raw values.
   StreamChatNetworkError.raw({
     required this.code,
     required String message,
     this.statusCode,
     this.data,
     StackTrace? stacktrace,
-    this.isRequestCancelledError = false,
+    @Deprecated('Set type to StreamChatNetworkErrorType.cancel instead') bool? isRequestCancelledError,
+    this.type = .unknown,
   }) : stackTrace = stacktrace ?? StackTrace.current,
+       _isRequestCancelledError = isRequestCancelledError,
        super(message);
 
-  ///
+  /// Creates a [StreamChatNetworkError] from a [DioException].
   factory StreamChatNetworkError.fromDioException(DioException exception) {
     final response = exception.response;
     ErrorResponse? errorResponse;
@@ -121,29 +131,37 @@ class StreamChatNetworkError extends StreamChatError {
       statusCode: errorResponse?.statusCode ?? response?.statusCode,
       data: errorResponse,
       stacktrace: exception.stackTrace,
-      isRequestCancelledError: exception.type == DioExceptionType.cancel,
+      type: _networkErrorTypeFromDio(exception.type),
     );
   }
 
-  /// Error code
+  /// The Stream error code. See [ChatErrorCode].
   final int code;
 
-  /// HTTP status code
+  /// The HTTP status code of the response, if any.
   final int? statusCode;
 
-  /// Response body. please refer to [ErrorResponse].
+  /// The structured error returned by the server, if any.
   final ErrorResponse? data;
 
-  /// True, in case the error is due to a cancelled network request.
-  final bool isRequestCancelledError;
+  /// The kind of transport failure that caused this error.
+  ///
+  /// Defaults to [StreamChatNetworkErrorType.unknown] when it can't be
+  /// determined.
+  final StreamChatNetworkErrorType type;
 
   /// The optional stack trace attached to the error.
   final StackTrace? stackTrace;
 
-  ///
+  /// Whether the request was cancelled before it completed.
+  @Deprecated('Use type == StreamChatNetworkErrorType.cancel instead')
+  bool get isRequestCancelledError => _isRequestCancelledError ?? type == .cancel;
+  final bool? _isRequestCancelledError;
+
+  /// The [ChatErrorCode] for this error, or null if unrecognised.
   ChatErrorCode? get errorCode => chatErrorCodeFromCode(code);
 
-  ///
+  /// Whether the operation can be retried.
   bool get isRetriable => data == null;
 
   @override
@@ -152,6 +170,7 @@ class StreamChatNetworkError extends StreamChatError {
   @override
   String toString({bool printStackTrace = false}) {
     var params = 'code: $code, message: $message';
+    if (type != .unknown) params += ', type: ${type.name}';
     if (statusCode != null) params += ', statusCode: $statusCode';
     if (data != null) params += ', data: $data';
     var msg = 'StreamChatNetworkError($params)';
@@ -161,4 +180,48 @@ class StreamChatNetworkError extends StreamChatError {
     }
     return msg;
   }
+}
+
+/// The kind of transport failure that caused a [StreamChatNetworkError].
+///
+/// Lets callers tell a lost connection apart from a timeout, a cancellation,
+/// or a server response — for example, to show a tailored error message.
+enum StreamChatNetworkErrorType {
+  /// The server could not be reached (e.g. no internet connection).
+  connectionError,
+
+  /// Opening the connection timed out.
+  connectionTimeout,
+
+  /// Sending the request timed out.
+  sendTimeout,
+
+  /// Receiving the response timed out.
+  receiveTimeout,
+
+  /// The server responded with a non-success status.
+  badResponse,
+
+  /// The request was cancelled before it completed.
+  cancel,
+
+  /// The connection's certificate could not be validated.
+  badCertificate,
+
+  /// The failure could not be attributed to a specific transport cause.
+  unknown,
+}
+
+StreamChatNetworkErrorType _networkErrorTypeFromDio(DioExceptionType type) {
+  return switch (type) {
+    DioExceptionType.connectionError => StreamChatNetworkErrorType.connectionError,
+    DioExceptionType.connectionTimeout => StreamChatNetworkErrorType.connectionTimeout,
+    DioExceptionType.sendTimeout => StreamChatNetworkErrorType.sendTimeout,
+    DioExceptionType.receiveTimeout => StreamChatNetworkErrorType.receiveTimeout,
+    DioExceptionType.badResponse => StreamChatNetworkErrorType.badResponse,
+    DioExceptionType.cancel => StreamChatNetworkErrorType.cancel,
+    DioExceptionType.badCertificate => StreamChatNetworkErrorType.badCertificate,
+    // Unknown or future dio types map to unknown.
+    _ => StreamChatNetworkErrorType.unknown,
+  };
 }

--- a/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
+++ b/packages/stream_chat/lib/src/core/error/stream_chat_error.dart
@@ -199,6 +199,9 @@ enum StreamChatNetworkErrorType {
   /// Receiving the response timed out.
   receiveTimeout,
 
+  /// Transforming the response (e.g. background JSON decoding) timed out.
+  transformTimeout,
+
   /// The server responded with a non-success status.
   badResponse,
 
@@ -218,10 +221,11 @@ StreamChatNetworkErrorType _networkErrorTypeFromDio(DioExceptionType type) {
     DioExceptionType.connectionTimeout => StreamChatNetworkErrorType.connectionTimeout,
     DioExceptionType.sendTimeout => StreamChatNetworkErrorType.sendTimeout,
     DioExceptionType.receiveTimeout => StreamChatNetworkErrorType.receiveTimeout,
+    DioExceptionType.transformTimeout => StreamChatNetworkErrorType.transformTimeout,
     DioExceptionType.badResponse => StreamChatNetworkErrorType.badResponse,
     DioExceptionType.cancel => StreamChatNetworkErrorType.cancel,
     DioExceptionType.badCertificate => StreamChatNetworkErrorType.badCertificate,
-    // Unknown or future dio types map to unknown.
+    // DioExceptionType.unknown and any future dio types map to unknown.
     _ => StreamChatNetworkErrorType.unknown,
   };
 }

--- a/packages/stream_chat/pubspec.yaml
+++ b/packages/stream_chat/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   async: ^2.13.1
   collection: ^1.19.1
   diacritic: ^0.1.6
-  dio: ^5.9.2
+  dio: ^5.11.0
   equatable: ^2.0.8
   freezed_annotation: ^3.0.0
   http_parser: ^4.1.2

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -112,6 +112,43 @@ void main() {
       expect(newChannelInstance.name, newName);
       expect(newChannelInstance.extraData['name'], newName);
     });
+
+    test('setters remain usable after a failed watch()', () async {
+      // Make initialization fail.
+      when(
+        () => client.queryChannel(
+          channelType,
+          channelId: any(named: 'channelId'),
+          channelData: any(named: 'channelData'),
+          state: any(named: 'state'),
+          watch: any(named: 'watch'),
+          presence: any(named: 'presence'),
+          messagesPagination: any(named: 'messagesPagination'),
+          membersPagination: any(named: 'membersPagination'),
+          watchersPagination: any(named: 'watchersPagination'),
+        ),
+      ).thenThrow(StreamChatNetworkError(ChatErrorCode.inputError));
+
+      // A failed watch() also completes `initialized` with the error. Attach
+      // the expectation up-front so that error has a listener the moment it
+      // occurs and isn't reported as an unhandled async error.
+      final initializedFailure = expectLater(
+        channel.initialized,
+        throwsA(isA<StreamChatNetworkError>()),
+      );
+
+      await expectLater(
+        channel.watch(),
+        throwsA(isA<StreamChatNetworkError>()),
+      );
+      await initializedFailure;
+
+      // Init never *succeeded*, so the raw setters must still work. Previously
+      // they threw because the completer was merely `isCompleted` (it had
+      // completed with an error).
+      expect(() => channel.name = 'New name', returnsNormally);
+      expect(channel.name, 'New name');
+    });
   });
 
   group('Initialized Channel with Persistence', () {
@@ -789,7 +826,7 @@ void main() {
             (_) async => throw StreamChatNetworkError.raw(
               code: 0,
               message: 'Request cancelled',
-              isRequestCancelledError: true,
+              type: StreamChatNetworkErrorType.cancel,
             ),
           );
 
@@ -843,7 +880,7 @@ void main() {
             (_) async => throw StreamChatNetworkError.raw(
               code: 0,
               message: 'Request cancelled',
-              isRequestCancelledError: true,
+              type: StreamChatNetworkErrorType.cancel,
             ),
           );
 
@@ -920,7 +957,7 @@ void main() {
             (_) async => throw StreamChatNetworkError.raw(
               code: 0,
               message: 'Request cancelled',
-              isRequestCancelledError: true,
+              type: StreamChatNetworkErrorType.cancel,
             ),
           );
 
@@ -992,7 +1029,7 @@ void main() {
             (_) async => throw StreamChatNetworkError.raw(
               code: 0,
               message: 'Request cancelled',
-              isRequestCancelledError: true,
+              type: StreamChatNetworkErrorType.cancel,
             ),
           );
 
@@ -3949,6 +3986,49 @@ void main() {
             watchersPagination: any(named: 'watchersPagination'),
           ),
         ).called(1);
+      });
+
+      test('a successful retry after a failed init reconciles '
+          '`initialized` and `state`', () async {
+        final freshChannel = Channel(client, channelType, channelId);
+        addTearDown(freshChannel.dispose);
+
+        var attempts = 0;
+        when(
+          () => client.queryChannel(
+            channelType,
+            channelId: channelId,
+            watch: true,
+            channelData: any(named: 'channelData'),
+            messagesPagination: any(named: 'messagesPagination'),
+            membersPagination: any(named: 'membersPagination'),
+            watchersPagination: any(named: 'watchersPagination'),
+          ),
+        ).thenAnswer((_) async {
+          if (++attempts == 1) {
+            throw StreamChatNetworkError(ChatErrorCode.inputError);
+          }
+          return _generateChannelState(channelId, channelType);
+        });
+
+        // First init fails: `initialized` errors and `state` stays null.
+        // Attach the expectation before watch() so the error is handled.
+        final firstInit = expectLater(
+          freshChannel.initialized,
+          throwsA(isA<StreamChatNetworkError>()),
+        );
+        await expectLater(
+          freshChannel.watch(),
+          throwsA(isA<StreamChatNetworkError>()),
+        );
+        await firstInit;
+        expect(freshChannel.state, isNull);
+
+        // Retrying resets the completer; the successful watch initializes the
+        // channel and `initialized`/`state` agree again.
+        await freshChannel.watch();
+        expect(freshChannel.state, isNotNull);
+        await expectLater(freshChannel.initialized, completion(isTrue));
       });
 
       test('should rethrow if `.query` throws', () async {

--- a/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
+++ b/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
@@ -3,6 +3,11 @@ import 'package:stream_chat/src/core/api/responses.dart';
 import 'package:stream_chat/src/core/error/error.dart';
 import 'package:test/test.dart';
 
+DioException _dioException(DioExceptionType type) => DioException(
+  requestOptions: RequestOptions(path: 'test-path'),
+  type: type,
+);
+
 void main() {
   group('StreamChatError', () {
     test('should match if message is same', () {
@@ -45,8 +50,13 @@ void main() {
 
       expect(
         error.toString(),
-        'WebSocketError(message: $message, data: $data)',
+        'StreamWebSocketError(code: ${data.code}, message: $message, data: $data)',
       );
+    });
+
+    test('`.toString` omits code when absent', () {
+      const error = StreamWebSocketError('boom');
+      expect(error.toString(), 'StreamWebSocketError(message: boom)');
     });
   });
 
@@ -214,6 +224,57 @@ void main() {
         'code: ${errorCode.code}, '
         'message: ${errorCode.message})',
       );
+    });
+
+    test('`.toString` includes the transport type when known', () {
+      final error = StreamChatNetworkError.fromDioException(
+        DioException(
+          requestOptions: RequestOptions(path: '/'),
+          type: DioExceptionType.connectionError,
+        ),
+      );
+
+      expect(error.toString(), contains('type: connectionError'));
+    });
+
+    group('.type from .fromDioException maps dio types 1:1', () {
+      const cases = {
+        DioExceptionType.connectionError: StreamChatNetworkErrorType.connectionError,
+        DioExceptionType.connectionTimeout: StreamChatNetworkErrorType.connectionTimeout,
+        DioExceptionType.sendTimeout: StreamChatNetworkErrorType.sendTimeout,
+        DioExceptionType.receiveTimeout: StreamChatNetworkErrorType.receiveTimeout,
+        DioExceptionType.badResponse: StreamChatNetworkErrorType.badResponse,
+        DioExceptionType.cancel: StreamChatNetworkErrorType.cancel,
+        DioExceptionType.badCertificate: StreamChatNetworkErrorType.badCertificate,
+        DioExceptionType.unknown: StreamChatNetworkErrorType.unknown,
+        // Unmodeled / future dio types degrade to unknown.
+        DioExceptionType.transformTimeout: StreamChatNetworkErrorType.unknown,
+      };
+
+      for (final MapEntry(key: dioType, value: expected) in cases.entries) {
+        test('$dioType -> $expected', () {
+          final error = StreamChatNetworkError.fromDioException(
+            _dioException(dioType),
+          );
+          expect(error.type, expected);
+        });
+      }
+    });
+
+    test('.type defaults to unknown for non-network errors', () {
+      final error = StreamChatNetworkError(ChatErrorCode.internalSystemError);
+      expect(error.type, StreamChatNetworkErrorType.unknown);
+    });
+
+    test('.type is not part of equality', () {
+      final error = StreamChatNetworkError.raw(code: 1, message: 'msg');
+      final error2 = StreamChatNetworkError.raw(
+        code: 1,
+        message: 'msg',
+        type: StreamChatNetworkErrorType.connectionTimeout,
+      );
+
+      expect(error, error2);
     });
   });
 }

--- a/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
+++ b/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
@@ -243,12 +243,11 @@ void main() {
         DioExceptionType.connectionTimeout: StreamChatNetworkErrorType.connectionTimeout,
         DioExceptionType.sendTimeout: StreamChatNetworkErrorType.sendTimeout,
         DioExceptionType.receiveTimeout: StreamChatNetworkErrorType.receiveTimeout,
+        DioExceptionType.transformTimeout: StreamChatNetworkErrorType.transformTimeout,
         DioExceptionType.badResponse: StreamChatNetworkErrorType.badResponse,
         DioExceptionType.cancel: StreamChatNetworkErrorType.cancel,
         DioExceptionType.badCertificate: StreamChatNetworkErrorType.badCertificate,
         DioExceptionType.unknown: StreamChatNetworkErrorType.unknown,
-        // Unmodeled / future dio types degrade to unknown.
-        DioExceptionType.transformTimeout: StreamChatNetworkErrorType.unknown,
       };
 
       for (final MapEntry(key: dioType, value: expected) in cases.entries) {

--- a/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
+++ b/packages/stream_chat/test/src/core/error/stream_chat_error_test.dart
@@ -266,7 +266,7 @@ void main() {
       expect(error.type, StreamChatNetworkErrorType.unknown);
     });
 
-    test('.type is not part of equality', () {
+    test('.type is part of equality', () {
       final error = StreamChatNetworkError.raw(code: 1, message: 'msg');
       final error2 = StreamChatNetworkError.raw(
         code: 1,
@@ -274,7 +274,7 @@ void main() {
         type: StreamChatNetworkErrorType.connectionTimeout,
       );
 
-      expect(error, error2);
+      expect(error, isNot(error2));
     });
   });
 }

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ⚠️ Deprecated
 
-- Deprecated the now-unused `height`/`width` of `StreamScrollViewLoadingWidget` in favor of `size`.
+- Deprecated `height`/`width` of `StreamScrollViewLoadingWidget` in favor of `size`.
 
 🐞 Fixed
 

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -3,9 +3,17 @@
 ✅ Added
 
 - Added `StreamMessageListViewConfiguration.autoScrollPolicy` to control whether and how `StreamMessageListView` scrolls to the newest message when a new message arrives. Use `StreamAutoScrollPolicy.disabled` to fully control scrolling yourself.
+- Added an `errorSubtitle` to `StreamScrollViewErrorWidget`, which now falls back to the design's generic error copy (title, description, and a "Try Again" retry label) when values aren't provided.
+- Added a `size` (`StreamLoadingSpinnerSize`) parameter to `StreamScrollViewLoadingWidget`.
+
+⚠️ Deprecated
+
+- Deprecated the now-unused `height`/`width` of `StreamScrollViewLoadingWidget` in favor of `size`.
 
 🐞 Fixed
 
+- Fixed the default `StreamChannel` loading and error states not being themed or localized; `StreamChat` now installs themed, connection-aware defaults, overridable per `StreamChannel` or via `DefaultStreamChannelBuilders`.
+- Fixed the default list/scroll-view error states (channel, message, member, user, thread, poll-vote, reaction, search, and photo) showing raw or fixed errors; they are now connection-aware (no internet / slow connection), falling back to each view's specific error text.
 - Fixed `StreamTypingIndicator` briefly showing typing users from a different context (main channel vs. thread) on its first frame.
 
 ## 10.2.0

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -197,6 +197,25 @@ abstract class Translations {
   /// The error shown when something went wrong
   String get somethingWentWrongError;
 
+  /// The title shown when there is no internet connection.
+  String get connectionErrorTitle;
+
+  /// The description shown when there is no internet connection.
+  String get connectionErrorDescription;
+
+  /// The title shown when the connection is too slow or the request timed out.
+  String get slowConnectionErrorTitle;
+
+  /// The description shown when the connection is too slow or the request
+  /// timed out.
+  String get slowConnectionErrorDescription;
+
+  /// The title shown for a generic, uncategorised error.
+  String get genericErrorTitle;
+
+  /// The description shown for a generic, uncategorised error.
+  String get genericErrorDescription;
+
   /// The label for "OK"
   String get okLabel;
 
@@ -944,6 +963,24 @@ class DefaultTranslations implements Translations {
 
   @override
   String get somethingWentWrongError => 'Something went wrong';
+
+  @override
+  String get connectionErrorTitle => 'No Internet Connection';
+
+  @override
+  String get connectionErrorDescription => 'Please check your internet connection';
+
+  @override
+  String get slowConnectionErrorTitle => 'Slow Internet Connection';
+
+  @override
+  String get slowConnectionErrorDescription => 'There seems to be a problem with your internet connection';
+
+  @override
+  String get genericErrorTitle => 'Error';
+
+  @override
+  String get genericErrorDescription => 'Oops, something went wrong';
 
   @override
   String get addMoreFilesLabel => 'Add more';

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -535,9 +535,15 @@ class _StreamMessageListViewState extends State<StreamMessageListView> {
 
     Widget defaultErrorBuilder(BuildContext context, Object error) {
       if (widget.builders.error case final builder?) return builder(context, error);
+
+      final translations = context.translations;
+      final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingMessagesError);
+
       return Center(
         child: StreamScrollViewErrorWidget(
-          errorTitle: Text(context.translations.loadingMessagesError),
+          errorTitle: Text(text.title),
+          errorSubtitle: Text(text.description),
+          retryButtonText: Text(translations.tryAgainLabel),
           onRetryPressed: () => streamChannel?.reloadChannel(),
         ),
       );

--- a/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/message_list_view/message_list_view.dart
@@ -15,6 +15,7 @@ import 'package:stream_chat_flutter/src/message_list_view/thread_separator.dart'
 import 'package:stream_chat_flutter/src/message_list_view/unread_messages_separator.dart';
 import 'package:stream_chat_flutter/src/message_widget/stream_ephemeral_message.dart';
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Spacing Types (These are properties of a message to help inform the decision

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/scroll_view/channel_scroll_view/stream_channel_list_skeleton_loading.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamChannelListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/channel_scroll_view/stream_channel_list_view.dart
@@ -333,14 +333,21 @@ class StreamChannelListView extends StatelessWidget {
         ),
       ),
       loadingBuilder: (context) => loadingBuilder?.call(context) ?? const StreamChannelListSkeletonLoading(),
-      errorBuilder: (context, error) =>
-          errorBuilder?.call(context, error) ??
-          Center(
-            child: StreamScrollViewErrorWidget(
-              errorTitle: Text(context.translations.loadingChannelsError),
-              onRetryPressed: controller.refresh,
-            ),
+      errorBuilder: (context, error) {
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingChannelsError);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            errorSubtitle: Text(text.description),
+            retryButtonText: Text(translations.tryAgainLabel),
+            onRetryPressed: controller.refresh,
           ),
+        );
+      },
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_grid_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_grid_view.dart
@@ -365,14 +365,19 @@ class StreamMemberGridView extends StatelessWidget {
           const Center(
             child: StreamScrollViewLoadingWidget(),
           ),
-      errorBuilder: (context, error) =>
-          errorBuilder?.call(context, error) ??
-          Center(
-            child: StreamScrollViewErrorWidget(
-              errorTitle: Text(context.translations.loadingUsersError),
-              onRetryPressed: controller.refresh,
-            ),
+      errorBuilder: (context, error) {
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingUsersError);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            onRetryPressed: controller.refresh,
           ),
+        );
+      },
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_grid_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_grid_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default grid delegate  for [StreamMemberGridView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamMemberListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/member_scroll_view/stream_member_list_view.dart
@@ -332,13 +332,18 @@ class StreamMemberListView extends StatelessWidget {
         const Center(
           child: StreamScrollViewLoadingWidget(),
         ),
-    errorBuilder: (context, error) =>
-        errorBuilder?.call(context, error) ??
-        Center(
-          child: StreamScrollViewErrorWidget(
-            errorTitle: Text(context.translations.loadingUsersError),
-            onRetryPressed: controller.refresh,
-          ),
+    errorBuilder: (context, error) {
+      if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+      final translations = context.translations;
+      final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingUsersError);
+
+      return Center(
+        child: StreamScrollViewErrorWidget(
+          errorTitle: Text(text.title),
+          onRetryPressed: controller.refresh,
         ),
+      );
+    },
   );
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_view.dart
@@ -335,14 +335,19 @@ class StreamMessageSearchListView extends StatelessWidget {
           const Center(
             child: StreamScrollViewLoadingWidget(),
           ),
-      errorBuilder: (context, error) =>
-          errorBuilder?.call(context, error) ??
-          Center(
-            child: StreamScrollViewErrorWidget(
-              errorTitle: Text(context.translations.loadingMessagesError),
-              onRetryPressed: controller.refresh,
-            ),
+      errorBuilder: (context, error) {
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingMessagesError);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            onRetryPressed: controller.refresh,
           ),
+        );
+      },
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/message_search_scroll_view/stream_message_search_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamMessageSearchListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart' show AssetEntity, ThumbnailFormat, ThumbnailSize;
 
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default grid delegate  for [StreamPhotoGallery].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/photo_gallery/stream_photo_gallery.dart
@@ -390,13 +390,17 @@ class StreamPhotoGallery extends StatelessWidget {
             );
       },
       errorBuilder: (context, error) {
-        return errorBuilder?.call(context, error) ??
-            Center(
-              child: StreamScrollViewErrorWidget(
-                errorTitle: Text(context.translations.genericErrorText),
-                onRetryPressed: controller.refresh,
-              ),
-            );
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.genericErrorText);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            onRetryPressed: controller.refresh,
+          ),
+        );
       },
     );
   }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/poll_vote_scroll_view/stream_poll_vote_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/poll_vote_scroll_view/stream_poll_vote_list_view.dart
@@ -7,6 +7,7 @@ import 'package:stream_chat_flutter/src/scroll_view/stream_scroll_view_indexed_w
 import 'package:stream_chat_flutter/src/scroll_view/stream_scroll_view_load_more_error.dart';
 import 'package:stream_chat_flutter/src/scroll_view/stream_scroll_view_loading_widget.dart';
 import 'package:stream_chat_flutter/src/utils/extensions.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 import 'package:stream_core_flutter/chat.dart';
 
@@ -340,13 +341,18 @@ class StreamPollVoteListView extends StatelessWidget {
         const Center(
           child: StreamScrollViewLoadingWidget(),
         ),
-    errorBuilder: (context, error) =>
-        errorBuilder?.call(context, error) ??
-        Center(
-          child: StreamScrollViewErrorWidget(
-            errorTitle: Text(context.translations.loadingPollVotesError),
-            onRetryPressed: controller.refresh,
-          ),
+    errorBuilder: (context, error) {
+      if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+      final translations = context.translations;
+      final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingPollVotesError);
+
+      return Center(
+        child: StreamScrollViewErrorWidget(
+          errorTitle: Text(text.title),
+          onRetryPressed: controller.refresh,
         ),
+      );
+    },
   );
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/reaction_scroll_view/stream_reaction_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/reaction_scroll_view/stream_reaction_list_view.dart
@@ -198,13 +198,18 @@ class StreamReactionListView extends StatelessWidget {
       ),
     ),
     loadingBuilder: (context) => loadingBuilder?.call(context) ?? const Center(child: StreamScrollViewLoadingWidget()),
-    errorBuilder: (context, error) =>
-        errorBuilder?.call(context, error) ??
-        Center(
-          child: StreamScrollViewErrorWidget(
-            errorTitle: Text(context.translations.loadingReactionsError),
-            onRetryPressed: controller.refresh,
-          ),
+    errorBuilder: (context, error) {
+      if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+      final translations = context.translations;
+      final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingReactionsError);
+
+      return Center(
+        child: StreamScrollViewErrorWidget(
+          errorTitle: Text(text.title),
+          onRetryPressed: controller.refresh,
         ),
+      );
+    },
   );
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/reaction_scroll_view/stream_reaction_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/reaction_scroll_view/stream_reaction_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamReactionListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_error_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_error_widget.dart
@@ -9,6 +9,8 @@ class StreamScrollViewErrorWidget extends StatelessWidget {
     super.key,
     this.errorTitle,
     this.errorTitleStyle,
+    this.errorSubtitle,
+    this.errorSubtitleStyle,
     this.errorIcon,
     this.retryButtonText,
     this.retryButtonTextStyle,
@@ -19,15 +21,28 @@ class StreamScrollViewErrorWidget extends StatelessWidget {
   });
 
   /// The title of the error.
+  ///
+  /// Defaults to a generic localized error title.
   final Widget? errorTitle;
 
   /// The style of the title.
   final TextStyle? errorTitleStyle;
 
+  /// An optional supporting description shown below the title.
+  ///
+  /// When no [errorTitle] is supplied, this defaults to a generic localized
+  /// description so the out-of-the-box error state matches the design.
+  final Widget? errorSubtitle;
+
+  /// The style of the subtitle.
+  final TextStyle? errorSubtitleStyle;
+
   /// The icon to display when the list shows error.
   final Widget? errorIcon;
 
   /// The text to display in the retry button.
+  ///
+  /// Defaults to a localized "Try Again" label.
   final Widget? retryButtonText;
 
   /// The style of the retryButtonText.
@@ -52,25 +67,47 @@ class StreamScrollViewErrorWidget extends StatelessWidget {
 
     final textTheme = context.streamTextTheme;
     final colorScheme = context.streamColorScheme;
+    final translations = context.translations;
 
-    final errorIcon = IconTheme.merge(
+    final icon = IconTheme.merge(
       data: IconThemeData(size: 32, color: colorScheme.textTertiary),
-      child: this.errorIcon ?? Icon(icons.exclamationCircle),
+      child: errorIcon ?? Icon(icons.exclamationCircle),
     );
 
-    final effectiveStyle = errorTitleStyle ?? textTheme.captionDefault.copyWith(color: colorScheme.textSecondary);
-    final emptyTitleText = AnimatedDefaultTextStyle(
-      style: effectiveStyle,
+    final effectiveErrorTitle = errorTitle ?? Text(translations.genericErrorTitle);
+    // The generic subtitle only pairs with the generic title, not a custom one.
+    final resolvedSubtitle = errorSubtitle ?? (errorTitle == null ? Text(translations.genericErrorDescription) : null);
+    final effectiveTitleStyle = errorTitleStyle ?? textTheme.headingSm.copyWith(color: colorScheme.textPrimary);
+    final effectiveSubtitleStyle =
+        errorSubtitleStyle ?? textTheme.bodyDefault.copyWith(color: colorScheme.textSecondary);
+    final effectiveRetryButtonText = retryButtonText ?? Text(translations.tryAgainLabel);
+
+    final title = AnimatedDefaultTextStyle(
+      style: effectiveTitleStyle,
+      textAlign: TextAlign.center,
       duration: kThemeChangeDuration,
-      child: errorTitle ?? Text(context.translations.genericErrorText),
+      child: effectiveErrorTitle,
     );
+
+    Widget? subtitle;
+    if (resolvedSubtitle != null) {
+      subtitle = Padding(
+        padding: .only(top: spacing.xs),
+        child: AnimatedDefaultTextStyle(
+          style: effectiveSubtitleStyle,
+          textAlign: TextAlign.center,
+          duration: kThemeChangeDuration,
+          child: resolvedSubtitle,
+        ),
+      );
+    }
 
     final retryButton = StreamButton(
       size: .medium,
       type: .outline,
       style: .secondary,
       onPressed: onRetryPressed,
-      child: Text(context.translations.retryLabel),
+      child: effectiveRetryButtonText,
     );
 
     return Padding(
@@ -83,9 +120,10 @@ class StreamScrollViewErrorWidget extends StatelessWidget {
         mainAxisAlignment: mainAxisAlignment,
         crossAxisAlignment: crossAxisAlignment,
         children: [
-          errorIcon,
-          SizedBox(height: spacing.xs),
-          emptyTitleText,
+          icon,
+          SizedBox(height: spacing.sm),
+          title,
+          ?subtitle,
           SizedBox(height: spacing.md),
           retryButton,
         ],

--- a/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_loading_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_loading_widget.dart
@@ -7,19 +7,19 @@ class StreamScrollViewLoadingWidget extends StatelessWidget {
   const StreamScrollViewLoadingWidget({
     super.key,
     this.size = StreamLoadingSpinnerSize.lg,
-    @Deprecated('No longer used; the spinner is sized via size') this.height = 42,
-    @Deprecated('No longer used; the spinner is sized via size') this.width = 42,
+    @Deprecated('Use size instead') this.height = 42,
+    @Deprecated('Use size instead') this.width = 42,
   });
 
   /// The size of the loading spinner.
   final StreamLoadingSpinnerSize size;
 
   /// The height of the indicator.
-  @Deprecated('No longer used; the spinner is sized via size')
+  @Deprecated('Use size instead')
   final double height;
 
   /// The width of the indicator.
-  @Deprecated('No longer used; the spinner is sized via size')
+  @Deprecated('Use size instead')
   final double width;
 
   @override
@@ -31,7 +31,11 @@ class StreamScrollViewLoadingWidget extends StatelessWidget {
         horizontal: spacing.md,
         vertical: spacing.xxxl,
       ),
-      child: StreamLoadingSpinner(size: size),
+      child: SizedBox(
+        width: width,
+        height: height,
+        child: StreamLoadingSpinner(size: size),
+      ),
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_loading_widget.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/stream_scroll_view_loading_widget.dart
@@ -1,24 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:stream_core_flutter/chat.dart';
 
 /// A widget that is displayed while the [StreamScrollView] is loading.
 class StreamScrollViewLoadingWidget extends StatelessWidget {
   /// Creates a new instance of [StreamScrollViewLoadingWidget].
   const StreamScrollViewLoadingWidget({
     super.key,
-    this.height = 42,
-    this.width = 42,
+    this.size = StreamLoadingSpinnerSize.lg,
+    @Deprecated('No longer used; the spinner is sized via size') this.height = 42,
+    @Deprecated('No longer used; the spinner is sized via size') this.width = 42,
   });
 
+  /// The size of the loading spinner.
+  final StreamLoadingSpinnerSize size;
+
   /// The height of the indicator.
+  @Deprecated('No longer used; the spinner is sized via size')
   final double height;
 
   /// The width of the indicator.
+  @Deprecated('No longer used; the spinner is sized via size')
   final double width;
 
   @override
-  Widget build(BuildContext context) => SizedBox(
-    height: height,
-    width: width,
-    child: const CircularProgressIndicator.adaptive(),
-  );
+  Widget build(BuildContext context) {
+    final spacing = context.streamSpacing;
+
+    return Padding(
+      padding: .symmetric(
+        horizontal: spacing.md,
+        vertical: spacing.xxxl,
+      ),
+      child: StreamLoadingSpinner(size: size),
+    );
+  }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_thread_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_thread_list_view.dart
@@ -336,14 +336,19 @@ class StreamThreadListView extends StatelessWidget {
           const Center(
             child: StreamThreadListSkeletonLoading(),
           ),
-      errorBuilder: (context, error) =>
-          errorBuilder?.call(context, error) ??
-          Center(
-            child: StreamScrollViewErrorWidget(
-              errorTitle: Text(context.translations.loadingMessagesError),
-              onRetryPressed: controller.refresh,
-            ),
+      errorBuilder: (context, error) {
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingMessagesError);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            onRetryPressed: controller.refresh,
           ),
+        );
+      },
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_thread_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/thread_scroll_view/stream_thread_list_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/src/scroll_view/thread_scroll_view/stream_thread_list_skeleton_loading.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamThreadListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_grid_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_grid_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default grid delegate  for [StreamUserGridView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_grid_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_grid_view.dart
@@ -362,14 +362,19 @@ class StreamUserGridView extends StatelessWidget {
           const Center(
             child: StreamScrollViewLoadingWidget(),
           ),
-      errorBuilder: (context, error) =>
-          errorBuilder?.call(context, error) ??
-          Center(
-            child: StreamScrollViewErrorWidget(
-              errorTitle: Text(context.translations.loadingUsersError),
-              onRetryPressed: controller.refresh,
-            ),
+      errorBuilder: (context, error) {
+        if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+        final translations = context.translations;
+        final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingUsersError);
+
+        return Center(
+          child: StreamScrollViewErrorWidget(
+            errorTitle: Text(text.title),
+            onRetryPressed: controller.refresh,
           ),
+        );
+      },
     );
   }
 }

--- a/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Default separator builder for [StreamUserListView].

--- a/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_view.dart
+++ b/packages/stream_chat_flutter/lib/src/scroll_view/user_scroll_view/stream_user_list_view.dart
@@ -332,14 +332,19 @@ class StreamUserListView extends StatelessWidget {
         const Center(
           child: StreamScrollViewLoadingWidget(),
         ),
-    errorBuilder: (context, error) =>
-        errorBuilder?.call(context, error) ??
-        Center(
-          child: StreamScrollViewErrorWidget(
-            errorTitle: Text(context.translations.loadingUsersError),
-            onRetryPressed: controller.refresh,
-          ),
+    errorBuilder: (context, error) {
+      if (errorBuilder?.call(context, error) case final builder?) return builder;
+
+      final translations = context.translations;
+      final text = resolveNetworkErrorText(context, error, fallbackTitle: translations.loadingUsersError);
+
+      return Center(
+        child: StreamScrollViewErrorWidget(
+          errorTitle: Text(text.title),
+          onRetryPressed: controller.refresh,
         ),
+      );
+    },
   );
 }
 

--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
+import 'package:stream_chat_flutter/src/utils/network_error_text.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Provides chat state and configuration to the descendant widget tree.

--- a/packages/stream_chat_flutter/lib/src/stream_chat.dart
+++ b/packages/stream_chat_flutter/lib/src/stream_chat.dart
@@ -194,7 +194,11 @@ class StreamChatState extends State<StreamChat> {
       onBackgroundEventReceived: widget.onBackgroundEventReceived,
       backgroundKeepAlive: widget.backgroundKeepAlive,
       connectivityStream: widget.connectivityStream,
-      child: StreamSnackbarScope(child: widget.child ?? const Empty()),
+      child: DefaultStreamChannelBuilders(
+        errorBuilder: _defaultChannelErrorBuilder,
+        loadingBuilder: _defaultChannelLoadingBuilder,
+        child: StreamSnackbarScope(child: widget.child ?? const Empty()),
+      ),
     );
 
     final theme = widget.themeData ?? StreamChatThemeData();
@@ -239,4 +243,40 @@ extension on ThemeData {
     // must come after the spread to win its slot when one is already present.
     return copyWith(extensions: [...extensions.values, extension]);
   }
+}
+
+// Installed by [StreamChat] as the default [StreamChannel] loading state, so
+// app-provided channels show a themed indicator on the app background.
+Widget _defaultChannelLoadingBuilder(BuildContext context) {
+  return Material(
+    color: context.streamColorScheme.backgroundApp,
+    child: const Center(
+      child: StreamScrollViewLoadingWidget(),
+    ),
+  );
+}
+
+// Installed by [StreamChat] as the default [StreamChannel] error state, so
+// app-provided channels show a themed, localized widget instead of a raw error.
+// Both builders are stable top-level tear-offs so DefaultStreamChannelBuilders
+// can compare them by identity in updateShouldNotify.
+Widget _defaultChannelErrorBuilder(
+  BuildContext context,
+  Object error,
+  StackTrace? stackTrace,
+) {
+  final translations = context.translations;
+  final text = resolveNetworkErrorText(context, error);
+
+  return Material(
+    color: context.streamColorScheme.backgroundApp,
+    child: Center(
+      child: StreamScrollViewErrorWidget(
+        errorTitle: Text(text.title),
+        errorSubtitle: Text(text.description),
+        retryButtonText: Text(translations.tryAgainLabel),
+        onRetryPressed: () => StreamChannel.of(context).retry(),
+      ),
+    ),
+  );
 }

--- a/packages/stream_chat_flutter/lib/src/utils/network_error_text.dart
+++ b/packages/stream_chat_flutter/lib/src/utils/network_error_text.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:stream_chat_flutter/src/utils/extensions.dart';
+import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
+
+/// Resolves a title and description for [error] based on its transport-level
+/// [StreamChatNetworkError.type].
+///
+/// Connection failures map to the "no internet" copy and timeouts to the
+/// "slow connection" copy. Everything else falls back to [fallbackTitle] /
+/// [fallbackDescription] when provided, otherwise to the generic localized copy.
+({String title, String description}) resolveNetworkErrorText(
+  BuildContext context,
+  Object? error, {
+  String? fallbackTitle,
+  String? fallbackDescription,
+}) {
+  final translations = context.translations;
+  return switch (error) {
+    StreamChatNetworkError(type: .connectionError) => (
+      title: translations.connectionErrorTitle,
+      description: translations.connectionErrorDescription,
+    ),
+    StreamChatNetworkError(type: .connectionTimeout || .sendTimeout || .receiveTimeout) => (
+      title: translations.slowConnectionErrorTitle,
+      description: translations.slowConnectionErrorDescription,
+    ),
+    _ => (
+      title: fallbackTitle ?? translations.genericErrorTitle,
+      description: fallbackDescription ?? translations.genericErrorDescription,
+    ),
+  };
+}

--- a/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
+++ b/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
@@ -157,5 +157,6 @@ export 'src/utils/device_segmentation.dart';
 export 'src/utils/extensions.dart';
 export 'src/utils/helpers.dart';
 export 'src/utils/message_preview_formatter.dart';
+export 'src/utils/network_error_text.dart';
 export 'src/utils/stream_image_cdn.dart';
 export 'src/utils/typedefs.dart';

--- a/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
+++ b/packages/stream_chat_flutter/lib/stream_chat_flutter.dart
@@ -157,6 +157,5 @@ export 'src/utils/device_segmentation.dart';
 export 'src/utils/extensions.dart';
 export 'src/utils/helpers.dart';
 export 'src/utils/message_preview_formatter.dart';
-export 'src/utils/network_error_text.dart';
 export 'src/utils/stream_image_cdn.dart';
 export 'src/utils/typedefs.dart';

--- a/packages/stream_chat_flutter/pubspec.yaml
+++ b/packages/stream_chat_flutter/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   collection: ^1.19.1
   desktop_drop: ^0.7.1
   diacritic: ^0.1.6
-  dio: ^5.9.2
+  dio: ^5.11.0
   ezanimation: ^0.6.0
   file_picker: ^11.0.0
   file_selector: ^1.1.0

--- a/packages/stream_chat_flutter/test/src/localization/default_translations_test.dart
+++ b/packages/stream_chat_flutter/test/src/localization/default_translations_test.dart
@@ -40,6 +40,12 @@ void main() {
     );
     expect(translations.emptyMessagesText, isNotNull);
     expect(translations.genericErrorText, isNotNull);
+    expect(translations.connectionErrorTitle, isNotNull);
+    expect(translations.connectionErrorDescription, isNotNull);
+    expect(translations.slowConnectionErrorTitle, isNotNull);
+    expect(translations.slowConnectionErrorDescription, isNotNull);
+    expect(translations.genericErrorTitle, isNotNull);
+    expect(translations.genericErrorDescription, isNotNull);
     expect(translations.loadingMessagesError, isNotNull);
     expect(translations.resultCountText(3), isNotNull);
     expect(translations.messageDeletedText, isNotNull);

--- a/packages/stream_chat_flutter/test/src/stream_chat_default_channel_error_test.dart
+++ b/packages/stream_chat_flutter/test/src/stream_chat_default_channel_error_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import 'mocks.dart';
+
+void main() {
+  late MockClient client;
+  late MockClientState clientState;
+
+  setUp(() {
+    client = MockClient();
+    clientState = MockClientState();
+    when(() => client.state).thenReturn(clientState);
+    when(() => clientState.currentUser).thenReturn(OwnUser(id: 'user-id'));
+  });
+
+  StreamChatNetworkError dioError(DioExceptionType type) => StreamChatNetworkError.fromDioException(
+    DioException(
+      requestOptions: RequestOptions(path: '/'),
+      type: type,
+    ),
+  );
+
+  // Pumps StreamChat and renders the default error state it installs for the
+  // given [error], via DefaultStreamChannelBuilders.errorBuilderOf.
+  Future<void> pumpDefaultError(WidgetTester tester, Object error) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: StreamChat(
+          client: client,
+          child: Scaffold(
+            body: Builder(
+              builder: (context) {
+                final errorBuilder = DefaultStreamChannelBuilders.errorBuilderOf(context);
+                return errorBuilder(context, error, null);
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('default channel error builder installed by StreamChat', () {
+    testWidgets('shows the no-internet copy for connection errors', (tester) async {
+      await pumpDefaultError(tester, dioError(DioExceptionType.connectionError));
+
+      expect(find.byType(StreamScrollViewErrorWidget), findsOneWidget);
+      expect(find.text('No Internet Connection'), findsOneWidget);
+      expect(find.text('Please check your internet connection'), findsOneWidget);
+      expect(find.text('Try Again'), findsOneWidget);
+    });
+
+    testWidgets('shows the slow-connection copy for timeouts', (tester) async {
+      await pumpDefaultError(tester, dioError(DioExceptionType.receiveTimeout));
+
+      expect(find.text('Slow Internet Connection'), findsOneWidget);
+      expect(
+        find.text('There seems to be a problem with your internet connection'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows a generic message and never the raw error', (tester) async {
+      final error = StreamChatNetworkError.raw(
+        code: -1,
+        message: 'super secret internal failure',
+        statusCode: 500,
+      );
+
+      await pumpDefaultError(tester, error);
+
+      expect(find.text('Error'), findsOneWidget);
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+      expect(find.textContaining('StreamChatNetworkError'), findsNothing);
+      expect(find.textContaining('super secret internal failure'), findsNothing);
+    });
+  });
+
+  testWidgets(
+    'StreamChat installs a themed default channel loading builder',
+    (tester) async {
+      Color? expectedBackground;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            child: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  expectedBackground = context.streamColorScheme.backgroundApp;
+                  final loadingBuilder = DefaultStreamChannelBuilders.loadingBuilderOf(context);
+                  return loadingBuilder(context);
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The installed default shows a spinner on the themed app background.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      final material = tester.widget<Material>(
+        find
+            .ancestor(
+              of: find.byType(CircularProgressIndicator),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      expect(material.color, expectedBackground);
+    },
+  );
+}

--- a/packages/stream_chat_flutter_core/CHANGELOG.md
+++ b/packages/stream_chat_flutter_core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Upcoming
+
+✅ Added
+
+- Added `StreamChannelState.retry()` to re-run a failed channel initialization, for use as the retry action in `StreamChannel.errorBuilder`.
+- Added `DefaultStreamChannelBuilders`, an inherited widget that supplies default loading and error builders to descendant `StreamChannel`s (resolved via `loadingBuilderOf`/`errorBuilderOf`).
+
+🐞 Fixed
+
+- Fixed `StreamChannel`'s default error state exposing raw error details; it now shows a safe error state (icon, message, and a Try Again button wired to `retry()`) that adapts to the failure type.
+
 ## 10.2.0
 
 🐞 Fixed

--- a/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
+++ b/packages/stream_chat_flutter_core/lib/src/stream_channel.dart
@@ -25,14 +25,6 @@ typedef ErrorWidgetBuilder =
       StackTrace? stackTrace,
     );
 
-Color _getDefaultBackgroundColor(BuildContext context) {
-  final brightness = Theme.of(context).brightness;
-  return switch (brightness) {
-    Brightness.light => const Color(0xfff7f7f8),
-    Brightness.dark => const Color(0xff000000),
-  };
-}
-
 /// Widget used to provide information about the channel to the widget tree
 ///
 /// Use [StreamChannel.of] to get the current [StreamChannelState] instance.
@@ -45,8 +37,8 @@ class StreamChannel extends StatefulWidget {
     required this.channel,
     this.showLoading = true,
     this.initialMessageId,
-    this.errorBuilder = _defaultErrorBuilder,
-    this.loadingBuilder = _defaultLoadingBuilder,
+    this.errorBuilder = _resolveErrorBuilder,
+    this.loadingBuilder = _resolveLoadingBuilder,
   }) : _shouldPosition = true;
 
   /// Exposes a [channel] to descendants without repositioning the loaded
@@ -68,8 +60,8 @@ class StreamChannel extends StatefulWidget {
     required this.channel,
   }) : showLoading = false,
        initialMessageId = null,
-       errorBuilder = _defaultErrorBuilder,
-       loadingBuilder = _defaultLoadingBuilder,
+       errorBuilder = _resolveErrorBuilder,
+       loadingBuilder = _resolveLoadingBuilder,
        _shouldPosition = false;
 
   /// The child of the widget
@@ -84,52 +76,35 @@ class StreamChannel extends StatefulWidget {
   /// If passed the channel will load from this particular message.
   final String? initialMessageId;
 
-  /// Widget builder used in case the channel is initialising.
+  /// Widget builder used while the channel is initialising.
+  ///
+  /// Defaults to a builder that resolves the nearest
+  /// [DefaultStreamChannelBuilders], falling back to a built-in loading
+  /// indicator.
   final WidgetBuilder loadingBuilder;
 
-  /// Widget builder used in case an error occurs while building the channel.
+  /// Widget builder used when an error occurs while building the channel.
+  ///
+  /// Defaults to a builder that resolves the nearest
+  /// [DefaultStreamChannelBuilders], falling back to a built-in error widget.
   final ErrorWidgetBuilder errorBuilder;
 
   // Whether to position the loaded window on mount (initialMessageId,
   // last-read, or latest). Only false for StreamChannel.value.
   final bool _shouldPosition;
 
-  static Widget _defaultLoadingBuilder(BuildContext context) {
-    final backgroundColor = _getDefaultBackgroundColor(context);
-    return Material(
-      color: backgroundColor,
-      child: const Center(
-        child: CircularProgressIndicator.adaptive(),
-      ),
-    );
+  static Widget _resolveLoadingBuilder(BuildContext context) {
+    final builder = DefaultStreamChannelBuilders.loadingBuilderOf(context);
+    return builder(context);
   }
 
-  static Widget _defaultErrorBuilder(
+  static Widget _resolveErrorBuilder(
     BuildContext context,
     Object error,
     StackTrace? stackTrace,
   ) {
-    final backgroundColor = _getDefaultBackgroundColor(context);
-
-    Object? unwrapParallelError(Object error) {
-      if (error case ParallelWaitError(:final List<AsyncError?> errors)) {
-        return errors.firstWhereOrNull((it) => it != null)?.error;
-      }
-
-      return error;
-    }
-
-    final exception = unwrapParallelError(error);
-    return Material(
-      color: backgroundColor,
-      child: Center(
-        child: switch (exception) {
-          DioException(type: DioExceptionType.badResponse) => Text(exception.message ?? 'Bad response'),
-          DioException() => const Text('Check your connection and retry'),
-          _ => Text(exception.toString()),
-        },
-      ),
-    );
+    final builder = DefaultStreamChannelBuilders.errorBuilderOf(context);
+    return builder(context, error, stackTrace);
   }
 
   /// Finds the [StreamChannelState] from the closest [StreamChannel] ancestor
@@ -842,6 +817,27 @@ class StreamChannelState extends State<StreamChannel> {
     return _queryAtMessage();
   }
 
+  /// Retries initializing the channel after a failure.
+  ///
+  /// Re-runs the channel initialization and rebuilds so a previously failed
+  /// load (e.g. due to a network error) can recover. This is the retry action
+  /// to wire into [StreamChannel.errorBuilder].
+  void retry() {
+    if (!mounted) return;
+    setState(_initializeChannel); // Rebuild to show the loading state again.
+  }
+
+  void _initializeChannel() {
+    // Order matters: `_maybeInitChannel()` triggers the (re)query that resets
+    // `channel.initialized` after a failed init, so it must run before
+    // `channel.initialized` is read here — otherwise a retry would await the
+    // stale, already-errored completer.
+    //
+    // `..ignore()` avoids an unhandled error if the future fails before the
+    // FutureBuilder resubscribes (e.g. on retry's deferred rebuild).
+    _channelInitFuture = Future.wait([_maybeInitChannel(), channel.initialized])..ignore();
+  }
+
   Future<void> _maybeInitChannel() async {
     // If the channel doesn't have an CID yet, it hasn't been created on the
     // server so we don't need to initialize it.
@@ -900,7 +896,7 @@ class StreamChannelState extends State<StreamChannel> {
   @override
   void initState() {
     super.initState();
-    _channelInitFuture = [_maybeInitChannel(), channel.initialized].wait;
+    _initializeChannel();
   }
 
   @override
@@ -908,7 +904,7 @@ class StreamChannelState extends State<StreamChannel> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.channel.cid != widget.channel.cid || oldWidget.initialMessageId != widget.initialMessageId) {
       // Re-initialize channel if the channel CID or initial message ID changes.
-      _channelInitFuture = [_maybeInitChannel(), channel.initialized].wait;
+      _initializeChannel();
     }
   }
 
@@ -926,18 +922,135 @@ class StreamChannelState extends State<StreamChannel> {
       child: FutureBuilder<void>(
         future: _channelInitFuture,
         builder: (context, snapshot) {
+          // Gate the error on `done`: the snapshot keeps the stale error across
+          // a retry, so checking it first would hide the loading state.
+          if (snapshot.connectionState != ConnectionState.done) {
+            if (widget.showLoading) return widget.loadingBuilder(context);
+            return widget.child; // return child directly if loading is disabled
+          }
+
           if (snapshot.hasError) {
             final error = snapshot.error!;
             final stackTrace = snapshot.stackTrace;
             return widget.errorBuilder(context, error, stackTrace);
           }
 
-          if (snapshot.connectionState != ConnectionState.done) {
-            if (widget.showLoading) return widget.loadingBuilder(context);
-          }
-
           return widget.child;
         },
+      ),
+    );
+  }
+}
+
+/// Provides default builders to descendant [StreamChannel]s that don't
+/// specify their own [StreamChannel.loadingBuilder] / [StreamChannel.errorBuilder].
+///
+/// Lets a higher layer (e.g. `stream_chat_flutter`'s `StreamChat`) supply
+/// themed, localized loading and error states for every [StreamChannel]
+/// beneath it, without each call site passing them.
+class DefaultStreamChannelBuilders extends InheritedWidget {
+  /// Creates a new instance of [DefaultStreamChannelBuilders].
+  const DefaultStreamChannelBuilders({
+    super.key,
+    this.loadingBuilder,
+    this.errorBuilder,
+    required super.child,
+  });
+
+  /// Default builder for the channel-initializing state.
+  final WidgetBuilder? loadingBuilder;
+
+  /// Default builder for the channel-initialization error state.
+  final ErrorWidgetBuilder? errorBuilder;
+
+  /// Resolves the loading builder from the closest [DefaultStreamChannelBuilders]
+  /// above [context], falling back to the built-in loading indicator.
+  static WidgetBuilder loadingBuilderOf(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<DefaultStreamChannelBuilders>();
+    return scope?.loadingBuilder ?? _defaultLoadingBuilder;
+  }
+
+  /// Resolves the error builder from the closest [DefaultStreamChannelBuilders]
+  /// above [context], falling back to the built-in error widget.
+  static ErrorWidgetBuilder errorBuilderOf(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<DefaultStreamChannelBuilders>();
+    return scope?.errorBuilder ?? _defaultErrorBuilder;
+  }
+
+  @override
+  bool updateShouldNotify(DefaultStreamChannelBuilders oldWidget) {
+    return loadingBuilder != oldWidget.loadingBuilder || errorBuilder != oldWidget.errorBuilder;
+  }
+
+  static Color _getDefaultBackgroundColor(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    return switch (brightness) {
+      Brightness.light => const Color(0xfff7f7f8),
+      Brightness.dark => const Color(0xff000000),
+    };
+  }
+
+  static Widget _defaultLoadingBuilder(BuildContext context) {
+    final backgroundColor = _getDefaultBackgroundColor(context);
+    return Material(
+      color: backgroundColor,
+      child: const Center(
+        child: CircularProgressIndicator.adaptive(),
+      ),
+    );
+  }
+
+  static Widget _defaultErrorBuilder(
+    BuildContext context,
+    Object error,
+    StackTrace? stackTrace,
+  ) {
+    final backgroundColor = _getDefaultBackgroundColor(context);
+
+    // Raw, unlocalized fallback: this core widget has no design system or
+    // translations, so copy/styling are hardcoded. Apps can override with
+    // [StreamChannel.errorBuilder] for a themed, localized state.
+    final (title, message) = switch (error) {
+      StreamChatNetworkError(type: .connectionError) => (
+        'No Internet Connection',
+        'Please check your internet connection',
+      ),
+      StreamChatNetworkError(type: .connectionTimeout || .sendTimeout || .receiveTimeout) => (
+        'Slow Internet Connection',
+        'There seems to be a problem with your internet connection',
+      ),
+      _ => ('Error', 'Oops, something went wrong'),
+    };
+
+    return Material(
+      color: backgroundColor,
+      child: Center(
+        child: Padding(
+          padding: const .symmetric(horizontal: 16, vertical: 40),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 32),
+              const SizedBox(height: 8),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 16, fontWeight: .w600),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 16),
+              OutlinedButton(
+                onPressed: () => StreamChannel.maybeOf(context)?.retry(),
+                child: const Text('Try Again'),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/packages/stream_chat_flutter_core/test/stream_channel_test.dart
+++ b/packages/stream_chat_flutter_core/test/stream_channel_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: lines_longer_than_80_chars
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -317,12 +319,11 @@ void main() {
       // Important: Making initialization fail with a direct error
       when(nonInitializedMockChannel.watch).thenThrow('Failed to connect');
 
-      // A widget with custom error handler
+      // A widget relying on the default error builder.
       final testWidget = MaterialApp(
         home: Scaffold(
           body: StreamChannel(
             channel: nonInitializedMockChannel,
-            // The default error builder will show the error message
             child: const Text('Child Widget'),
           ),
         ),
@@ -336,8 +337,9 @@ void main() {
       // Wait for error to occur
       await tester.pumpAndSettle();
 
-      // Should show error widget with the error message
-      expect(find.text('Failed to connect'), findsOneWidget);
+      // Should show a safe, generic error message instead of the raw error.
+      expect(find.text('Failed to connect'), findsNothing);
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
       expect(find.text('Child Widget'), findsNothing);
     },
   );
@@ -372,6 +374,290 @@ void main() {
       // Should show error widget with the error message
       expect(find.text('Custom Error'), findsOneWidget);
       expect(find.text('Child Widget'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'errorBuilder receives the unwrapped error, not a ParallelWaitError',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      final networkError = StreamChatNetworkError.fromDioException(
+        DioException(
+          requestOptions: RequestOptions(path: 'test'),
+          type: DioExceptionType.connectionError,
+        ),
+      );
+      when(channel.watch).thenThrow(networkError);
+
+      Object? capturedError;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              errorBuilder: (_, error, _) {
+                capturedError = error;
+                return const Text('Custom Error');
+              },
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The builder gets the real cause, not the aggregate wrapper.
+      expect(capturedError, isNot(isA<ParallelWaitError>()));
+      expect(capturedError, same(networkError));
+    },
+  );
+
+  testWidgets(
+    'default errorBuilder never renders the raw error and shows a generic message',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      final rawError = StreamChatNetworkError.raw(
+        code: -1,
+        message: 'super secret internal failure',
+        statusCode: 500,
+      );
+      when(channel.watch).thenThrow(rawError);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The raw error string must not leak to the UI.
+      expect(find.textContaining('StreamChatNetworkError'), findsNothing);
+      expect(find.textContaining('super secret internal failure'), findsNothing);
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'default errorBuilder shows a connection message for connection errors',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      when(channel.watch).thenThrow(
+        StreamChatNetworkError.fromDioException(
+          DioException(
+            requestOptions: RequestOptions(path: 'test'),
+            type: DioExceptionType.connectionError,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('No Internet Connection'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'retry() re-runs initialization and clears the error on success',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      var attempts = 0;
+      when(channel.watch).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) {
+          throw StreamChatNetworkError.raw(code: -1, message: 'boom');
+        }
+        return const ChannelState();
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The error state is shown and the child is hidden.
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+      expect(find.text('Child Widget'), findsNothing);
+
+      // Retrying re-runs init; the second watch succeeds and the child renders.
+      tester.state<StreamChannelState>(find.byType(StreamChannel)).retry();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Child Widget'), findsOneWidget);
+      expect(find.text('Oops, something went wrong'), findsNothing);
+      expect(attempts, 2);
+    },
+  );
+
+  testWidgets(
+    'retry() shows the loading state again instead of the stale error',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      Completer<ChannelState>? secondWatch;
+      var attempts = 0;
+      when(channel.watch).thenAnswer((_) {
+        attempts++;
+        if (attempts == 1) {
+          return Future<ChannelState>.error(
+            StreamChatNetworkError.raw(code: -1, message: 'boom'),
+          );
+        }
+        secondWatch = Completer<ChannelState>();
+        return secondWatch!.future;
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+
+      // Retry while the second attempt is still in flight.
+      tester.state<StreamChannelState>(find.byType(StreamChannel)).retry();
+      await tester.pump();
+
+      // The loading state is shown again — not the stale error snapshot that
+      // FutureBuilder retains across the future reassignment.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Oops, something went wrong'), findsNothing);
+
+      // Completing the in-flight watch renders the child.
+      secondWatch!.complete(const ChannelState());
+      await tester.pumpAndSettle();
+      expect(find.text('Child Widget'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'retry into a persistent failure surfaces the error without leaking',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      // Always fails, so the retry fails again.
+      when(channel.watch).thenThrow(
+        StreamChatNetworkError.raw(code: -1, message: 'boom'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StreamChannel(
+              channel: channel,
+              child: const Text('Child Widget'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+
+      // Retry while still failing. The init future errors before the deferred
+      // rebuild resubscribes; without the `..ignore()` guard this leaks an
+      // unhandled async error, which the test binding reports as a failure.
+      tester.state<StreamChannelState>(find.byType(StreamChannel)).retry();
+      await tester.pumpAndSettle();
+
+      // Error UI still shown, and no unhandled error was thrown.
+      expect(find.text('Oops, something went wrong'), findsOneWidget);
+      expect(find.text('Child Widget'), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'uses DefaultStreamChannelBuilders.errorBuilder when none is provided',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      when(channel.watch).thenThrow(
+        StreamChatNetworkError.raw(code: -1, message: 'boom'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultStreamChannelBuilders(
+            errorBuilder: (_, _, _) => const Text('Inherited Error'),
+            child: Scaffold(
+              body: StreamChannel(
+                channel: channel,
+                child: const Text('Child Widget'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The inherited default is used, not the built-in one.
+      expect(find.text('Inherited Error'), findsOneWidget);
+      expect(find.text('Oops, something went wrong'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'explicit errorBuilder wins over DefaultStreamChannelBuilders',
+    (tester) async {
+      final channel = NonInitializedMockChannel();
+      when(() => channel.cid).thenReturn('test:channel');
+      when(channel.watch).thenThrow(
+        StreamChatNetworkError.raw(code: -1, message: 'boom'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultStreamChannelBuilders(
+            errorBuilder: (_, _, _) => const Text('Inherited Error'),
+            child: Scaffold(
+              body: StreamChannel(
+                channel: channel,
+                errorBuilder: (_, _, _) => const Text('Explicit Error'),
+                child: const Text('Child Widget'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Explicit Error'), findsOneWidget);
+      expect(find.text('Inherited Error'), findsNothing);
     },
   );
 

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+✅ Added
+
+- Added connection-error translations (`connectionErrorTitle`/`Description`, `slowConnectionErrorTitle`/`Description`, `genericErrorTitle`/`Description`) for all supported locales.
+
 ## 10.2.0
 
 ✅ Added

--- a/packages/stream_chat_localizations/example/lib/add_new_lang.dart
+++ b/packages/stream_chat_localizations/example/lib/add_new_lang.dart
@@ -339,6 +339,24 @@ class NnStreamChatLocalizations extends GlobalStreamChatLocalizations {
   String get tryAgainLabel => 'Try Again';
 
   @override
+  String get connectionErrorTitle => 'No Internet Connection';
+
+  @override
+  String get connectionErrorDescription => 'Please check your internet connection';
+
+  @override
+  String get slowConnectionErrorTitle => 'Slow Internet Connection';
+
+  @override
+  String get slowConnectionErrorDescription => 'There seems to be a problem with your internet connection';
+
+  @override
+  String get genericErrorTitle => 'Error';
+
+  @override
+  String get genericErrorDescription => 'Oops, something went wrong';
+
+  @override
   String membersCountText(int count) {
     if (count == 1) return '1 Member';
     return '$count Members';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
@@ -186,6 +186,24 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Alguna cosa ha anat malament';
 
   @override
+  String get connectionErrorTitle => 'Sense connexió a Internet';
+
+  @override
+  String get connectionErrorDescription => 'Comprova la teva connexió a Internet';
+
+  @override
+  String get slowConnectionErrorTitle => 'Connexió a Internet lenta';
+
+  @override
+  String get slowConnectionErrorDescription => 'Sembla que hi ha un problema amb la teva connexió a Internet';
+
+  @override
+  String get genericErrorTitle => 'Error';
+
+  @override
+  String get genericErrorDescription => 'Vaja, alguna cosa ha anat malament';
+
+  @override
   String get addMoreFilesLabel => 'Afegir més';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -180,6 +180,24 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Etwas ist schief gelaufen';
 
   @override
+  String get connectionErrorTitle => 'Keine Internetverbindung';
+
+  @override
+  String get connectionErrorDescription => 'Bitte überprüfe deine Internetverbindung';
+
+  @override
+  String get slowConnectionErrorTitle => 'Langsame Internetverbindung';
+
+  @override
+  String get slowConnectionErrorDescription => 'Es scheint ein Problem mit deiner Internetverbindung zu geben';
+
+  @override
+  String get genericErrorTitle => 'Fehler';
+
+  @override
+  String get genericErrorDescription => 'Hoppla, etwas ist schief gelaufen';
+
+  @override
   String get addMoreFilesLabel => 'Mehr hinzufügen';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -185,6 +185,24 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Something went wrong';
 
   @override
+  String get connectionErrorTitle => 'No Internet Connection';
+
+  @override
+  String get connectionErrorDescription => 'Please check your internet connection';
+
+  @override
+  String get slowConnectionErrorTitle => 'Slow Internet Connection';
+
+  @override
+  String get slowConnectionErrorDescription => 'There seems to be a problem with your internet connection';
+
+  @override
+  String get genericErrorTitle => 'Error';
+
+  @override
+  String get genericErrorDescription => 'Oops, something went wrong';
+
+  @override
   String get addMoreFilesLabel => 'Add more';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
@@ -186,6 +186,24 @@ class StreamChatLocalizationsEs extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Algo ha salido mal';
 
   @override
+  String get connectionErrorTitle => 'Sin conexión a Internet';
+
+  @override
+  String get connectionErrorDescription => 'Comprueba tu conexión a Internet';
+
+  @override
+  String get slowConnectionErrorTitle => 'Conexión a Internet lenta';
+
+  @override
+  String get slowConnectionErrorDescription => 'Parece que hay un problema con tu conexión a Internet';
+
+  @override
+  String get genericErrorTitle => 'Error';
+
+  @override
+  String get genericErrorDescription => 'Vaya, algo ha salido mal';
+
+  @override
   String get addMoreFilesLabel => 'Añadir más';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -186,6 +186,24 @@ class StreamChatLocalizationsFr extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Quelque chose a mal tourné';
 
   @override
+  String get connectionErrorTitle => 'Pas de connexion Internet';
+
+  @override
+  String get connectionErrorDescription => 'Veuillez vérifier votre connexion Internet';
+
+  @override
+  String get slowConnectionErrorTitle => 'Connexion Internet lente';
+
+  @override
+  String get slowConnectionErrorDescription => 'Il semble y avoir un problème avec votre connexion Internet';
+
+  @override
+  String get genericErrorTitle => 'Erreur';
+
+  @override
+  String get genericErrorDescription => 'Oups, quelque chose a mal tourné';
+
+  @override
   String get addMoreFilesLabel => 'Ajouter plus';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -185,6 +185,24 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'लोड करने में समस्या';
 
   @override
+  String get connectionErrorTitle => 'इंटरनेट कनेक्शन नहीं है';
+
+  @override
+  String get connectionErrorDescription => 'कृपया अपना इंटरनेट कनेक्शन जांचें';
+
+  @override
+  String get slowConnectionErrorTitle => 'धीमा इंटरनेट कनेक्शन';
+
+  @override
+  String get slowConnectionErrorDescription => 'ऐसा लगता है कि आपके इंटरनेट कनेक्शन में कोई समस्या है';
+
+  @override
+  String get genericErrorTitle => 'त्रुटि';
+
+  @override
+  String get genericErrorDescription => 'ओह, कुछ गलत हो गया';
+
+  @override
   String get addMoreFilesLabel => 'और जोड़ें';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -190,6 +190,24 @@ Il file è troppo grande per essere caricato. Il limite è di $limitInMB MB.''';
   String get somethingWentWrongError => 'Qualcosa è andato storto';
 
   @override
+  String get connectionErrorTitle => 'Nessuna connessione a Internet';
+
+  @override
+  String get connectionErrorDescription => 'Controlla la tua connessione a Internet';
+
+  @override
+  String get slowConnectionErrorTitle => 'Connessione a Internet lenta';
+
+  @override
+  String get slowConnectionErrorDescription => 'Sembra esserci un problema con la tua connessione a Internet';
+
+  @override
+  String get genericErrorTitle => 'Errore';
+
+  @override
+  String get genericErrorDescription => 'Ops, qualcosa è andato storto';
+
+  @override
   String get addMoreFilesLabel => 'Aggiungi altri';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
@@ -179,6 +179,24 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'エラーが発生しました';
 
   @override
+  String get connectionErrorTitle => 'インターネット接続がありません';
+
+  @override
+  String get connectionErrorDescription => 'インターネット接続を確認してください';
+
+  @override
+  String get slowConnectionErrorTitle => 'インターネット接続が遅いです';
+
+  @override
+  String get slowConnectionErrorDescription => 'インターネット接続に問題があるようです';
+
+  @override
+  String get genericErrorTitle => 'エラー';
+
+  @override
+  String get genericErrorDescription => 'おっと、問題が発生しました';
+
+  @override
   String get addMoreFilesLabel => 'さらに追加';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
@@ -179,6 +179,24 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => '뭔가 잘못됐습느다';
 
   @override
+  String get connectionErrorTitle => '인터넷 연결 없음';
+
+  @override
+  String get connectionErrorDescription => '인터넷 연결을 확인해 주세요';
+
+  @override
+  String get slowConnectionErrorTitle => '인터넷 연결이 느림';
+
+  @override
+  String get slowConnectionErrorDescription => '인터넷 연결에 문제가 있는 것 같습니다';
+
+  @override
+  String get genericErrorTitle => '오류';
+
+  @override
+  String get genericErrorDescription => '앗, 문제가 발생했습니다';
+
+  @override
   String get addMoreFilesLabel => '더 추가';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
@@ -181,6 +181,24 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Noe gikk galt';
 
   @override
+  String get connectionErrorTitle => 'Ingen internettforbindelse';
+
+  @override
+  String get connectionErrorDescription => 'Sjekk internettforbindelsen din';
+
+  @override
+  String get slowConnectionErrorTitle => 'Treg internettforbindelse';
+
+  @override
+  String get slowConnectionErrorDescription => 'Det ser ut til å være et problem med internettforbindelsen din';
+
+  @override
+  String get genericErrorTitle => 'Feil';
+
+  @override
+  String get genericErrorDescription => 'Oi, noe gikk galt';
+
+  @override
   String get addMoreFilesLabel => 'Legg til flere';
 
   @override

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -183,6 +183,24 @@ class StreamChatLocalizationsPt extends GlobalStreamChatLocalizations {
   String get somethingWentWrongError => 'Algo deu errado';
 
   @override
+  String get connectionErrorTitle => 'Sem conexão com a Internet';
+
+  @override
+  String get connectionErrorDescription => 'Verifique sua conexão com a Internet';
+
+  @override
+  String get slowConnectionErrorTitle => 'Conexão com a Internet lenta';
+
+  @override
+  String get slowConnectionErrorDescription => 'Parece haver um problema com sua conexão com a Internet';
+
+  @override
+  String get genericErrorTitle => 'Erro';
+
+  @override
+  String get genericErrorDescription => 'Ops, algo deu errado';
+
+  @override
   String get addMoreFilesLabel => 'Adicionar mais';
 
   @override

--- a/packages/stream_chat_localizations/test/translations_test.dart
+++ b/packages/stream_chat_localizations/test/translations_test.dart
@@ -162,6 +162,12 @@ void main() {
       expect(localizations.searchingForNetworkText, isNotNull);
       expect(localizations.offlineLabel, isNotNull);
       expect(localizations.tryAgainLabel, isNotNull);
+      expect(localizations.connectionErrorTitle, isNotNull);
+      expect(localizations.connectionErrorDescription, isNotNull);
+      expect(localizations.slowConnectionErrorTitle, isNotNull);
+      expect(localizations.slowConnectionErrorDescription, isNotNull);
+      expect(localizations.genericErrorTitle, isNotNull);
+      expect(localizations.genericErrorDescription, isNotNull);
       // 1 member
       expect(localizations.membersCountText(1), isNotNull);
       // 3 members


### PR DESCRIPTION
## FLU-628

Raw `StreamChannel` initialization errors — and the default list/scroll-view error states — were leaking unthemed, unlocalized error details to end users. This routes them through themed, localized, **connection-aware** default states (no internet / slow connection / generic), overridable at every level.

### What changed

**`stream_chat`**
- Add `StreamChatNetworkError.type` (`StreamChatNetworkErrorType`) exposing the transport failure kind; deprecate `isRequestCancelledError` in favor of `type == StreamChatNetworkErrorType.cancel`.
- A *failed* channel initialization no longer leaves `Channel.initialized` errored or its `name`/`image`/`extraData` setters throwing — a subsequent successful (re)init recovers cleanly (supports the retry flow).
- Clearer `toString()` for `StreamWebSocketError` / `StreamChatNetworkError`.

**`stream_chat_flutter_core`**
- Add `StreamChannelState.retry()` to re-run a failed channel init (the retry action for `StreamChannel.errorBuilder`).
- Add `DefaultStreamChannelBuilders`, an inherited widget supplying default loading/error builders to descendant `StreamChannel`s.
- The default `StreamChannel` error state no longer exposes raw error details.

**`stream_chat_flutter`**
- `StreamChat` now installs themed, connection-aware default loading & error states for `StreamChannel` — overridable per-`StreamChannel` or via `DefaultStreamChannelBuilders`.
- Default list/scroll-view error states (channel, message, member, user, thread, poll-vote, reaction, search, photo) are now connection-aware, falling back to each view's specific error text.
- `StreamScrollViewErrorWidget` gains `errorSubtitle`; `StreamScrollViewLoadingWidget` gains `size` (`StreamLoadingSpinnerSize`) and deprecates the now-unused `height`/`width`.

**`stream_chat_localizations`**
- New connection-error strings (`connectionError*`, `slowConnectionError*`, `genericError*`) for all supported locales.

### Testing
- All four touched package suites pass; `dart analyze --fatal-infos` clean.
- New tests cover the default channel error/loading states, the retry-clears-stale-error flow, and full localization coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Try Again” retry support for failed channel initialization.
  * Introduced default themed channel loading/error builders (connection-aware).
  * Added network error text resolution with localized connection/slow-connection/generic copy.
  * Added loading spinner sizing and optional error subtitles.
  * Added transport error classification to improve error display.
* **Bug Fixes**
  * Improved channel initialization/retry behavior and watcher state consistency.
  * Error UI now stays safe (no raw error leakage) while showing clearer, connection-specific guidance.
* **Deprecations**
  * Deprecated older cancellation flag, some loading widget sizing parameters, and a reaction picker callback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->