### PR TITLE
fix(ui): attachment picker type without label

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed the default `StreamChannel` loading and error states not being themed or localized; `StreamChat` now installs themed, connection-aware defaults, overridable per `StreamChannel` or via `DefaultStreamChannelBuilders`.
 - Fixed the default list/scroll-view error states (channel, message, member, user, thread, poll-vote, reaction, search, and photo) showing raw or fixed errors; they are now connection-aware (no internet / slow connection), falling back to each view's specific error text.
 - Fixed `StreamTypingIndicator` briefly showing typing users from a different context (main channel vs. thread) on its first frame.
+- Fixed the attachment picker throwing a `Tooltip` assertion error when a custom `TabbedAttachmentPickerOption` is added without a `title`; the tooltip is now only shown when a title is provided.
 
 ## 10.2.0
 

--- a/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/attachment_picker/stream_attachment_picker.dart
@@ -202,6 +202,25 @@ class _TabbedAttachmentPickerOptions extends StatelessWidget {
                       _ => null,
                     };
 
+                    Widget button = StreamButton.icon(
+                      style: StreamButtonStyle.secondary,
+                      type: StreamButtonType.ghost,
+                      size: StreamButtonSize.large,
+                      onPressed: onPressed,
+                      isSelected: isSelected,
+                      autofocus: isSelected,
+                      icon: Icon(option.icon),
+                    );
+
+                    // Only show a tooltip if the option provides a title.
+                    if (option.title case final title?) {
+                      button = Tooltip(
+                        message: title,
+                        excludeFromSemantics: true,
+                        child: button,
+                      );
+                    }
+
                     return MergeSemantics(
                       child: Semantics(
                         label: option.title,
@@ -209,19 +228,7 @@ class _TabbedAttachmentPickerOptions extends StatelessWidget {
                         role: SemanticsRole.tab,
                         child: Stack(
                           children: [
-                            Tooltip(
-                              message: option.title,
-                              excludeFromSemantics: true,
-                              child: StreamButton.icon(
-                                style: StreamButtonStyle.secondary,
-                                type: StreamButtonType.ghost,
-                                size: StreamButtonSize.large,
-                                onPressed: onPressed,
-                                isSelected: isSelected,
-                                autofocus: isSelected,
-                                icon: Icon(option.icon),
-                              ),
-                            ),
+                            button,
                             Semantics(
                               label: localizations.tabLabel(
                                 tabIndex: index + 1,

--- a/packages/stream_chat_flutter/test/src/message_input/attachment_picker/stream_attachment_picker_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_input/attachment_picker/stream_attachment_picker_test.dart
@@ -118,6 +118,52 @@ void main() {
           expect(tester.takeException(), isA<ArgumentError>());
         },
       );
+
+      testWidgets(
+        'should allow adding a custom option without a title',
+        (tester) async {
+          final controller = StreamAttachmentPickerController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            _wrapWithStreamChatApp(
+              Builder(
+                builder: (context) {
+                  return SizedBox(
+                    height: 400,
+                    child: tabbedAttachmentPickerBuilder(
+                      context: context,
+                      controller: controller,
+                      allowedTypes: [
+                        ...AttachmentPickerType.values,
+                        const _TestPickerType(),
+                      ],
+                      optionsBuilder: (context, defaultOptions) {
+                        return [
+                          ...defaultOptions,
+                          TabbedAttachmentPickerOption(
+                            key: 'untitled',
+                            icon: Icons.pin_drop,
+                            supportedTypes: const [_TestPickerType()],
+                            optionViewBuilder: (context, controller) {
+                              return const Text('Untitled option');
+                            },
+                          ),
+                        ];
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(find.byIcon(Icons.pin_drop), findsOneWidget);
+        },
+      );
     });
 
     group('allowedTypes', () {
@@ -309,6 +355,10 @@ void main() {
       );
     });
   });
+}
+
+final class _TestPickerType extends CustomAttachmentPickerType {
+  const _TestPickerType();
 }
 
 Widget _wrapWithStreamChatApp(

--- a/sample_app/lib/pages/channel_page.dart
+++ b/sample_app/lib/pages/channel_page.dart
@@ -135,6 +135,7 @@ class _ChannelPageState extends State<ChannelPage> {
                   if (locationEnabled)
                     TabbedAttachmentPickerOption(
                       key: 'location-picker',
+                      title: 'Location',
                       icon: context.streamIcons.location,
                       supportedTypes: [const LocationPickerType()],
                       isEnabled: (value) {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
I was testing location sharing attachment, but it was failing because the location attachment type did not have a title.
This PR fixes 2 things. It adds a title in the sample_app and fixes the crash when there is no title.

## Screenshots / Videos

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/8e02e0e4-5b93-40fe-96b3-ef74f8a10308" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an assertion error when using attachment picker tabs without a title.
  * Tooltips now appear only for tabs with a provided title.
  * Custom untitled attachment options continue to display their icons correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->