### PR TITLE
feat(ui): add snackbar feedback for user actions

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a `size` (`StreamLoadingSpinnerSize`) parameter to `StreamScrollViewLoadingWidget`.
 - Added `onReactionTap` to `StreamMessageItem` and `StreamMessageListView`, reporting the tapped message's `BuildContext` and a `ReactionTapDetails` with the tapped `message` and `reaction` (the reaction is `null` for a clustered or overflow chip that maps to no single reaction).
 - Added an `unreadIndicator` parameter to `StreamBackButton` that overlays a widget (typically a `StreamUnreadIndicator`) on the button's top-end corner. Pass `StreamUnreadIndicator(excludeCid: cid)` to show the total unread count of other channels, or `StreamUnreadIndicator.channels(cid: cid)` for a single channel's count.
+- Added snackbar feedback for user actions: message copy, pin/unpin, delete, flag, mark unread, and mute/unmute user; ending a poll; audio-recording permission denial; and message send/edit failures (shown only when no `onError` handler is provided).
 
 ⚠️ Deprecated
 

--- a/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
@@ -152,7 +152,7 @@ class _DefaultStreamPollAttachmentState extends State<DefaultStreamPollAttachmen
               ),
               replace: true,
             );
-          } catch (_) {
+          } on Exception catch (_) {
             messenger?.show(
               StreamSnackbar(
                 message: Text(translations.endVoteErrorMessage),

--- a/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
@@ -146,18 +146,12 @@ class _DefaultStreamPollAttachmentState extends State<DefaultStreamPollAttachmen
           try {
             await channel.closePoll(poll);
             messenger?.show(
-              StreamSnackbar(
-                message: Text(translations.endVoteSuccessMessage),
-                variant: .success,
-              ),
+              StreamSnackbar(message: Text(translations.endVoteSuccessMessage), variant: .success),
               replace: true,
             );
           } on Exception catch (_) {
             messenger?.show(
-              StreamSnackbar(
-                message: Text(translations.endVoteErrorMessage),
-                variant: .error,
-              ),
+              StreamSnackbar(message: Text(translations.endVoteErrorMessage), variant: .error),
               replace: true,
             );
           }

--- a/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/poll_attachment.dart
@@ -9,6 +9,7 @@ import 'package:stream_chat_flutter/src/poll/stream_poll_comments_sheet.dart';
 import 'package:stream_chat_flutter/src/poll/stream_poll_options_sheet.dart';
 import 'package:stream_chat_flutter/src/poll/stream_poll_results_sheet.dart';
 import 'package:stream_chat_flutter/src/stream_chat.dart';
+import 'package:stream_chat_flutter/src/utils/extensions.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 import 'package:stream_core_flutter/chat.dart';
 
@@ -136,10 +137,30 @@ class _DefaultStreamPollAttachmentState extends State<DefaultStreamPollAttachmen
         final channel = StreamChannel.of(context).channel;
 
         Future<void> onEndVote() async {
+          final translations = context.translations;
+          final messenger = StreamSnackbarMessenger.maybeOf(context);
+
           final confirm = await showPollEndVoteDialog(context: context);
           if (confirm == null || !confirm) return;
 
-          channel.closePoll(poll).ignore();
+          try {
+            await channel.closePoll(poll);
+            messenger?.show(
+              StreamSnackbar(
+                message: Text(translations.endVoteSuccessMessage),
+                variant: .success,
+              ),
+              replace: true,
+            );
+          } catch (_) {
+            messenger?.show(
+              StreamSnackbar(
+                message: Text(translations.endVoteErrorMessage),
+                variant: .error,
+              ),
+              replace: true,
+            );
+          }
         }
 
         Future<void> onAddComment() async {

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -292,12 +292,12 @@ abstract class Translations {
   /// The text of an error shown when deleting a message fails
   String get deleteMessageError;
 
-  /// The text shown when a message is successfully pinned or unpinned
-  /// based on [pinned]
+  /// The text shown when a message is successfully pinned or unpinned, where
+  /// [pinned] is the message's resulting pinned state (`true` after a pin).
   String togglePinUnpinMessageSuccessText({required bool pinned});
 
-  /// The text of an error shown when pinning or unpinning a message fails
-  /// based on [pinned]
+  /// The text of an error shown when pinning or unpinning a message fails, where
+  /// [pinned] is the pinned state that was being applied (`true` for a pin).
   String togglePinUnpinMessageErrorText({required bool pinned});
 
   /// The text of an error shown when flagging a message fails

--- a/packages/stream_chat_flutter/lib/src/localization/translations.dart
+++ b/packages/stream_chat_flutter/lib/src/localization/translations.dart
@@ -286,6 +286,43 @@ abstract class Translations {
   /// The text of an error shown when marking a message as unread fails
   String get markUnreadError;
 
+  /// The text shown when a message is successfully marked as unread
+  String get messageMarkedAsUnreadText;
+
+  /// The text of an error shown when deleting a message fails
+  String get deleteMessageError;
+
+  /// The text shown when a message is successfully pinned or unpinned
+  /// based on [pinned]
+  String togglePinUnpinMessageSuccessText({required bool pinned});
+
+  /// The text of an error shown when pinning or unpinning a message fails
+  /// based on [pinned]
+  String togglePinUnpinMessageErrorText({required bool pinned});
+
+  /// The text of an error shown when flagging a message fails
+  String get flagMessageError;
+
+  /// The text shown when a message is copied to the clipboard
+  String get messageCopiedToClipboardText;
+
+  /// The text of an error shown when sending a message fails
+  String get sendMessageError;
+
+  /// The text of an error shown when editing a message fails
+  String get editMessageError;
+
+  /// The text shown when a [user] is successfully muted or unmuted
+  /// based on [isMuted]
+  String toggleMuteUnmuteUserSuccessText({
+    required String user,
+    required bool isMuted,
+  });
+
+  /// The text of an error shown when muting or unmuting a user fails
+  /// based on [isMuted]
+  String toggleMuteUnmuteUserErrorText({required bool isMuted});
+
   /// The text for showing delete/retry-delete based on [isDeleteFailed]
   String toggleDeleteRetryDeleteMessageText({required bool isDeleteFailed});
 
@@ -594,6 +631,12 @@ abstract class Translations {
   /// The label for "End Poll".
   String get endVoteLabel;
 
+  /// The text shown when a poll is successfully ended
+  String get endVoteSuccessMessage;
+
+  /// The text of an error shown when ending a poll fails
+  String get endVoteErrorMessage;
+
   /// The label for "Poll Results".
   String get pollResultsLabel;
 
@@ -637,6 +680,9 @@ abstract class Translations {
 
   /// The label for "Hold to record"
   String get holdToRecordLabel;
+
+  /// The message shown when audio recording permission is denied
+  String get audioRecordingPermissionMessage;
 
   /// The label for "Send Anyway"
   String get sendAnywayLabel;
@@ -1304,6 +1350,51 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
       ' newest 100 channel messages.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Message marked as unread';
+
+  @override
+  String get deleteMessageError => 'Error deleting message';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Message pinned';
+    return 'Message unpinned';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Error pinning message';
+    return 'Error removing message pin';
+  }
+
+  @override
+  String get flagMessageError => 'Error adding flag';
+
+  @override
+  String get messageCopiedToClipboardText => 'Message copied to clipboard';
+
+  @override
+  String get sendMessageError => 'Send message request failed';
+
+  @override
+  String get editMessageError => 'Edit message request failed';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({
+    required String user,
+    required bool isMuted,
+  }) {
+    if (isMuted) return '$user has been unmuted';
+    return '$user has been muted';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) return 'Error unmuting a user, please try again';
+    return 'Error muting a user, please try again';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Create a new poll';
     return 'Create Poll';
@@ -1458,6 +1549,12 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
   String get endVoteLabel => 'End Poll';
 
   @override
+  String get endVoteSuccessMessage => 'Poll ended';
+
+  @override
+  String get endVoteErrorMessage => 'Failed to end the poll';
+
+  @override
   String get pollResultsLabel => 'Poll Results';
 
   @override
@@ -1509,6 +1606,9 @@ Attachment limit exceeded: it's not possible to add more than $limit attachments
 
   @override
   String get holdToRecordLabel => 'Hold to record. Release to save.';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Please allow Audio permissions in settings.';
 
   @override
   String get sendAnywayLabel => 'Send Anyway';

--- a/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
@@ -72,6 +72,9 @@ class StreamAudioRecorderController extends ValueNotifier<AudioRecorderState>
         // recording session again to record audio.
         final granted = await _recorder.hasPermission(request: true);
         if (!granted && permissionDeniedMessage != null) {
+          // Cancel any pending info timer so it can't clear the denial message.
+          _infoTimer?.cancel();
+          _infoTimer = null;
           value = RecordStateIdle(message: permissionDeniedMessage);
         }
         return;

--- a/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/audio_recorder/audio_recorder_controller.dart
@@ -58,15 +58,22 @@ class StreamAudioRecorderController extends ValueNotifier<AudioRecorderState>
   final AudioRecorder _recorder;
 
   /// Starts a new recording session.
-  Future<void> startRecord() async {
+  ///
+  /// When audio permission is denied, [permissionDeniedMessage] (if provided) is
+  /// surfaced through [RecordStateIdle.message] so the message input can prompt
+  /// the user to grant access.
+  Future<void> startRecord({String? permissionDeniedMessage}) async {
     // Only start the recorder if it is currently idle.
     if (value case RecordStateIdle()) {
       // Return if the recorder does not have permission to record audio.
       final hasPermission = await _recorder.hasPermission(request: false);
       if (!hasPermission) {
-        /// Request permission to record audio.
-        /// User has to start the recording session again to record audio.
-        await _recorder.hasPermission(request: true);
+        // Request permission to record audio. The user has to start the
+        // recording session again to record audio.
+        final granted = await _recorder.hasPermission(request: true);
+        if (!granted && permissionDeniedMessage != null) {
+          value = RecordStateIdle(message: permissionDeniedMessage);
+        }
         return;
       }
 

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_chat_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_chat_message_input.dart
@@ -298,8 +298,14 @@ class _StreamChatMessageInputContent extends StatelessWidget {
           // Return if the recording is already started.
           if (audioRecorderController.isRecording) return;
 
+          // Capture the message before the async gap to avoid using a
+          // potentially unmounted BuildContext after awaiting.
+          final permissionDeniedMessage = context.translations.audioRecordingPermissionMessage;
+
           await widget.feedback.onRecordStart(context);
-          return audioRecorderController.startRecord();
+          return audioRecorderController.startRecord(
+            permissionDeniedMessage: permissionDeniedMessage,
+          );
         },
         onLongPressEnd: (_) async {
           // Return if the recording not yet started or already locked.

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_chat_message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_chat_message_input.dart
@@ -303,9 +303,7 @@ class _StreamChatMessageInputContent extends StatelessWidget {
           final permissionDeniedMessage = context.translations.audioRecordingPermissionMessage;
 
           await widget.feedback.onRecordStart(context);
-          return audioRecorderController.startRecord(
-            permissionDeniedMessage: permissionDeniedMessage,
-          );
+          return audioRecorderController.startRecord(permissionDeniedMessage: permissionDeniedMessage);
         },
         onLongPressEnd: (_) async {
           // Return if the recording not yet started or already locked.

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
@@ -1471,13 +1471,15 @@ class DefaultStreamMessageComposerState extends State<DefaultStreamMessageCompos
     required Message message,
     required Channel channel,
   }) async {
-    try {
-      // A message is considered fresh if it doesn't have a remoteCreatedAt.
-      final isFreshMessage = message.remoteCreatedAt == null;
+    // A message is considered fresh if it doesn't have a remoteCreatedAt.
+    final isFreshMessage = message.remoteCreatedAt == null;
 
-      // Note: edited messages which are bounced back with an error needs to be
-      // sent as new messages as the backend doesn't store them.
-      final resp = await switch (!isFreshMessage && !message.isBouncedWithError) {
+    // Note: edited messages which are bounced back with an error needs to be
+    // sent as new messages as the backend doesn't store them.
+    final isUpdate = !isFreshMessage && !message.isBouncedWithError;
+
+    try {
+      final resp = await switch (isUpdate) {
         true => channel.updateMessage(message),
         false => channel.sendMessage(message),
       };
@@ -1486,6 +1488,17 @@ class DefaultStreamMessageComposerState extends State<DefaultStreamMessageCompos
     } catch (e, stk) {
       if (widget.props.onError != null) {
         return widget.props.onError?.call(e, stk);
+      }
+
+      if (mounted) {
+        final translations = context.translations;
+        StreamSnackbarMessenger.maybeOf(context)?.show(
+          StreamSnackbar(
+            message: Text(isUpdate ? translations.editMessageError : translations.sendMessageError),
+            variant: .error,
+          ),
+          replace: true,
+        );
       }
 
       rethrow;

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
@@ -1490,16 +1490,15 @@ class DefaultStreamMessageComposerState extends State<DefaultStreamMessageCompos
         return widget.props.onError?.call(e, stk);
       }
 
-      if (mounted) {
-        final translations = context.translations;
-        StreamSnackbarMessenger.maybeOf(context)?.show(
-          StreamSnackbar(
-            message: Text(isUpdate ? translations.editMessageError : translations.sendMessageError),
-            variant: .error,
-          ),
-          replace: true,
-        );
-      }
+      if (!mounted) return;
+
+      final translations = context.translations;
+      final message = isUpdate ? translations.editMessageError : translations.sendMessageError;
+
+      StreamSnackbarMessenger.maybeOf(context)?.show(
+        StreamSnackbar(message: Text(message), variant: .error),
+        replace: true,
+      );
 
       rethrow;
     }

--- a/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
@@ -877,48 +877,144 @@ class DefaultStreamMessageItem extends StatelessWidget {
   }
 
   // Dispatches a MessageAction to the appropriate channel or callback handler.
+  //
+  // Mutating actions (delete, pin, flag, mark-unread, mute) and copy surface a
+  // success/error snackbar via [_runWithFeedback]; reactions, resend and
+  // block/unblock stay fire-and-forget, and edit/reply/thread delegate to their
+  // callbacks.
   Future<void> _onActionTap(
     BuildContext context,
     Channel channel,
     MessageAction action,
-  ) async => switch (action) {
-    SelectReaction() => _selectReaction(context, action.message, channel, action.reaction),
-    CopyMessage() => _copyMessage(action.message, channel),
-    DeleteMessage() => _maybeDeleteMessage(context, action.message, channel),
-    HardDeleteMessage() => channel.deleteMessage(action.message, hard: true),
-    EditMessage() => props.onEditMessageTap?.call(action.message),
-    FlagMessage() => _maybeFlagMessage(context, action.message, channel),
-    MarkUnread() => channel.markUnread(action.message.id),
-    MuteUser() => channel.client.muteUser(action.user.id),
-    UnmuteUser() => channel.client.unmuteUser(action.user.id),
-    BlockUser() => channel.client.blockUser(action.user.id),
-    UnblockUser() => channel.client.unblockUser(action.user.id),
-    PinMessage() => channel.pinMessage(action.message),
-    UnpinMessage() => channel.unpinMessage(action.message),
-    ResendMessage() => channel.retryMessage(action.message),
-    QuotedReply() => props.onReplyTap?.call(action.message),
-    ThreadReply() => props.onThreadTap?.call(action.message, null),
-  };
+  ) async {
+    final translations = context.translations;
+    // Resolved up-front — before the confirmation dialogs and before the action
+    // can remove the message item (e.g. a delete) — so the snackbar still shows.
+    final messenger = StreamSnackbarMessenger.maybeOf(context);
 
-  // Copies the message text (with mentions replaced) to the clipboard.
+    switch (action) {
+      case SelectReaction():
+        return _selectReaction(context, action.message, channel, action.reaction).ignore();
+      case CopyMessage():
+        return _copyMessage(action.message, messenger, translations.messageCopiedToClipboardText);
+      case DeleteMessage():
+        return _maybeDeleteMessage(context, action.message, channel, messenger);
+      case HardDeleteMessage():
+        return _runWithFeedback(
+          messenger,
+          () => channel.deleteMessage(action.message, hard: true),
+          successMessage: translations.messageDeletedLabel,
+          errorMessage: translations.deleteMessageError,
+        );
+      case EditMessage():
+        return props.onEditMessageTap?.call(action.message);
+      case FlagMessage():
+        return _maybeFlagMessage(context, action.message, channel, messenger);
+      case MarkUnread():
+        return _runWithFeedback(
+          messenger,
+          () => channel.markUnread(action.message.id),
+          successMessage: translations.messageMarkedAsUnreadText,
+          errorMessage: translations.markUnreadError,
+        );
+      case MuteUser():
+        return _runWithFeedback(
+          messenger,
+          () => channel.client.muteUser(action.user.id),
+          successMessage: translations.toggleMuteUnmuteUserSuccessText(
+            user: action.user.name,
+            isMuted: false,
+          ),
+          errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: false),
+        );
+      case UnmuteUser():
+        return _runWithFeedback(
+          messenger,
+          () => channel.client.unmuteUser(action.user.id),
+          successMessage: translations.toggleMuteUnmuteUserSuccessText(
+            user: action.user.name,
+            isMuted: true,
+          ),
+          errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: true),
+        );
+      case BlockUser():
+        return channel.client.blockUser(action.user.id).ignore();
+      case UnblockUser():
+        return channel.client.unblockUser(action.user.id).ignore();
+      case PinMessage():
+        return _runWithFeedback(
+          messenger,
+          () => channel.pinMessage(action.message),
+          successMessage: translations.togglePinUnpinMessageSuccessText(pinned: true),
+          errorMessage: translations.togglePinUnpinMessageErrorText(pinned: true),
+        );
+      case UnpinMessage():
+        return _runWithFeedback(
+          messenger,
+          () => channel.unpinMessage(action.message),
+          successMessage: translations.togglePinUnpinMessageSuccessText(pinned: false),
+          errorMessage: translations.togglePinUnpinMessageErrorText(pinned: false),
+        );
+      case ResendMessage():
+        return channel.retryMessage(action.message).ignore();
+      case QuotedReply():
+        return props.onReplyTap?.call(action.message);
+      case ThreadReply():
+        return props.onThreadTap?.call(action.message, null);
+    }
+  }
+
+  // Runs [action] and shows a success or error snackbar on [messenger] with the
+  // given messages. Does nothing if [messenger] is null.
+  Future<void> _runWithFeedback(
+    StreamSnackbarMessenger? messenger,
+    Future<void> Function() action, {
+    required String errorMessage,
+    String? successMessage,
+  }) async {
+    try {
+      await action();
+      if (successMessage == null) return;
+      messenger?.show(
+        StreamSnackbar(message: Text(successMessage), variant: .success),
+        replace: true,
+      );
+    } catch (_) {
+      messenger?.show(
+        StreamSnackbar(message: Text(errorMessage), variant: .error),
+        replace: true,
+      );
+    }
+  }
+
+  // Copies the message text (with mentions replaced) to the clipboard and
+  // confirms with a snackbar on [messenger].
   Future<void> _copyMessage(
     Message message,
-    Channel channel,
+    StreamSnackbarMessenger? messenger,
+    String confirmationMessage,
   ) async {
     final presentableMessage = message.replaceMentions(linkify: false);
 
     final messageText = presentableMessage.text;
     if (messageText == null || messageText.isEmpty) return;
 
-    return Clipboard.setData(ClipboardData(text: messageText));
+    await Clipboard.setData(ClipboardData(text: messageText));
+    messenger?.show(
+      StreamSnackbar(message: Text(confirmationMessage)),
+      replace: true,
+    );
   }
 
-  // Shows a confirmation dialog before deleting the message.
-  Future<EmptyResponse?> _maybeDeleteMessage(
+  // Shows a confirmation dialog before deleting the message, then a
+  // success/error snackbar on [messenger] once confirmed.
+  Future<void> _maybeDeleteMessage(
     BuildContext context,
     Message message,
     Channel channel,
+    StreamSnackbarMessenger? messenger,
   ) async {
+    final translations = context.translations;
     final confirmDelete = await showStreamDialog<bool>(
       context: context,
       builder: (context) => StreamMessageActionConfirmationModal(
@@ -930,17 +1026,25 @@ class DefaultStreamMessageItem extends StatelessWidget {
       ),
     );
 
-    if (confirmDelete != true) return null;
+    if (confirmDelete != true) return;
 
-    return channel.deleteMessage(message);
+    return _runWithFeedback(
+      messenger,
+      () => channel.deleteMessage(message),
+      successMessage: translations.messageDeletedLabel,
+      errorMessage: translations.deleteMessageError,
+    );
   }
 
-  // Shows a confirmation dialog before flagging the message.
-  Future<EmptyResponse?> _maybeFlagMessage(
+  // Shows a confirmation dialog before flagging the message, then a
+  // success/error snackbar on [messenger] once confirmed.
+  Future<void> _maybeFlagMessage(
     BuildContext context,
     Message message,
     Channel channel,
+    StreamSnackbarMessenger? messenger,
   ) async {
+    final translations = context.translations;
     final confirmFlag = await showStreamDialog<bool>(
       context: context,
       builder: (context) => StreamMessageActionConfirmationModal(
@@ -952,10 +1056,14 @@ class DefaultStreamMessageItem extends StatelessWidget {
       ),
     );
 
-    if (confirmFlag != true) return null;
+    if (confirmFlag != true) return;
 
-    final messageId = message.id;
-    return channel.client.flagMessage(messageId);
+    return _runWithFeedback(
+      messenger,
+      () => channel.client.flagMessage(message.id),
+      successMessage: translations.flagMessageSuccessfulLabel,
+      errorMessage: translations.flagMessageError,
+    );
   }
 
   // Toggles a reaction: removes it if already present, otherwise sends it.

--- a/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
@@ -965,7 +965,8 @@ class DefaultStreamMessageItem extends StatelessWidget {
   }
 
   // Runs [action] and shows a success or error snackbar on [messenger] with the
-  // given messages. Does nothing if [messenger] is null.
+  // given messages. When [messenger] is null the action still runs; only the
+  // snackbar feedback is skipped.
   Future<void> _runWithFeedback(
     StreamSnackbarMessenger? messenger,
     Future<void> Function() action, {
@@ -979,7 +980,7 @@ class DefaultStreamMessageItem extends StatelessWidget {
         StreamSnackbar(message: Text(successMessage), variant: .success),
         replace: true,
       );
-    } catch (_) {
+    } on Exception catch (_) {
       messenger?.show(
         StreamSnackbar(message: Text(errorMessage), variant: .error),
         replace: true,

--- a/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/stream_message_item.dart
@@ -892,76 +892,54 @@ class DefaultStreamMessageItem extends StatelessWidget {
     // can remove the message item (e.g. a delete) — so the snackbar still shows.
     final messenger = StreamSnackbarMessenger.maybeOf(context);
 
-    switch (action) {
-      case SelectReaction():
-        return _selectReaction(context, action.message, channel, action.reaction).ignore();
-      case CopyMessage():
-        return _copyMessage(action.message, messenger, translations.messageCopiedToClipboardText);
-      case DeleteMessage():
-        return _maybeDeleteMessage(context, action.message, channel, messenger);
-      case HardDeleteMessage():
-        return _runWithFeedback(
-          messenger,
-          () => channel.deleteMessage(action.message, hard: true),
-          successMessage: translations.messageDeletedLabel,
-          errorMessage: translations.deleteMessageError,
-        );
-      case EditMessage():
-        return props.onEditMessageTap?.call(action.message);
-      case FlagMessage():
-        return _maybeFlagMessage(context, action.message, channel, messenger);
-      case MarkUnread():
-        return _runWithFeedback(
-          messenger,
-          () => channel.markUnread(action.message.id),
-          successMessage: translations.messageMarkedAsUnreadText,
-          errorMessage: translations.markUnreadError,
-        );
-      case MuteUser():
-        return _runWithFeedback(
-          messenger,
-          () => channel.client.muteUser(action.user.id),
-          successMessage: translations.toggleMuteUnmuteUserSuccessText(
-            user: action.user.name,
-            isMuted: false,
-          ),
-          errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: false),
-        );
-      case UnmuteUser():
-        return _runWithFeedback(
-          messenger,
-          () => channel.client.unmuteUser(action.user.id),
-          successMessage: translations.toggleMuteUnmuteUserSuccessText(
-            user: action.user.name,
-            isMuted: true,
-          ),
-          errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: true),
-        );
-      case BlockUser():
-        return channel.client.blockUser(action.user.id).ignore();
-      case UnblockUser():
-        return channel.client.unblockUser(action.user.id).ignore();
-      case PinMessage():
-        return _runWithFeedback(
-          messenger,
-          () => channel.pinMessage(action.message),
-          successMessage: translations.togglePinUnpinMessageSuccessText(pinned: true),
-          errorMessage: translations.togglePinUnpinMessageErrorText(pinned: true),
-        );
-      case UnpinMessage():
-        return _runWithFeedback(
-          messenger,
-          () => channel.unpinMessage(action.message),
-          successMessage: translations.togglePinUnpinMessageSuccessText(pinned: false),
-          errorMessage: translations.togglePinUnpinMessageErrorText(pinned: false),
-        );
-      case ResendMessage():
-        return channel.retryMessage(action.message).ignore();
-      case QuotedReply():
-        return props.onReplyTap?.call(action.message);
-      case ThreadReply():
-        return props.onThreadTap?.call(action.message, null);
-    }
+    return switch (action) {
+      SelectReaction() => _selectReaction(context, action.message, channel, action.reaction).ignore(),
+      CopyMessage() => _copyMessage(action.message, messenger, translations.messageCopiedToClipboardText),
+      DeleteMessage() => _maybeDeleteMessage(context, action.message, channel, messenger),
+      HardDeleteMessage() => _runWithFeedback(
+        messenger,
+        () => channel.deleteMessage(action.message, hard: true),
+        successMessage: translations.messageDeletedLabel,
+        errorMessage: translations.deleteMessageError,
+      ),
+      EditMessage() => props.onEditMessageTap?.call(action.message),
+      FlagMessage() => _maybeFlagMessage(context, action.message, channel, messenger),
+      MarkUnread() => _runWithFeedback(
+        messenger,
+        () => channel.markUnread(action.message.id),
+        successMessage: translations.messageMarkedAsUnreadText,
+        errorMessage: translations.markUnreadError,
+      ),
+      MuteUser() => _runWithFeedback(
+        messenger,
+        () => channel.client.muteUser(action.user.id),
+        successMessage: translations.toggleMuteUnmuteUserSuccessText(user: action.user.name, isMuted: false),
+        errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: false),
+      ),
+      UnmuteUser() => _runWithFeedback(
+        messenger,
+        () => channel.client.unmuteUser(action.user.id),
+        successMessage: translations.toggleMuteUnmuteUserSuccessText(user: action.user.name, isMuted: true),
+        errorMessage: translations.toggleMuteUnmuteUserErrorText(isMuted: true),
+      ),
+      BlockUser() => channel.client.blockUser(action.user.id).ignore(),
+      UnblockUser() => channel.client.unblockUser(action.user.id).ignore(),
+      PinMessage() => _runWithFeedback(
+        messenger,
+        () => channel.pinMessage(action.message),
+        successMessage: translations.togglePinUnpinMessageSuccessText(pinned: true),
+        errorMessage: translations.togglePinUnpinMessageErrorText(pinned: true),
+      ),
+      UnpinMessage() => _runWithFeedback(
+        messenger,
+        () => channel.unpinMessage(action.message),
+        successMessage: translations.togglePinUnpinMessageSuccessText(pinned: false),
+        errorMessage: translations.togglePinUnpinMessageErrorText(pinned: false),
+      ),
+      ResendMessage() => channel.retryMessage(action.message).ignore(),
+      QuotedReply() => props.onReplyTap?.call(action.message),
+      ThreadReply() => props.onThreadTap?.call(action.message, null),
+    };
   }
 
   // Runs [action] and shows a success or error snackbar on [messenger] with the

--- a/packages/stream_chat_flutter/test/src/message_widget/stream_message_item_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_widget/stream_message_item_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../mocks.dart';
+
+void main() {
+  // Drives the real flow: long-press a message to open the actions modal, tap
+  // "Pin", and assert the resulting success/error snackbar. StreamChat sits
+  // above the Navigator (as in a real app) so the snackbar host is reachable
+  // once the modal route pops.
+  group('StreamMessageItem action snackbars', () {
+    final currentUser = OwnUser(id: 'current-user');
+    final message = Message(
+      id: 'test-message',
+      text: 'Pin me',
+      createdAt: DateTime(2026),
+      user: User(id: 'other-user'),
+      state: MessageState.sent,
+    );
+
+    late MockClient client;
+    late MockClientState clientState;
+    late MockChannel channel;
+    late MockChannelState channelState;
+
+    setUp(() {
+      client = MockClient();
+      clientState = MockClientState();
+      channel = MockChannel(
+        ownCapabilities: const [
+          ChannelCapability.sendMessage,
+          ChannelCapability.pinMessage,
+        ],
+      );
+      channelState = MockChannelState();
+
+      when(() => client.state).thenReturn(clientState);
+      when(() => clientState.currentUser).thenReturn(currentUser);
+      when(() => clientState.currentUserStream).thenAnswer((_) => Stream.value(currentUser));
+      when(() => channel.client).thenReturn(client);
+      when(() => channel.state).thenReturn(channelState);
+    });
+
+    Widget buildHarness() => MaterialApp(
+      builder: (context, child) => StreamChat(client: client, child: child),
+      home: StreamChannel(
+        channel: channel,
+        child: Scaffold(body: StreamMessageItem(message: message)),
+      ),
+    );
+
+    Future<void> openActionsAndTapPin(WidgetTester tester) async {
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(StreamMessageItem).first),
+      );
+      await tester.pump(const Duration(milliseconds: 700));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pin to Conversation'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('shows a success snackbar when pinning succeeds', (tester) async {
+      when(() => channel.pinMessage(message)).thenAnswer((_) async => UpdateMessageResponse());
+
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      await openActionsAndTapPin(tester);
+
+      verify(() => channel.pinMessage(message)).called(1);
+      expect(find.text('Message pinned'), findsOneWidget);
+    });
+
+    testWidgets('shows an error snackbar when pinning fails', (tester) async {
+      when(() => channel.pinMessage(message)).thenThrow(Exception('failed to pin'));
+
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      await openActionsAndTapPin(tester);
+
+      expect(find.text('Error pinning message'), findsOneWidget);
+    });
+
+    testWidgets('confirms with a snackbar when copying a message', (tester) async {
+      // Stub the clipboard platform channel so Clipboard.setData resolves.
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async => null,
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(StreamMessageItem).first),
+      );
+      await tester.pump(const Duration(milliseconds: 700));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy Message'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Message copied to clipboard'), findsOneWidget);
+    });
+  });
+}

--- a/packages/stream_chat_flutter/test/src/message_widget/stream_message_item_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_widget/stream_message_item_test.dart
@@ -33,6 +33,7 @@ void main() {
         ownCapabilities: const [
           ChannelCapability.sendMessage,
           ChannelCapability.pinMessage,
+          ChannelCapability.deleteAnyMessage,
         ],
       );
       channelState = MockChannelState();
@@ -52,7 +53,7 @@ void main() {
       ),
     );
 
-    Future<void> openActionsAndTapPin(WidgetTester tester) async {
+    Future<void> openActionsAndTap(WidgetTester tester, String actionLabel) async {
       final gesture = await tester.startGesture(
         tester.getCenter(find.byType(StreamMessageItem).first),
       );
@@ -60,7 +61,7 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Pin to Conversation'));
+      await tester.tap(find.text(actionLabel));
       await tester.pumpAndSettle();
     }
 
@@ -70,7 +71,7 @@ void main() {
       await tester.pumpWidget(buildHarness());
       await tester.pumpAndSettle();
 
-      await openActionsAndTapPin(tester);
+      await openActionsAndTap(tester, 'Pin to Conversation');
 
       verify(() => channel.pinMessage(message)).called(1);
       expect(find.text('Message pinned'), findsOneWidget);
@@ -82,9 +83,39 @@ void main() {
       await tester.pumpWidget(buildHarness());
       await tester.pumpAndSettle();
 
-      await openActionsAndTapPin(tester);
+      await openActionsAndTap(tester, 'Pin to Conversation');
 
+      verify(() => channel.pinMessage(message)).called(1);
       expect(find.text('Error pinning message'), findsOneWidget);
+    });
+
+    testWidgets('shows a success snackbar when a confirmed delete succeeds', (tester) async {
+      when(() => channel.deleteMessage(message)).thenAnswer((_) async => EmptyResponse());
+
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      // Opens the actions modal and taps "Delete Message", surfacing the
+      // confirmation dialog; then confirm via "Delete".
+      await openActionsAndTap(tester, 'Delete Message');
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      verify(() => channel.deleteMessage(message)).called(1);
+      expect(find.text('Message deleted'), findsOneWidget);
+    });
+
+    testWidgets('shows an error snackbar when a confirmed delete fails', (tester) async {
+      when(() => channel.deleteMessage(message)).thenThrow(Exception('failed to delete'));
+
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      await openActionsAndTap(tester, 'Delete Message');
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Error deleting message'), findsOneWidget);
     });
 
     testWidgets('confirms with a snackbar when copying a message', (tester) async {
@@ -103,15 +134,7 @@ void main() {
       await tester.pumpWidget(buildHarness());
       await tester.pumpAndSettle();
 
-      final gesture = await tester.startGesture(
-        tester.getCenter(find.byType(StreamMessageItem).first),
-      );
-      await tester.pump(const Duration(milliseconds: 700));
-      await gesture.up();
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Copy Message'));
-      await tester.pumpAndSettle();
+      await openActionsAndTap(tester, 'Copy Message');
 
       expect(find.text('Message copied to clipboard'), findsOneWidget);
     });

--- a/packages/stream_chat_localizations/CHANGELOG.md
+++ b/packages/stream_chat_localizations/CHANGELOG.md
@@ -3,6 +3,7 @@
 ✅ Added
 
 - Added connection-error translations (`connectionErrorTitle`/`Description`, `slowConnectionErrorTitle`/`Description`, `genericErrorTitle`/`Description`) for all supported locales.
+- Added action-feedback snackbar translations (message copy, pin/unpin, delete, flag, mark unread, mute/unmute user, end poll, audio-recording permission, and message send/edit failures) for all supported locales.
 
 ## 10.2.0
 

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ca.dart
@@ -516,6 +516,48 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
       ' canal.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Missatge marcat com a no llegit';
+
+  @override
+  String get deleteMessageError => 'Error en eliminar el missatge';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Missatge fixat';
+    return 'Missatge desfixat';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Error en fixar el missatge';
+    return 'Error en desfixar el missatge';
+  }
+
+  @override
+  String get flagMessageError => 'Error en reportar el missatge';
+
+  @override
+  String get messageCopiedToClipboardText => 'Missatge copiat al porta-retalls';
+
+  @override
+  String get sendMessageError => "No s'ha pogut enviar el missatge";
+
+  @override
+  String get editMessageError => "No s'ha pogut editar el missatge";
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return "S'ha activat el so de $user";
+    return "S'ha silenciat $user";
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) return "Error en activar el so de l'usuari, torna-ho a provar";
+    return "Error en silenciar l'usuari, torna-ho a provar";
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Crear una enquesta nova';
     return 'Crea enquesta';
@@ -652,6 +694,12 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
   String get endVoteLabel => 'Finalitzar votació';
 
   @override
+  String get endVoteSuccessMessage => 'Votació finalitzada';
+
+  @override
+  String get endVoteErrorMessage => "No s'ha pogut finalitzar la votació";
+
+  @override
   String get pollResultsLabel => 'Resultats de la votació';
 
   @override
@@ -703,6 +751,9 @@ class StreamChatLocalizationsCa extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => 'Mantén premut per gravar, deixa anar per enviar';
+
+  @override
+  String get audioRecordingPermissionMessage => "Permet els permisos d'àudio a la configuració.";
 
   @override
   String get sendAnywayLabel => 'Enviar igualment';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_de.dart
@@ -514,6 +514,50 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
       ' Kanalnachrichten.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Nachricht als ungelesen markiert';
+
+  @override
+  String get deleteMessageError => 'Fehler beim Löschen der Nachricht';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Nachricht angeheftet';
+    return 'Anheftung der Nachricht aufgehoben';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Fehler beim Anheften der Nachricht';
+    return 'Fehler beim Aufheben der Anheftung';
+  }
+
+  @override
+  String get flagMessageError => 'Fehler beim Hinzufügen der Meldung';
+
+  @override
+  String get messageCopiedToClipboardText => 'Nachricht in die Zwischenablage kopiert';
+
+  @override
+  String get sendMessageError => 'Senden der Nachricht fehlgeschlagen';
+
+  @override
+  String get editMessageError => 'Bearbeiten der Nachricht fehlgeschlagen';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return 'Stummschaltung von $user wurde aufgehoben';
+    return '$user wurde stummgeschaltet';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'Fehler beim Aufheben der Stummschaltung, bitte versuche es erneut';
+    }
+    return 'Fehler beim Stummschalten, bitte versuche es erneut';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Erstellen einer neuen Umfrage';
     return 'Umfrage erstellen';
@@ -650,6 +694,12 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
   String get endVoteLabel => 'Abstimmung beenden';
 
   @override
+  String get endVoteSuccessMessage => 'Abstimmung beendet';
+
+  @override
+  String get endVoteErrorMessage => 'Abstimmung konnte nicht beendet werden';
+
+  @override
   String get pollResultsLabel => 'Umfrage-Ergebnisse';
 
   @override
@@ -701,6 +751,9 @@ class StreamChatLocalizationsDe extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => 'Zum Aufnehmen halten, zum Senden loslassen';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Bitte erlaube die Audioberechtigung in den Einstellungen.';
 
   @override
   String get sendAnywayLabel => 'Trotzdem senden';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_en.dart
@@ -514,6 +514,48 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
       ' than the newest 100 channel messages.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Message marked as unread';
+
+  @override
+  String get deleteMessageError => 'Error deleting message';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Message pinned';
+    return 'Message unpinned';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Error pinning message';
+    return 'Error removing message pin';
+  }
+
+  @override
+  String get flagMessageError => 'Error adding flag';
+
+  @override
+  String get messageCopiedToClipboardText => 'Message copied to clipboard';
+
+  @override
+  String get sendMessageError => 'Send message request failed';
+
+  @override
+  String get editMessageError => 'Edit message request failed';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return '$user has been unmuted';
+    return '$user has been muted';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) return 'Error unmuting a user, please try again';
+    return 'Error muting a user, please try again';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Create a new poll';
     return 'Create Poll';
@@ -650,6 +692,12 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
   String get endVoteLabel => 'End Poll';
 
   @override
+  String get endVoteSuccessMessage => 'Poll ended';
+
+  @override
+  String get endVoteErrorMessage => 'Failed to end the poll';
+
+  @override
   String get pollResultsLabel => 'Poll Results';
 
   @override
@@ -701,6 +749,9 @@ class StreamChatLocalizationsEn extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => 'Hold to record. Release to save.';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Please allow Audio permissions in settings.';
 
   @override
   String get sendAnywayLabel => 'Send Anyway';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_es.dart
@@ -518,6 +518,50 @@ No es posible añadir más de $limit archivos adjuntos
       ' no leídos más antiguos que los últimos 100 mensajes del canal.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Mensaje marcado como no leído';
+
+  @override
+  String get deleteMessageError => 'Error al eliminar el mensaje';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Mensaje fijado';
+    return 'Mensaje desfijado';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Error al fijar el mensaje';
+    return 'Error al desfijar el mensaje';
+  }
+
+  @override
+  String get flagMessageError => 'Error al reportar el mensaje';
+
+  @override
+  String get messageCopiedToClipboardText => 'Mensaje copiado al portapapeles';
+
+  @override
+  String get sendMessageError => 'No se pudo enviar el mensaje';
+
+  @override
+  String get editMessageError => 'No se pudo editar el mensaje';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return 'Se ha dejado de silenciar a $user';
+    return 'Se ha silenciado a $user';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'Error al dejar de silenciar al usuario, inténtalo de nuevo';
+    }
+    return 'Error al silenciar al usuario, inténtalo de nuevo';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Crear un nuevo sondeo';
     return 'Crear sondeo';
