### PR TITLE
fix(llc): Ignore events dispatched after the client is disposed

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed watchers not being removed from `ChannelClientState.watchers` on `user.watching.stop`.
 - Fixed `Channel.name`/`image`/`extraData` setters throwing after a *failed* initialization; they now only throw once the channel is successfully initialized.
 - Fixed `Channel.initialized` staying errored after a failed init; it now reflects a subsequent successful (re)initialization.
+- Fixed a `StateError` (`Cannot add new events after calling close`) thrown when the client is disposed while a reconnect recovery is still in flight.
 
 ## 10.2.0
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -576,11 +576,14 @@ class StreamChatClient {
 
   /// Method called to add a new event to the [_eventController].
   void handleEvent(Event event) {
+    // Ignore events that arrive after the client has been disposed.
+    if (_eventController.isClosed) return;
+
     if (event.type == EventType.healthCheck) {
       return _handleHealthCheckEvent(event);
     }
     state.updateUser(event.user);
-    return _eventController.add(event);
+    return _eventController.safeAdd(event);
   }
 
   void _onConnectionStatusChanged(

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values, lines_longer_than_80_chars
 
+import 'dart:async';
+
 import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat/src/core/http/token.dart';
 import 'package:stream_chat/stream_chat.dart';
@@ -5420,6 +5422,83 @@ void main() {
           paginationParams: any(named: 'paginationParams'),
         ),
       ).called(1);
+    });
+  });
+
+  group('dispose during reconnect recovery', () {
+    const apiKey = 'test-api-key';
+    final user = User(id: 'test-user-id');
+    final token = Token.development(user.id).rawValue;
+
+    late FakeChatApi api;
+    late FakeWebSocket ws;
+    late StreamChatClient client;
+    var disposed = false;
+
+    setUpAll(() {
+      registerFallbackValue(const PaginationParams());
+      registerFallbackValue(Filter.equal('cid', ''));
+    });
+
+    setUp(() {
+      api = FakeChatApi();
+      ws = FakeWebSocket();
+      disposed = false;
+    });
+
+    // The test disposes the client itself; avoid disposing it a second time.
+    tearDown(() async {
+      if (!disposed) await client.dispose();
+    });
+
+    // Disposing the client while a reconnect is still recovering must complete
+    // cleanly: recovery work that finishes after disposal is discarded, never
+    // surfacing as an error.
+    test('disposing mid-recovery does not surface a late recovery event', () async {
+      // Keep the recovery's channel query pending so the client is still
+      // mid-recovery at the moment it is disposed.
+      final pendingQuery = Completer<QueryChannelsResponse>();
+      when(
+        () => api.channel.queryChannels(
+          filter: any(named: 'filter'),
+          sort: any(named: 'sort'),
+          state: any(named: 'state'),
+          watch: any(named: 'watch'),
+          presence: any(named: 'presence'),
+          memberLimit: any(named: 'memberLimit'),
+          messageLimit: any(named: 'messageLimit'),
+          paginationParams: any(named: 'paginationParams'),
+        ),
+      ).thenAnswer((_) => pendingQuery.future);
+
+      client = StreamChatClient(apiKey, chatApi: api, ws: ws);
+      await client.connectUser(user, token);
+      await delay(300);
+
+      // Track a channel so reconnecting triggers channel recovery, which then
+      // blocks on the pending query above.
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+
+      // Drop then restore the connection to start a reconnect recovery.
+      ws.connectionStatus = ConnectionStatus.disconnected;
+      await delay(100);
+      ws.connectionStatus = ConnectionStatus.connected;
+      await delay(100);
+
+      // Dispose while the recovery is still in flight.
+      await client.dispose();
+      disposed = true;
+
+      // Let the now-orphaned recovery finish. Its trailing work must be
+      // discarded silently instead of thrown as an unhandled async error.
+      pendingQuery.complete(QueryChannelsResponse()..channels = []);
+      await delay(300);
+
+      expect(client.wsConnectionStatus, ConnectionStatus.disconnected);
     });
   });
 


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-658

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`StreamChatClient.handleEvent` could throw `StateError: Cannot add new events after calling close` when the client is disposed while a **reconnect recovery** was still in flight.

### Root cause

`_onConnectionStatusChanged` is `async`. On an offline→online transition it awaits a recovery pipeline (`sync` / `queryChannelsOnline`) and only then emits the final `connectionRecovered` event. The driving subscription is fire-and-forget (`wsConnectionStatusStream.pairwise().listen(...)`). If `dispose()` closes `_eventController` while that continuation is suspended on an `await`, the trailing `handleEvent(connectionRecovered)` adds to a **closed** controller — surfacing as an unhandled async error (zone / `PlatformDispatcher.onError` / Crashlytics).

This is pre-existing on `master`; it was surfaced by the offline-reactions E2E test (`user adds a reaction while offline`) on #2847, where the Android emulator's slower timing loses the race deterministically.

### Fix

Guard `handleEvent` against a closed controller:

```dart
void handleEvent(Event event) {
  // Ignore events that arrive after the client has been disposed.
  if (_eventController.isClosed) return;
  ...
}
```

`_eventController.isClosed` is terminal and set only in `dispose()`; `disconnectUser()` (logout→login reuse) leaves it open, so live/reused clients are unaffected. Post-`close()` the broadcast stream is already complete, so no consumer ever received these events — the guard removes only the internal throw, not any delivery.

### Test instructions

A new regression test in `client_test.dart` (`dispose during reconnect recovery`) disposes the client while a reconnect recovery is suspended on a held-open `queryChannels`, then resumes it — reproducing the exact CI stack. Red without the guard, green with it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a `StateError` when disposing the client while reconnect recovery is still in progress.
  * Ensured reconnect recovery can complete without emitting late events or errors after disposal.
* **Tests**
  * Added a new test covering disposal during in-flight reconnect recovery, verifying the client remains disconnected with no late recovery propagation.
* **Documentation**
  * Updated the changelog to include the reconnect recovery disposal fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->