### PR TITLE
feat(ci): Add opt-in offline persistence for E2E tests

### DIFF
--- a/sample_app/integration_test/support/stream_test_case.dart
+++ b/sample_app/integration_test/support/stream_test_case.dart
@@ -72,6 +72,7 @@ void streamTestWithEnv({
   required String description,
   required Future<void> Function(StreamTestEnv env) body,
   String? skip,
+  bool persistence = false,
 }) {
   streamTest(
     allureId: allureId,
@@ -82,7 +83,7 @@ void streamTestWithEnv({
       // Registered before setUp so cleanup also runs when setup fails partway
       // (e.g. the mock server started but the app failed to boot).
       addTearDown(env.tearDown);
-      await env.setUp(tester);
+      await env.setUp(tester, persistence: persistence);
       await body(env);
     },
   );

--- a/sample_app/integration_test/support/stream_test_env.dart
+++ b/sample_app/integration_test/support/stream_test_env.dart
@@ -23,7 +23,7 @@ class StreamTestEnv {
   final _connectivity = StreamController<List<ConnectivityResult>>.broadcast();
   var _connectivityPrimed = false;
 
-  Future<void> setUp(WidgetTester tester) async {
+  Future<void> setUp(WidgetTester tester, {bool persistence = false}) async {
     _tester = tester;
     final server = _mockServer = await MockServer.start();
     backendRobot = BackendRobot(server);
@@ -34,6 +34,7 @@ class StreamTestEnv {
       ..debugConnectionOverride = StreamConnectionOverride(
         baseURL: server.url,
         baseWsUrl: server.wsUrl,
+        usePersistence: persistence,
       )
       ..debugConnectivityStream = _connectivity.stream;
 

--- a/sample_app/lib/auth/auth_controller.dart
+++ b/sample_app/lib/auth/auth_controller.dart
@@ -45,10 +45,15 @@ Future<void> _sampleAppLogHandler(LogRecord record) async {
 
 @visibleForTesting
 class StreamConnectionOverride {
-  const StreamConnectionOverride({this.baseURL, this.baseWsUrl});
+  const StreamConnectionOverride({
+    this.baseURL,
+    this.baseWsUrl,
+    this.usePersistence = false,
+  });
 
   final String? baseURL;
   final String? baseWsUrl;
+  final bool usePersistence;
 }
 
 StreamChatClient _buildStreamChatClient(
@@ -73,12 +78,14 @@ StreamChatClient _buildStreamChatClient(
       // debugConnectivityStream). See `AuthController.debugForceOffline`.
       chatApiInterceptors: connectionOverride != null ? [_offlineSimulationInterceptor] : null,
     )
-    // No offline persistence under e2e. The persistence client is a shared,
-    // never-cleared SQLite DB, so state leaks across the tests in a bundle and
-    // a reaction event referencing an unpersisted message throws an async
-    // FOREIGN KEY error — which, being async, poisons the shared test binding
-    // and makes every remaining test in the file fail before it can report.
-    ..chatPersistenceClient = connectionOverride != null ? null : _chatPersistenceClient;
+    ..chatPersistenceClient = switch (connectionOverride) {
+      // Production always persists.
+      null => _chatPersistenceClient,
+      // Under e2e, persistence is opt-in per test; the harness empties the DB
+      // on teardown (see AuthController.debugReset) so it can't leak between
+      // tests. Off by default keeps most e2e tests fast and DB-free.
+      final override => override.usePersistence ? _chatPersistenceClient : null,
+    };
 }
 
 /// Rejects every Stream API request with a connection error while
@@ -263,6 +270,8 @@ class AuthController extends ValueNotifier<AuthState> {
     _pushTokenManager?.dispose().ignore();
     _pushTokenManager = null;
 
+    // dispose() won't flush; empty the DB so it can't leak to the next test.
+    await _client?.closePersistenceConnection(flush: true);
     await _client?.dispose();
     _client = null;
     _activeApiKey = null;


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-643

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
- Adds `persistence` opt-in flag on the `streamTestWithEnv`: When **on** - wires a `StreamChatPersistenceClient` in the `ChatClient` undergoing the test
- Clears the DB on test cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistence controls for stream connection setups.
  * Persistence can now be enabled for applicable integration test environments.

* **Bug Fixes**
  * Improved handling of chat persistence when connection overrides are used.
  * Reset actions now flush and clear persisted chat state for a cleaner restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->