@@ -654,6 +698,12 @@ No es posible añadir más de $limit archivos adjuntos
   String get endVoteLabel => 'Finalizar votación';
 
   @override
+  String get endVoteSuccessMessage => 'Votación finalizada';
+
+  @override
+  String get endVoteErrorMessage => 'No se pudo finalizar la votación';
+
+  @override
   String get pollResultsLabel => 'Resultados de la encuesta';
 
   @override
@@ -705,6 +755,9 @@ No es posible añadir más de $limit archivos adjuntos
 
   @override
   String get holdToRecordLabel => 'Mantén pulsado para grabar, suelta para enviar';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Permite los permisos de audio en la configuración.';
 
   @override
   String get sendAnywayLabel => 'Enviar de todos modos';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_fr.dart
@@ -520,6 +520,50 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
       ' du canal.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Message marqué comme non lu';
+
+  @override
+  String get deleteMessageError => 'Erreur lors de la suppression du message';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Message épinglé';
+    return 'Message désépinglé';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return "Erreur lors de l'épinglage du message";
+    return 'Erreur lors du désépinglage du message';
+  }
+
+  @override
+  String get flagMessageError => 'Erreur lors du signalement du message';
+
+  @override
+  String get messageCopiedToClipboardText => 'Message copié dans le presse-papiers';
+
+  @override
+  String get sendMessageError => "Échec de l'envoi du message";
+
+  @override
+  String get editMessageError => 'Échec de la modification du message';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return 'Le son de $user a été réactivé';
+    return 'Le son de $user a été coupé';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'Erreur lors de la réactivation du son, veuillez réessayer';
+    }
+    return 'Erreur lors de la coupure du son, veuillez réessayer';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Créer un sondage';
     return 'Créer sondage';
