### PR TITLE
fix(ui, samples): dispose fixes on channel list and avatar

### DIFF
--- a/packages/stream_chat_flutter/lib/src/components/avatar/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/components/avatar/stream_channel_avatar.dart
@@ -76,7 +76,11 @@ class StreamChannelAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(channel.state != null, 'Channel ${channel.id} is not initialized');
+    // The channel may be disposed (e.g. on logout) while this avatar is still
+    // mounted and the framework rebuilds it (a parent rebuild, or an inherited
+    // dependency change re-running the inner builder). Reading channel state
+    // then throws, so bail out instead.
+    if (channel.state == null) return const SizedBox.shrink();
 
     final effectiveSize = size ?? StreamAvatarGroupSize.lg;
     final effectiveLabel = semanticsLabel ?? _defaultSemanticsLabel(context);
@@ -91,9 +95,13 @@ class StreamChannelAvatar extends StatelessWidget {
         placeholder: (_) => const _StreamChannelAvatarPlaceholder(),
       ),
       noDataBuilder: (context) => BetterStreamBuilder(
-        stream: channel.state!.membersStream,
-        initialData: channel.state!.members,
+        stream: channel.state?.membersStream,
+        initialData: channel.state?.members,
         builder: (context, members) {
+          // This builder is re-run by inherited-dependency changes too, so
+          // it can fire after the channel is disposed — guard again here.
+          if (channel.state == null) return const SizedBox.shrink();
+
           final users = members.map((it) => it.user!).toList();
           final currentUserId = channel.client.state.currentUser?.id;
 

--- a/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
+++ b/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
@@ -89,12 +89,16 @@ void main() {
       // Simulate logout: the channel's state is disposed and nulled...
       liveState = null;
 
-      // ...then the framework rebuilds the avatar (as an inherited-dependency
-      // change would) against the now-disposed channel.
-      rebuildNotifier.value++;
-      await tester.pump();
-      // ...and, for good measure, a trailing members emission too.
+      // ...then a members emission arrives while the nested BetterStreamBuilder
+      // is still mounted, exercising the member-stream disposal path against the
+      // now-disposed channel.
       membersController.add(List.of(members));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      // ...and separately, the framework rebuilds the avatar (as an inherited-
+      // dependency change would) against the now-disposed channel.
+      rebuildNotifier.value++;
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 

--- a/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
+++ b/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stream_chat_flutter/stream_chat_flutter.dart';
+
+import '../fakes.dart';
+import '../mocks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final originalConnectivityPlatform = ConnectivityPlatform.instance;
+  setUp(() => ConnectivityPlatform.instance = FakeConnectivityPlatform());
+  tearDown(() => ConnectivityPlatform.instance = originalConnectivityPlatform);
+
+  testWidgets(
+    'does not throw when the channel is disposed while the avatar is still '
+    'mounted and gets rebuilt',
+    (tester) async {
+      final client = MockClient();
+      final clientState = client.state; // stable MockClientState instance
+      when(() => clientState.currentUser).thenReturn(OwnUser(id: 'alice'));
+
+      final channel = MockChannel();
+      final channelState = MockChannelState();
+
+      final members = [
+        Member(
+          userId: 'alice',
+          user: User(id: 'alice'),
+        ),
+        Member(
+          userId: 'bob',
+          user: User(id: 'bob'),
+        ),
+      ];
+
+      // The avatar's inner builder can be re-run by the framework (an inherited
+      // dependency changing on logout) after the channel is disposed — not only
+      // by a member-stream event. We model both: a mutable state ref that flips
+      // to null on "dispose", plus a members controller we can push to.
+      final membersController = StreamController<List<Member>>.broadcast();
+      addTearDown(membersController.close);
+
+      ChannelClientState? liveState = channelState;
+
+      when(() => channel.client).thenReturn(client);
+      when(() => channel.state).thenAnswer((_) => liveState);
+      when(() => channel.image).thenReturn(null);
+      when(() => channel.imageStream).thenAnswer((_) => Stream<String?>.value(null));
+      when(() => channel.isGroup).thenReturn(false);
+      when(() => channel.isOneToOne).thenReturn(true);
+
+      when(() => channelState.membersStream).thenAnswer((_) => membersController.stream);
+      when(() => channelState.members).thenReturn(members);
+
+      // A key we can use to force a rebuild of the avatar's subtree, simulating
+      // the framework rebuilding it after the channel is disposed.
+      final rebuildNotifier = ValueNotifier<int>(0);
+      addTearDown(rebuildNotifier.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamChat(
+            client: client,
+            themeData: StreamChatThemeData(),
+            child: Scaffold(
+              body: Center(
+                child: ValueListenableBuilder<int>(
+                  valueListenable: rebuildNotifier,
+                  builder: (context, _, __) => StreamChannelAvatar(
+                    channel: channel,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The avatar renders fine while the channel is alive.
+      expect(tester.takeException(), isNull);
+      expect(find.byType(StreamUserAvatar), findsOneWidget);
+
+      // Simulate logout: the channel's state is disposed and nulled...
+      liveState = null;
+
+      // ...then the framework rebuilds the avatar (as an inherited-dependency
+      // change would) against the now-disposed channel.
+      rebuildNotifier.value++;
+      await tester.pump();
+      // ...and, for good measure, a trailing members emission too.
+      membersController.add(List.of(members));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Rebuilding against a disposed channel must not throw.
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
+++ b/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
@@ -52,7 +52,13 @@ void main() {
       when(() => channel.image).thenReturn(null);
       when(() => channel.imageStream).thenAnswer((_) => Stream<String?>.value(null));
       when(() => channel.isGroup).thenReturn(false);
-      when(() => channel.isOneToOne).thenReturn(true);
+      // Reading channel properties after disposal throws in real code; model
+      // that so the member-stream builder must rely on the disposed-channel
+      // guard rather than reaching this getter.
+      when(() => channel.isOneToOne).thenAnswer((_) {
+        if (liveState == null) throw StateError('Channel is disposed');
+        return true;
+      });
 
       when(() => channelState.membersStream).thenAnswer((_) => membersController.stream);
       when(() => channelState.members).thenReturn(members);
@@ -94,7 +100,10 @@ void main() {
       // now-disposed channel.
       membersController.add(List.of(members));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
       expect(tester.takeException(), isNull);
+      // The guard rendered the fallback instead of reaching the throwing getter.
+      expect(find.byType(StreamUserAvatar), findsNothing);
 
       // ...and separately, the framework rebuilds the avatar (as an inherited-
       // dependency change would) against the now-disposed channel.

--- a/sample_app/lib/widgets/channel_list.dart
+++ b/sample_app/lib/widgets/channel_list.dart
@@ -18,21 +18,44 @@ class ChannelList extends StatefulWidget {
 
 class _ChannelList extends State<ChannelList> {
   final ScrollController _scrollController = ScrollController();
-
-  late final StreamMessageSearchListController _messageSearchListController = StreamMessageSearchListController(
-    client: StreamChat.of(context).client,
-    filter: Filter.in_('members', [StreamChat.of(context).currentUser!.id]),
-    limit: 5,
-    searchQuery: '',
-    sort: [
-      const SortOption.desc(ChannelSortKey.pinnedAt),
-      const SortOption.asc(ChannelSortKey.createdAt),
-    ],
-  );
+  late StreamChatState _streamChat;
 
   late final TextEditingController _controller = TextEditingController()..addListener(_channelQueryListener);
 
   bool _isSearchActive = false;
+  bool _controllersAreInitialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _streamChat = StreamChat.of(context);
+    _initControllers();
+    _controllersAreInitialized = true;
+  }
+
+  void _initControllers() {
+    if (_controllersAreInitialized) {
+      _messageSearchListController.dispose();
+      _channelListController.dispose();
+    }
+
+    _messageSearchListController = StreamMessageSearchListController(
+      client: _streamChat.client,
+      filter: Filter.in_('members', [_streamChat.currentUser!.id]),
+      limit: 5,
+      searchQuery: '',
+      sort: [
+        const SortOption.desc(ChannelSortKey.pinnedAt),
+        const SortOption.asc(ChannelSortKey.createdAt),
+      ],
+    );
+    _channelListController = StreamChannelListController(
+      client: _streamChat.client,
+      predefinedFilter: 'stream_chat_flutter_sample_app',
+      filterValues: {'user_id': _streamChat.currentUser!.id},
+      limit: 30,
+    );
+  }
 
   void _channelQueryListener() {
     final query = _controller.text;
@@ -41,12 +64,8 @@ class _ChannelList extends State<ChannelList> {
     return _messageSearchListController.search(query);
   }
 
-  late final _channelListController = StreamChannelListController(
-    client: StreamChat.of(context).client,
-    predefinedFilter: 'stream_chat_flutter_sample_app',
-    filterValues: {'user_id': StreamChat.of(context).currentUser!.id},
-    limit: 30,
-  );
+  late StreamMessageSearchListController _messageSearchListController;
+  late StreamChannelListController _channelListController;
 
   @override
   void dispose() {

--- a/sample_app/lib/widgets/channel_list.dart
+++ b/sample_app/lib/widgets/channel_list.dart
@@ -34,6 +34,11 @@ class _ChannelList extends State<ChannelList> {
   }
 
   void _initControllers() {
+    // Preserve any active search query so recreating the controllers (e.g. on a
+    // dependency change) keeps the visible results in sync with the search field
+    // instead of leaving the UI in active-search mode with an empty query.
+    final searchQuery = _controller.text;
+
     if (_controllersAreInitialized) {
       _messageSearchListController.dispose();
       _channelListController.dispose();
@@ -43,12 +48,13 @@ class _ChannelList extends State<ChannelList> {
       client: _streamChat.client,
       filter: Filter.in_('members', [_streamChat.currentUser!.id]),
       limit: 5,
-      searchQuery: '',
+      searchQuery: searchQuery,
       sort: [
         const SortOption.desc(ChannelSortKey.pinnedAt),
         const SortOption.asc(ChannelSortKey.createdAt),
       ],
     );
+    if (searchQuery.isNotEmpty) _messageSearchListController.search(searchQuery);
     _channelListController = StreamChannelListController(
       client: _streamChat.client,
       predefinedFilter: 'stream_chat_flutter_sample_app',


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The avatar issue was introduced in: https://github.com/GetStream/stream-chat-flutter/pull/2827
The issue was not released yet, so no changelog entry needed for this.

The `channel.isOneToOne` checks if the channel state is already disposed and if it is it crashes. This PR adds a channel state check before that. 

In the ChannelList we have the issue that the `_messageSearchListController` was only created inside the dispose method, because of the `late final`. Now it's always created in `didChangeDependencies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented channel avatars from throwing errors when channel state is disposed during a rebuild.
  - Improved avatar rendering while membership data is updating or unavailable.
  - Ensured channel lists refresh correctly when the active chat context changes.
  - Preserved active channel-list searches during context changes and reapplied them automatically.

- **Tests**
  - Added regression coverage for avatar rebuilding after channel state disposal and member-data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->