### PR TITLE
chore(repo): don't run e2e ios tests on pr's

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -2,6 +2,15 @@ name: E2E Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      android:
+        description: "Run Android e2e tests"
+        type: boolean
+        default: true
+      ios:
+        description: "Run iOS e2e tests"
+        type: boolean
+        default: true
   pull_request:
 
 permissions:
@@ -18,6 +27,8 @@ env:
 
 jobs:
   android:
+    # Always on pull_request; opt-out via the checkbox on workflow_dispatch.
+    if: github.event_name != 'workflow_dispatch' || inputs.android
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -80,6 +91,8 @@ jobs:
             sample_app/build/e2e-test.log
 
   ios:
+    # Only on workflow_dispatch, when the checkbox is ticked.
+    if: github.event_name == 'workflow_dispatch' && inputs.ios
     runs-on: macos-15
     timeout-minutes: 40
     env:


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This disables the iOS e2e workflow by default, but can still be used with workflow_dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual workflow controls for selecting Android and iOS end-to-end test runs.
  * Android tests continue to run automatically for pull requests and can be skipped during manual runs.
  * iOS tests can be enabled for manual workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->