@@ -656,6 +700,12 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
   String get endVoteLabel => 'Terminer le vote';
 
   @override
+  String get endVoteSuccessMessage => 'Vote terminé';
+
+  @override
+  String get endVoteErrorMessage => 'Impossible de terminer le vote';
+
+  @override
   String get pollResultsLabel => 'Résultats du sondage';
 
   @override
@@ -707,6 +757,9 @@ Limite de pièces jointes dépassée : il n'est pas possible d'ajouter plus de $
 
   @override
   String get holdToRecordLabel => 'Maintenez pour enregistrer, relâchez pour envoyer';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Veuillez autoriser les permissions audio dans les paramètres.';
 
   @override
   String get sendAnywayLabel => 'Envoyer quand même';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_hi.dart
@@ -516,6 +516,50 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
       ' सभी अपठित संदेशों को अपठित मार्क नहीं किया जा सकता है।';
 
   @override
+  String get messageMarkedAsUnreadText => 'संदेश को अपठित के रूप में चिह्नित किया गया';
+
+  @override
+  String get deleteMessageError => 'संदेश हटाने में त्रुटि';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'संदेश पिन किया गया';
+    return 'संदेश अनपिन किया गया';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'संदेश पिन करने में त्रुटि';
+    return 'संदेश पिन हटाने में त्रुटि';
+  }
+
+  @override
+  String get flagMessageError => 'फ्लैग जोड़ने में त्रुटि';
+
+  @override
+  String get messageCopiedToClipboardText => 'संदेश क्लिपबोर्ड पर कॉपी किया गया';
+
+  @override
+  String get sendMessageError => 'संदेश भेजने में विफल';
+
+  @override
+  String get editMessageError => 'संदेश संपादित करने में विफल';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return '$user को अनम्यूट कर दिया गया है';
+    return '$user को म्यूट कर दिया गया है';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'उपयोगकर्ता को अनम्यूट करने में त्रुटि, कृपया पुनः प्रयास करें';
+    }
+    return 'उपयोगकर्ता को म्यूट करने में त्रुटि, कृपया पुनः प्रयास करें';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'एक नया पोल बनाएँ';
     return 'पोल बनाएँ';
