### PR TITLE
fix(llc): keep reaction group while its count stays positive

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed `Channel.initialized` staying errored after a failed init; it now reflects a subsequent successful (re)initialization.
 - `ComparableField` now folds diacritics/ligatures and ignores case when comparing strings, so `SortOption` on fields like `name` no longer pushes lowercase or non-ASCII names (`jhon`, `Łukasz`, `Øystein`) to the end of client-sorted lists ([#2601](https://github.com/GetStream/stream-chat-flutter/issues/2601)).
 - Fixed `message.updated` and soft `message.deleted` events being incorrectly upserted into `ChannelState.messages` (and thread reply lists) when they targeted a message outside the currently loaded window.
+- Fixed `Message.deleteMyReaction` dropping an entire reaction group when its summed scores reached zero even though other users' reactions kept the count positive; the group is now retained as long as its count stays above zero.
 
 ## 9.26.0
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `ComparableField` now folds diacritics/ligatures and ignores case when comparing strings, so `SortOption` on fields like `name` no longer pushes lowercase or non-ASCII names (`jhon`, `Łukasz`, `Øystein`) to the end of client-sorted lists ([#2601](https://github.com/GetStream/stream-chat-flutter/issues/2601)).
 - Fixed `message.updated` and soft `message.deleted` events being incorrectly upserted into `ChannelState.messages` (and thread reply lists) when they targeted a message outside the currently loaded window.
 - Fixed `Message.deleteMyReaction` dropping an entire reaction group when its summed scores reached zero even though other users' reactions kept the count positive; the group is now retained as long as its count stays above zero.
+- Fixed reaction groups derived from legacy `reaction_counts`/`reaction_scores` payloads being discarded when their score total was zero or negative despite a positive count.
 
 ## 9.26.0
 

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -159,7 +159,8 @@ class Message extends Equatable implements ComparableFieldProvider {
       final count = reactionCounts?[type] ?? 0;
       final sumScores = reactionScores?[type] ?? 0;
 
-      if (count == 0 || sumScores == 0) continue;
+      // Keep the group while count is positive; score may be zero or negative.
+      if (count == 0) continue;
       groups[type] = ReactionGroup(count: count, sumScores: sumScores);
     }
 
@@ -914,13 +915,7 @@ extension MessageReactionHelper on Message {
       final group = reactionGroups.remove(type);
       if (group == null) continue;
 
-      // Update the reaction group.
-      //
-      // The group exists as long as at least one reaction remains, mirroring
-      // the backend which derives groups from the reaction count alone. The
-      // score is an independent aggregate and must not gate the group, else a
-      // group whose scores net to zero would be dropped while its count (and
-      // thus other users' reactions) is still positive.
+      // Keep the group while count is positive; score may be zero or negative.
       final updatedCount = group.count - 1;
       final updatedSumScores = group.sumScores - reaction.score;
 

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -160,7 +160,7 @@ class Message extends Equatable implements ComparableFieldProvider {
       final sumScores = reactionScores?[type] ?? 0;
 
       // Keep the group while count is positive; score may be zero or negative.
-      if (count == 0) continue;
+      if (count <= 0) continue;
       groups[type] = ReactionGroup(count: count, sumScores: sumScores);
     }
 

--- a/packages/stream_chat/lib/src/core/models/message.dart
+++ b/packages/stream_chat/lib/src/core/models/message.dart
@@ -915,10 +915,16 @@ extension MessageReactionHelper on Message {
       if (group == null) continue;
 
       // Update the reaction group.
+      //
+      // The group exists as long as at least one reaction remains, mirroring
+      // the backend which derives groups from the reaction count alone. The
+      // score is an independent aggregate and must not gate the group, else a
+      // group whose scores net to zero would be dropped while its count (and
+      // thus other users' reactions) is still positive.
       final updatedCount = group.count - 1;
       final updatedSumScores = group.sumScores - reaction.score;
 
-      if (updatedCount > 0 && updatedSumScores > 0) {
+      if (updatedCount > 0) {
         reactionGroups[type] = group.copyWith(
           count: updatedCount,
           sumScores: updatedSumScores,

--- a/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
@@ -364,6 +364,51 @@ void main() {
         // Should have updated the reaction group counts
         expect(updatedMessage.reactionGroups, isEmpty);
       });
+
+      test('should keep reaction group when count remains after sumScores '
+          'reaches zero', () {
+        // Own reaction with a score that cancels out the group total, leaving
+        // sumScores at 0 while another user's reaction keeps count positive.
+        final ownReaction = Reaction(
+          type: 'like',
+          score: 0,
+          user: testUser,
+          userId: testUser.id,
+          messageId: emptyMessage.id,
+        );
+
+        final otherUser = User(id: 'other-user-id');
+        final otherReaction = Reaction(
+          type: 'like',
+          score: 0,
+          user: otherUser,
+          userId: otherUser.id,
+          messageId: emptyMessage.id,
+        );
+
+        final messageWithReactions = emptyMessage.copyWith(
+          ownReactions: [ownReaction],
+          latestReactions: [ownReaction, otherReaction],
+          reactionGroups: {
+            'like': ReactionGroup(
+              count: 2,
+              sumScores: 0,
+              firstReactionAt: ownReaction.createdAt,
+              lastReactionAt: otherReaction.createdAt,
+            ),
+          },
+        );
+
+        final updatedMessage = messageWithReactions.deleteMyReaction();
+
+        // The group must survive because another user's reaction remains, even
+        // though the summed scores are zero.
+        expect(updatedMessage.reactionGroups!.length, 1);
+        expect(updatedMessage.reactionGroups!['like']!.count, 1);
+        expect(updatedMessage.reactionGroups!['like']!.sumScores, 0);
+        expect(updatedMessage.latestReactions!.length, 1);
+        expect(updatedMessage.latestReactions!.first.userId, otherUser.id);
+      });
     });
   });
 }

--- a/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
@@ -365,7 +365,8 @@ void main() {
         expect(updatedMessage.reactionGroups, isEmpty);
       });
 
-      test('should keep reaction group with non-positive score sum while '
+      test(
+          'should keep reaction group with non-positive score sum while '
           'count remains positive', () {
         // A positively-scored own reaction and a negatively-scored reaction
         // from another user net the group score to zero while count is 2.

--- a/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_reaction_helper_test.dart
@@ -365,13 +365,13 @@ void main() {
         expect(updatedMessage.reactionGroups, isEmpty);
       });
 
-      test('should keep reaction group when count remains after sumScores '
-          'reaches zero', () {
-        // Own reaction with a score that cancels out the group total, leaving
-        // sumScores at 0 while another user's reaction keeps count positive.
+      test('should keep reaction group with non-positive score sum while '
+          'count remains positive', () {
+        // A positively-scored own reaction and a negatively-scored reaction
+        // from another user net the group score to zero while count is 2.
         final ownReaction = Reaction(
           type: 'like',
-          score: 0,
+          score: 1,
           user: testUser,
           userId: testUser.id,
           messageId: emptyMessage.id,
@@ -380,7 +380,7 @@ void main() {
         final otherUser = User(id: 'other-user-id');
         final otherReaction = Reaction(
           type: 'like',
-          score: 0,
+          score: -1,
           user: otherUser,
           userId: otherUser.id,
           messageId: emptyMessage.id,
@@ -402,10 +402,10 @@ void main() {
         final updatedMessage = messageWithReactions.deleteMyReaction();
 
         // The group must survive because another user's reaction remains, even
-        // though the summed scores are zero.
+        // though the remaining summed score is negative.
         expect(updatedMessage.reactionGroups!.length, 1);
         expect(updatedMessage.reactionGroups!['like']!.count, 1);
-        expect(updatedMessage.reactionGroups!['like']!.sumScores, 0);
+        expect(updatedMessage.reactionGroups!['like']!.sumScores, -1);
         expect(updatedMessage.latestReactions!.length, 1);
         expect(updatedMessage.latestReactions!.first.userId, otherUser.id);
       });

--- a/packages/stream_chat/test/src/core/models/message_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_test.dart
@@ -307,6 +307,25 @@ void main() {
           expect(message.reactionGroups!['love']!.sumScores, 5);
         },
       );
+
+      test(
+        'is derived from legacy reaction fields even when the score total is '
+        'zero or negative',
+        () {
+          final message = Message.fromJson(const {
+            'reaction_counts': {'like': 2, 'dislike': 3},
+            'reaction_scores': {'like': 0, 'dislike': -3},
+          });
+
+          // Both groups must be retained because their count is positive, even
+          // though the summed scores are zero and negative respectively.
+          expect(message.reactionGroups, isNotNull);
+          expect(message.reactionGroups!['like']!.count, 2);
+          expect(message.reactionGroups!['like']!.sumScores, 0);
+          expect(message.reactionGroups!['dislike']!.count, 3);
+          expect(message.reactionGroups!['dislike']!.sumScores, -3);
+        },
+      );
     });
   });
 

--- a/packages/stream_chat/test/src/core/models/message_test.dart
+++ b/packages/stream_chat/test/src/core/models/message_test.dart
@@ -312,10 +312,12 @@ void main() {
         'is derived from legacy reaction fields even when the score total is '
         'zero or negative',
         () {
-          final message = Message.fromJson(const {
-            'reaction_counts': {'like': 2, 'dislike': 3},
-            'reaction_scores': {'like': 0, 'dislike': -3},
-          });
+          final message = Message(
+            // ignore: deprecated_member_use_from_same_package
+            reactionCounts: const {'like': 2, 'dislike': 3},
+            // ignore: deprecated_member_use_from_same_package
+            reactionScores: const {'like': 0, 'dislike': -3},
+          );
 
           // Both groups must be retained because their count is positive, even
           // though the summed scores are zero and negative respectively.


### PR DESCRIPTION
Port of #2858 to `v9`.

## Summary

`Message` dropped an entire `ReactionGroup` in two places when a group's summed scores were **non-positive**, even though its `count` was still positive — so count-based reaction UIs lost other users' reactions:

1. **`deleteMyReaction`** (optimistic delete) kept a group only when `count > 0 && sumScores > 0`. A group whose scores net to zero/negative vanished during the optimistic delete until the next server event.
2. **`_maybeGetReactionGroups`** (derives groups from the deprecated `reactionCounts`/`reactionScores`) discarded a group when `sumScores == 0`, dropping a still-populated group.

## Root cause / backend alignment

The backend derives reaction groups from the `reactions` table via `count(type)` / `sum(score)` grouped by `(message_id, type)`. A group exists **iff at least one reaction row remains** (`count >= 1`); `sum(score)` is an independent aggregate that may legitimately be `0` or **negative** and never gates whether the group exists.

Both call sites now gate purely on the count.

## Changes

- `deleteMyReaction`: retain the group while `updatedCount > 0`.
- `_maybeGetReactionGroups`: retain the group while `count > 0` (guard `count <= 0` so a malformed negative count can't build an invalid group).
- Regression tests: realistic delete-path fixture (own `score: 1`, other `score: -1`) and a legacy-fields test (via the deprecated params) covering zero and negative score totals.
- `stream_chat` CHANGELOG entries.

## Testing

`flutter test test/src/core/models/message_test.dart test/src/core/models/message_reaction_helper_test.dart` — all pass.

Fixes FLU-663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