@@ -591,6 +635,12 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
 
   @override
   String get endVoteLabel => 'वोट समाप्त करें';
+
+  @override
+  String get endVoteSuccessMessage => 'वोट समाप्त हो गया';
+
+  @override
+  String get endVoteErrorMessage => 'वोट समाप्त करने में विफल';
 
   @override
   String get enterANewOptionLabel => 'एक नया विकल्प दर्ज करें';
@@ -703,6 +753,9 @@ class StreamChatLocalizationsHi extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => 'रिकॉर्ड करने के लिए दबाए रखें, भेजने के लिए छोड़ें';
+
+  @override
+  String get audioRecordingPermissionMessage => 'कृपया सेटिंग्स में ऑडियो अनुमति दें।';
 
   @override
   String get sendAnywayLabel => 'फिर भी भेजें';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_it.dart
@@ -523,6 +523,50 @@ Attenzione: il limite massimo di $limit file è stato superato.
       ' del canale.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Messaggio contrassegnato come non letto';
+
+  @override
+  String get deleteMessageError => "Errore durante l'eliminazione del messaggio";
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Messaggio messo in evidenza';
+    return 'Messaggio rimosso dagli elementi in evidenza';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Errore durante la messa in evidenza del messaggio';
+    return 'Errore durante la rimozione del messaggio dagli elementi in evidenza';
+  }
+
+  @override
+  String get flagMessageError => 'Errore durante la segnalazione del messaggio';
+
+  @override
+  String get messageCopiedToClipboardText => 'Messaggio copiato negli appunti';
+
+  @override
+  String get sendMessageError => 'Invio del messaggio non riuscito';
+
+  @override
+  String get editMessageError => 'Modifica del messaggio non riuscita';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return "L'audio di $user è stato attivato";
+    return "L'audio di $user è stato disattivato";
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return "Errore durante l'attivazione dell'audio, riprova";
+    }
+    return "Errore durante la disattivazione dell'audio, riprova";
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Crea un nuovo sondaggio';
     return 'Crea sondaggio';
@@ -659,6 +703,12 @@ Attenzione: il limite massimo di $limit file è stato superato.
   String get endVoteLabel => 'Termina votazione';
 
   @override
+  String get endVoteSuccessMessage => 'Votazione terminata';
+
+  @override
+  String get endVoteErrorMessage => 'Impossibile terminare la votazione';
+
+  @override
   String get pollResultsLabel => 'Risultati del sondaggio';
 
   @override
@@ -710,6 +760,9 @@ Attenzione: il limite massimo di $limit file è stato superato.
 
   @override
   String get holdToRecordLabel => 'Tieni premuto per registrare, rilascia per inviare';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Consenti le autorizzazioni audio nelle impostazioni.';
 
   @override
   String get sendAnywayLabel => 'Invia comunque';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ja.dart
@@ -502,6 +502,50 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get markUnreadError => 'メッセージを未読にする際にエラーが発生しました。最新の100件のチャンネルメッセージより古い未読メッセージはマークできません。';
 
   @override
+  String get messageMarkedAsUnreadText => 'メッセージを未読としてマークしました';
+
+  @override
+  String get deleteMessageError => 'メッセージの削除中にエラーが発生しました';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'メッセージをピンしました';
+    return 'メッセージのピンを外しました';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'メッセージのピンに失敗しました';
+    return 'メッセージのピン解除に失敗しました';
+  }
+
+  @override
+  String get flagMessageError => 'フラグの追加中にエラーが発生しました';
+
+  @override
+  String get messageCopiedToClipboardText => 'メッセージをクリップボードにコピーしました';
+
+  @override
+  String get sendMessageError => 'メッセージの送信に失敗しました';
+
+  @override
+  String get editMessageError => 'メッセージの編集に失敗しました';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return '$userのミュートを解除しました';
+    return '$userをミュートしました';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'ユーザーのミュート解除に失敗しました。もう一度お試しください';
+    }
+    return 'ユーザーのミュートに失敗しました。もう一度お試しください';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return '新しい投票を作成する';
     return '投票の作成';
@@ -634,6 +678,12 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
   String get endVoteLabel => '投票を終了';
 
   @override
+  String get endVoteSuccessMessage => '投票が終了しました';
+
+  @override
+  String get endVoteErrorMessage => '投票を終了できませんでした';
+
+  @override
   String get pollResultsLabel => '投票結果';
 
   @override
@@ -684,6 +734,9 @@ class StreamChatLocalizationsJa extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => '長押しで録音、離すと送信';
+
+  @override
+  String get audioRecordingPermissionMessage => '設定でオーディオの権限を許可してください。';
 
   @override
   String get sendAnywayLabel => 'それでも送信';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_ko.dart
@@ -505,6 +505,50 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
       ' 표시할 수 없습니다.';
 
   @override
+  String get messageMarkedAsUnreadText => '메시지를 읽지 않음으로 표시했습니다';
+
+  @override
+  String get deleteMessageError => '메시지를 삭제하는 중 오류가 발생했습니다';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return '메시지를 고정했습니다';
+    return '메시지 고정을 해제했습니다';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return '메시지를 고정하는 중 오류가 발생했습니다';
+    return '메시지 고정을 해제하는 중 오류가 발생했습니다';
+  }
+
+  @override
+  String get flagMessageError => '플래그를 추가하는 중 오류가 발생했습니다';
+
+  @override
+  String get messageCopiedToClipboardText => '메시지를 클립보드에 복사했습니다';
+
+  @override
+  String get sendMessageError => '메시지 전송에 실패했습니다';
+
+  @override
+  String get editMessageError => '메시지 편집에 실패했습니다';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return '$user님의 음소거를 해제했습니다';
+    return '$user님을 음소거했습니다';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return '사용자 음소거 해제 중 오류가 발생했습니다. 다시 시도해 주세요';
+    }
+    return '사용자 음소거 중 오류가 발생했습니다. 다시 시도해 주세요';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return '새 투표 만들기';
     return '투표 만들기';
@@ -637,6 +681,12 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
   String get endVoteLabel => '투표 종료';
 
   @override
+  String get endVoteSuccessMessage => '투표가 종료되었습니다';
+
+  @override
+  String get endVoteErrorMessage => '투표를 종료하지 못했습니다';
+
+  @override
   String get pollResultsLabel => '투표 결과';
 
   @override
@@ -687,6 +737,9 @@ class StreamChatLocalizationsKo extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => '길게 눌러서 녹음, 놓아서 전송';
+
+  @override
+  String get audioRecordingPermissionMessage => '설정에서 오디오 권한을 허용해 주세요.';
 
   @override
   String get sendAnywayLabel => '그래도 보내기';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_no.dart
@@ -502,6 +502,48 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
       ' uleste som er eldre enn de 100 nyeste kanalmeldingene.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Melding merket som ulest';
+
+  @override
+  String get deleteMessageError => 'Feil ved sletting av melding';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Melding festet';
+    return 'Melding løsnet';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Feil ved festing av melding';
+    return 'Feil ved løsning av melding';
+  }
+
+  @override
+  String get flagMessageError => 'Feil ved rapportering av melding';
+
+  @override
+  String get messageCopiedToClipboardText => 'Melding kopiert til utklippstavlen';
+
+  @override
+  String get sendMessageError => 'Kunne ikke sende meldingen';
+
+  @override
+  String get editMessageError => 'Kunne ikke redigere meldingen';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return 'Lyden til $user er slått på igjen';
+    return '$user er dempet';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) return 'Feil ved oppheving av demping, prøv igjen';
+    return 'Feil ved demping av bruker, prøv igjen';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Opprett en ny avstemning';
     return 'Opprett avstemning';
@@ -635,6 +677,12 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
   String get endVoteLabel => 'Avslutt avstemning';
 
   @override
+  String get endVoteSuccessMessage => 'Avstemning avsluttet';
+
+  @override
+  String get endVoteErrorMessage => 'Kunne ikke avslutte avstemningen';
+
+  @override
   String get pollResultsLabel => 'Resultater for avstemningen';
 
   @override
@@ -686,6 +734,9 @@ class StreamChatLocalizationsNo extends GlobalStreamChatLocalizations {
 
   @override
   String get holdToRecordLabel => 'Hold for å ta opp, slipp for å sende';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Tillat lydtillatelser i innstillingene.';
 
   @override
   String get sendAnywayLabel => 'Send likevel';

--- a/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
+++ b/packages/stream_chat_localizations/lib/src/stream_chat_localizations_pt.dart
@@ -517,6 +517,50 @@ Não é possível adicionar mais de $limit arquivos de uma vez
       ' não lidas mais antigas do que as 100 mensagens mais recentes do canal.';
 
   @override
+  String get messageMarkedAsUnreadText => 'Mensagem marcada como não lida';
+
+  @override
+  String get deleteMessageError => 'Erro ao excluir a mensagem';
+
+  @override
+  String togglePinUnpinMessageSuccessText({required bool pinned}) {
+    if (pinned) return 'Mensagem fixada';
+    return 'Mensagem desafixada';
+  }
+
+  @override
+  String togglePinUnpinMessageErrorText({required bool pinned}) {
+    if (pinned) return 'Erro ao fixar a mensagem';
+    return 'Erro ao desafixar a mensagem';
+  }
+
+  @override
+  String get flagMessageError => 'Erro ao denunciar a mensagem';
+
+  @override
+  String get messageCopiedToClipboardText => 'Mensagem copiada para a área de transferência';
+
+  @override
+  String get sendMessageError => 'Falha ao enviar a mensagem';
+
+  @override
+  String get editMessageError => 'Falha ao editar a mensagem';
+
+  @override
+  String toggleMuteUnmuteUserSuccessText({required String user, required bool isMuted}) {
+    if (isMuted) return 'O som de $user foi ativado';
+    return '$user foi silenciado';
+  }
+
+  @override
+  String toggleMuteUnmuteUserErrorText({required bool isMuted}) {
+    if (isMuted) {
+      return 'Erro ao ativar o som do usuário, tente novamente';
+    }
+    return 'Erro ao silenciar o usuário, tente novamente';
+  }
+
+  @override
   String createPollLabel({bool isNew = false}) {
     if (isNew) return 'Criar uma nova sondagem';
     return 'Criar sondagem';
@@ -653,6 +697,12 @@ Não é possível adicionar mais de $limit arquivos de uma vez
   String get endVoteLabel => 'Encerrar votação';
 
   @override
+  String get endVoteSuccessMessage => 'Votação encerrada';
+
+  @override
+  String get endVoteErrorMessage => 'Não foi possível encerrar a votação';
+
+  @override
   String get pollResultsLabel => 'Resultados da votação';
 
   @override
@@ -704,6 +754,9 @@ Não é possível adicionar mais de $limit arquivos de uma vez
 
   @override
   String get holdToRecordLabel => 'Mantenha pressionado para gravar, solte para enviar';
+
+  @override
+  String get audioRecordingPermissionMessage => 'Permita as permissões de áudio nas configurações.';
 
   @override
   String get sendAnywayLabel => 'Enviar mesmo assim';

--- a/packages/stream_chat_localizations/test/translations_test.dart
+++ b/packages/stream_chat_localizations/test/translations_test.dart
@@ -100,6 +100,10 @@ void main() {
       expect(localizations.togglePinUnpinText(pinned: true), isNotNull);
       // un-pinned
       expect(localizations.togglePinUnpinText(pinned: false), isNotNull);
+      expect(localizations.togglePinUnpinMessageSuccessText(pinned: true), isNotNull);
+      expect(localizations.togglePinUnpinMessageSuccessText(pinned: false), isNotNull);
+      expect(localizations.togglePinUnpinMessageErrorText(pinned: true), isNotNull);
+      expect(localizations.togglePinUnpinMessageErrorText(pinned: false), isNotNull);
       // delete-failed
       expect(
         localizations.toggleDeleteRetryDeleteMessageText(isDeleteFailed: true),
@@ -222,6 +226,16 @@ void main() {
       expect(localizations.toggleMuteUnmuteUserQuestion(isMuted: true), isNotNull);
       expect(localizations.toggleMuteUnmuteUserText(isMuted: true), isNotNull);
       expect(localizations.toggleMuteUnmuteUserText(isMuted: false), isNotNull);
+      expect(
+        localizations.toggleMuteUnmuteUserSuccessText(user: 'test-user', isMuted: true),
+        isNotNull,
+      );
+      expect(
+        localizations.toggleMuteUnmuteUserSuccessText(user: 'test-user', isMuted: false),
+        isNotNull,
+      );
+      expect(localizations.toggleMuteUnmuteUserErrorText(isMuted: true), isNotNull);
+      expect(localizations.toggleMuteUnmuteUserErrorText(isMuted: false), isNotNull);
       expect(localizations.toggleBlockUnblockUserText(isBlocked: true), isNotNull);
       expect(localizations.toggleBlockUnblockUserText(isBlocked: false), isNotNull);
       expect(localizations.viewLibrary, isNotNull);
@@ -232,6 +246,12 @@ void main() {
       expect(localizations.unreadMessagesSeparatorText(), isNotNull);
       expect(localizations.markUnreadError, isNotNull);
       expect(localizations.markAsUnreadLabel, isNotNull);
+      expect(localizations.messageMarkedAsUnreadText, isNotNull);
+      expect(localizations.deleteMessageError, isNotNull);
+      expect(localizations.flagMessageError, isNotNull);
+      expect(localizations.messageCopiedToClipboardText, isNotNull);
+      expect(localizations.sendMessageError, isNotNull);
+      expect(localizations.editMessageError, isNotNull);
       // Create poll
       expect(localizations.createPollLabel(), isNotNull);
       // Create a new poll
@@ -282,6 +302,8 @@ void main() {
       expect(localizations.createLabel, isNotNull);
       expect(localizations.endLabel, isNotNull);
       expect(localizations.endVoteLabel, isNotNull);
+      expect(localizations.endVoteSuccessMessage, isNotNull);
+      expect(localizations.endVoteErrorMessage, isNotNull);
       expect(localizations.enterANewOptionLabel, isNotNull);
       expect(localizations.enterYourCommentLabel, isNotNull);
       expect(localizations.loadingPollVotesError, isNotNull);
@@ -328,6 +350,7 @@ void main() {
       expect(localizations.loadingLabel, isNotNull);
       expect(localizations.slideToCancelLabel, isNotNull);
       expect(localizations.holdToRecordLabel, isNotNull);
+      expect(localizations.audioRecordingPermissionMessage, isNotNull);
       expect(localizations.sendAnywayLabel, isNotNull);
       expect(localizations.moderatedMessageBlockedText, isNotNull);
       expect(localizations.moderationReviewModalTitle, isNotNull);

--- a/sample_app/lib/pages/chat_info_screen.dart
+++ b/sample_app/lib/pages/chat_info_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:sample_app/pages/channel_file_display_screen.dart';
 import 'package:sample_app/pages/channel_media_display_screen.dart';
 import 'package:sample_app/pages/pinned_messages_screen.dart';
+import 'package:sample_app/utils/action_feedback.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 /// Detail screen for a 1:1 chat correspondence.
@@ -182,10 +183,21 @@ class _ActionsSection extends StatelessWidget {
             trailing: StreamSwitch(
               value: isMuted,
               onChanged: (_) {
+                final messenger = StreamSnackbarMessenger.maybeOf(context);
                 if (isMuted) {
-                  channel.unmute();
+                  runWithFeedback(
+                    messenger,
+                    channel.unmute,
+                    successMessage: 'Channel unmuted',
+                    errorMessage: 'Failed to update channel mute status',
+                  ).ignore();
                 } else {
-                  channel.mute();
+                  runWithFeedback(
+                    messenger,
+                    channel.mute,
+                    successMessage: 'Channel muted',
+                    errorMessage: 'Failed to update channel mute status',
+                  ).ignore();
                 }
               },
             ),
@@ -216,6 +228,7 @@ class _ActionsSection extends StatelessWidget {
   Future<void> _confirmDelete(BuildContext context) async {
     final navigator = Navigator.of(context);
     final channel = StreamChannel.of(context).channel;
+    final messenger = StreamSnackbarMessenger.maybeOf(context);
 
     final confirmed = await _showConfirmationDialog(
       context: context,
@@ -225,11 +238,22 @@ class _ActionsSection extends StatelessWidget {
     );
     if (confirmed != true) return;
 
-    await channel.delete();
-    // Pop every screen until we land on the channel list — going back to
-    // the channel page would crash trying to read state from the now
-    // deleted channel.
-    navigator.popUntil((route) => route.isFirst);
+    try {
+      await channel.delete();
+      messenger?.show(
+        StreamSnackbar(message: const Text('Channel deleted'), variant: .success),
+        replace: true,
+      );
+      // Pop every screen until we land on the channel list — going back to
+      // the channel page would crash trying to read state from the now
+      // deleted channel.
+      navigator.popUntil((route) => route.isFirst);
+    } catch (_) {
+      messenger?.show(
+        StreamSnackbar(message: const Text('Failed to delete channel'), variant: .error),
+        replace: true,
+      );
+    }
   }
 }
 

--- a/sample_app/lib/pages/group_info_screen.dart
+++ b/sample_app/lib/pages/group_info_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:sample_app/pages/channel_file_display_screen.dart';
 import 'package:sample_app/pages/channel_media_display_screen.dart';
 import 'package:sample_app/pages/pinned_messages_screen.dart';
+import 'package:sample_app/utils/action_feedback.dart';
 import 'package:sample_app/widgets/add_members_sheet.dart';
 import 'package:sample_app/widgets/all_members_sheet.dart';
 import 'package:sample_app/widgets/edit_group_sheet.dart';
@@ -295,10 +296,21 @@ class _ActionsSection extends StatelessWidget {
             trailing: StreamSwitch(
               value: isMuted,
               onChanged: (_) {
+                final messenger = StreamSnackbarMessenger.maybeOf(context);
                 if (isMuted) {
-                  channel.unmute();
+                  runWithFeedback(
+                    messenger,
+                    channel.unmute,
+                    successMessage: 'Channel unmuted',
+                    errorMessage: 'Failed to update channel mute status',
+                  ).ignore();
                 } else {
-                  channel.mute();
+                  runWithFeedback(
+                    messenger,
+                    channel.mute,
+                    successMessage: 'Channel muted',
+                    errorMessage: 'Failed to update channel mute status',
+                  ).ignore();
                 }
               },
             ),
@@ -328,6 +340,7 @@ class _ActionsSection extends StatelessWidget {
     final currentUserId = StreamChat.of(context).currentUser?.id;
     if (currentUserId == null) return;
 
+    final messenger = StreamSnackbarMessenger.maybeOf(context);
     final confirmed = await _showConfirmationDialog(
       context: context,
       title: 'Leave group',
@@ -336,15 +349,27 @@ class _ActionsSection extends StatelessWidget {
     );
     if (confirmed != true) return;
 
-    await channel.removeMembers([currentUserId]);
-    // Pop every screen until we land on the channel list — going back to
-    // the channel page would crash since we're no longer a member.
-    navigator.popUntil((route) => route.isFirst);
+    try {
+      await channel.removeMembers([currentUserId]);
+      messenger?.show(
+        StreamSnackbar(message: const Text('Left channel'), variant: .success),
+        replace: true,
+      );
+      // Pop every screen until we land on the channel list — going back to
+      // the channel page would crash since we're no longer a member.
+      navigator.popUntil((route) => route.isFirst);
+    } catch (_) {
+      messenger?.show(
+        StreamSnackbar(message: const Text('Failed to leave channel'), variant: .error),
+        replace: true,
+      );
+    }
   }
 
   Future<void> _confirmDelete(BuildContext context) async {
     final navigator = Navigator.of(context);
     final channel = StreamChannel.of(context).channel;
+    final messenger = StreamSnackbarMessenger.maybeOf(context);
 
     final confirmed = await _showConfirmationDialog(
       context: context,
@@ -354,11 +379,22 @@ class _ActionsSection extends StatelessWidget {
     );
     if (confirmed != true) return;
 
-    await channel.delete();
-    // Pop every screen until we land on the channel list — going back to
-    // the channel page would crash trying to read state from the now
-    // deleted channel.
-    navigator.popUntil((route) => route.isFirst);
+    try {
+      await channel.delete();
+      messenger?.show(
+        StreamSnackbar(message: const Text('Channel deleted'), variant: .success),
+        replace: true,
+      );
+      // Pop every screen until we land on the channel list — going back to
+      // the channel page would crash trying to read state from the now
+      // deleted channel.
+      navigator.popUntil((route) => route.isFirst);
+    } catch (_) {
+      messenger?.show(
+        StreamSnackbar(message: const Text('Failed to delete channel'), variant: .error),
+        replace: true,
+      );
+    }
   }
 }
 

--- a/sample_app/lib/utils/action_feedback.dart
+++ b/sample_app/lib/utils/action_feedback.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
 
 // Runs [action] and shows a success or error snackbar on [messenger] with the
-// given messages. Does nothing if [messenger] is null.
+// given messages. When [messenger] is null the action still runs; only the
+// snackbar feedback is skipped.
 Future<void> runWithFeedback(
   StreamSnackbarMessenger? messenger,
   Future<void> Function() action, {
@@ -16,7 +17,7 @@ Future<void> runWithFeedback(
       StreamSnackbar(message: Text(successMessage), variant: .success),
       replace: true,
     );
-  } catch (_) {
+  } on Exception catch (_) {
     messenger?.show(
       StreamSnackbar(message: Text(errorMessage), variant: .error),
       replace: true,

--- a/sample_app/lib/utils/action_feedback.dart
+++ b/sample_app/lib/utils/action_feedback.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+// Runs [action] and shows a success or error snackbar on [messenger] with the
+// given messages. Does nothing if [messenger] is null.
+Future<void> runWithFeedback(
+  StreamSnackbarMessenger? messenger,
+  Future<void> Function() action, {
+  required String errorMessage,
+  String? successMessage,
+}) async {
+  try {
+    await action();
+    if (successMessage == null) return;
+    messenger?.show(
+      StreamSnackbar(message: Text(successMessage), variant: .success),
+      replace: true,
+    );
+  } catch (_) {
+    messenger?.show(
+      StreamSnackbar(message: Text(errorMessage), variant: .error),
+      replace: true,
+    );
+  }
+}

--- a/sample_app/lib/widgets/channel_list.dart
+++ b/sample_app/lib/widgets/channel_list.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sample_app/routes/routes.dart';
+import 'package:sample_app/utils/action_feedback.dart';
 import 'package:sample_app/widgets/channel_detail_sheet.dart';
 import 'package:sample_app/widgets/search_text_field.dart';
 import 'package:stream_chat_flutter/stream_chat_flutter.dart';
@@ -137,8 +138,21 @@ class _ChannelListDefault extends StatelessWidget {
                       foregroundColor: colorScheme.textOnAccent,
                       backgroundColor: colorScheme.accentPrimary,
                       onPressed: (_) {
-                        if (isMuted) return channel.unmute().ignore();
-                        return channel.mute().ignore();
+                        final messenger = StreamSnackbarMessenger.maybeOf(context);
+                        if (isMuted) {
+                          return runWithFeedback(
+                            messenger,
+                            channel.unmute,
+                            successMessage: 'Channel unmuted',
+                            errorMessage: 'Failed to update channel mute status',
+                          ).ignore();
+                        }
+                        return runWithFeedback(
+                          messenger,
+                          channel.mute,
+                          successMessage: 'Channel muted',
+                          errorMessage: 'Failed to update channel mute status',
+                        ).ignore();
                       },
                       child: Icon(isMuted ? icons.audio : icons.mute, size: 20),
                     ),
@@ -186,15 +200,41 @@ Future<void> _onChannelDetailAction(
   ChannelDetailAction action,
 ) async {
   final client = StreamChat.of(context).client;
+  final messenger = StreamSnackbarMessenger.maybeOf(context);
   return switch (action) {
     ViewChannelInfo(:final user) => _pushChannelInfo(context, channel, user),
-    PinChannel() => channel.pin(),
-    UnpinChannel() => channel.unpin(),
-    MuteChannelMember(:final user) => client.muteUser(user.id),
-    UnmuteChannelMember(:final user) => client.unmuteUser(user.id),
-    BlockChannelMember(:final user) => client.blockUser(user.id),
-    LeaveChannel() => _maybeLeaveChannel(context, channel),
-    DeleteChannel() => _maybeDeleteChannel(context, channel),
+    PinChannel() => runWithFeedback(
+      messenger,
+      () => channel.pin(),
+      successMessage: 'Channel pinned',
+      errorMessage: 'Failed to update channel pinned status',
+    ),
+    UnpinChannel() => runWithFeedback(
+      messenger,
+      () => channel.unpin(),
+      successMessage: 'Channel unpinned',
+      errorMessage: 'Failed to update channel pinned status',
+    ),
+    MuteChannelMember(:final user) => runWithFeedback(
+      messenger,
+      () => client.muteUser(user.id),
+      successMessage: '${user.name} has been muted',
+      errorMessage: 'Error muting a user, please try again',
+    ),
+    UnmuteChannelMember(:final user) => runWithFeedback(
+      messenger,
+      () => client.unmuteUser(user.id),
+      successMessage: '${user.name} has been unmuted',
+      errorMessage: 'Error unmuting a user, please try again',
+    ),
+    BlockChannelMember(:final user) => runWithFeedback(
+      messenger,
+      () => client.blockUser(user.id),
+      successMessage: 'User blocked',
+      errorMessage: 'Failed to block user',
+    ),
+    LeaveChannel() => _maybeLeaveChannel(context, channel, messenger),
+    DeleteChannel() => _maybeDeleteChannel(context, channel, messenger),
   };
 }
 
@@ -222,7 +262,11 @@ Future<void> _pushChannelInfo(BuildContext context, Channel channel, User? user)
 // Shows a confirmation dialog before removing the current user from the
 // channel. Leave is only surfaced for group channels in the detail sheet,
 // so the copy is group-specific here.
-Future<void> _maybeLeaveChannel(BuildContext context, Channel channel) async {
+Future<void> _maybeLeaveChannel(
+  BuildContext context,
+  Channel channel,
+  StreamSnackbarMessenger? messenger,
+) async {
   final currentUserId = StreamChat.of(context).currentUser?.id;
   if (currentUserId == null) return;
 
@@ -234,13 +278,22 @@ Future<void> _maybeLeaveChannel(BuildContext context, Channel channel) async {
   );
 
   if (confirmed != true) return;
-  await channel.removeMembers([currentUserId]);
+  return runWithFeedback(
+    messenger,
+    () => channel.removeMembers([currentUserId]),
+    successMessage: 'Left channel',
+    errorMessage: 'Failed to leave channel',
+  );
 }
 
 // Shows a confirmation dialog before deleting the channel. On success, pops
 // the channel page if currently visible (e.g. when invoked from inside a
 // channel route).
-Future<void> _maybeDeleteChannel(BuildContext context, Channel channel) async {
+Future<void> _maybeDeleteChannel(
+  BuildContext context,
+  Channel channel,
+  StreamSnackbarMessenger? messenger,
+) async {
   final router = GoRouter.of(context);
   final subject = channel.isOneToOne ? 'conversation' : 'group';
 
@@ -252,8 +305,20 @@ Future<void> _maybeDeleteChannel(BuildContext context, Channel channel) async {
   );
 
   if (confirmed != true) return;
-  await channel.delete();
-  if (router.canPop()) router.pop();
+
+  try {
+    await channel.delete();
+    messenger?.show(
+      StreamSnackbar(message: const Text('Channel deleted'), variant: .success),
+      replace: true,
+    );
+    if (router.canPop()) router.pop();
+  } catch (_) {
+    messenger?.show(
+      StreamSnackbar(message: const Text('Failed to delete channel'), variant: .error),
+      replace: true,
+    );
+  }
 }
 
 class _ChannelListSearch extends StatelessWidget {


### PR DESCRIPTION
Linear: [FLU-682](https://linear.app/stream/issue/FLU-682/add-snackbar-feedback-for-user-actions-rn-parity)

## 🎯 Goal

Give users success/error snackbar feedback for actions that were previously **fire-and-forget** (`.ignore()`), silently swallowing both success and failures. RN is the reference here — its `addNotification` system surfaces feedback for ~66 call sites; the Flutter SDK surfaced almost none. The snackbar infrastructure (`StreamSnackbar` / `StreamSnackbarMessenger`) already exists in `stream_core_flutter`, so this is a wiring effort.

Also incorporates the cross-SDK decision (Slack thread, Aug 2026) to add a **"Message copied to clipboard"** snackbar — none of the SDKs had one.

## 🛠 What changed

**SDK (`stream_chat_flutter`)** — success/error snackbars for:
- **Message actions**: copy, pin/unpin, delete, flag, mark unread, mute/unmute user (centralized in `_onActionTap`)
- **Poll**: ending a poll
- **Audio**: recording-permission denial (surfaced via the existing `RecordStateIdle` bridge)
- **Composer**: message send/edit failures — only when no `onError` handler is supplied

The messenger is resolved from the **page context before any `await`**, so the snackbar still shows across confirmation dialogs and even if the message is removed by the action (e.g. delete).

**Localizations (`stream_chat_localizations`)** — 13 new keys implemented across all 11 locales.

**Sample app** — channel/member action snackbars (mute/pin/leave/delete channel, mute/block member) across the channel-list swipe, detail sheet, and chat/group info screens.

## 🧪 Testing

- New end-to-end widget tests drive the real flow (long-press → actions modal → tap → snackbar) for pin success/error and copy.
- Whole-package `flutter analyze` clean; `stream_chat_flutter` full non-golden suite **993 passing**; `stream_chat_localizations` **23/23** (every locale implements all new keys).

## 📝 Notes / follow-ups

- Translation strings for the 10 non-English locales were machine-generated and are asserted non-null only — worth a **native-speaker pass** (the bool-branch strings like muted/unmuted could be swapped without failing the test).
- The audio-permission snackbar shows the message but has **no "Open Settings" action button** (RN has one) — deferred.
- Sample-app snackbars were analyzed + reasoned about but **not run** in-app.
- Out of scope (no Flutter UI to attach to): channel archive/hide/truncate, standalone flag-user.

## ✅ Contributor checklist

- [x] Changelog updated (`stream_chat_flutter`, `stream_chat_localizations`)
- [x] `melos run analyze` passes
- [x] `melos run format` passes
- [x] Tests added / updated
- [ ] Native-speaker review of new translations
- [ ] Manual QA in the sample app

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success and error snackbar feedback for message actions, user moderation, poll ending, channel actions, and message send/edit failures.
  * Added clear guidance when audio-recording permission is denied.
  * Channel and group deletion or leaving now return to the previous screen only after successful completion.
* **Localization**
  * Added translated feedback messages across all supported languages.
* **Tests**
  * Expanded coverage for message action feedback and localization entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->