### PR TITLE
ci(repo): pass the project root to pana

### DIFF
--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -47,7 +47,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        PANA=$(pana . --no-warning); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
+        PANA=$(pana . --no-warning --project-root "${{ github.workspace }}"); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
         echo "Score: $PANA_SCORE"
         IFS='/'; read -a SCORE_ARR <<< "$PANA_SCORE"; SCORE=SCORE_ARR[0];
         if (( $SCORE < ${{inputs.min_score}} )); then echo "The minimum score of ${{inputs.min_score}} was not met!"; exit 1; fi


### PR DESCRIPTION
## Problem

Every `pana` job has been failing on every branch since **2026-08-12 09:36 UTC**, when [`pana 0.23.18`](https://pub.dev/packages/pana/changelog) was published. The action runs `flutter pub global activate pana` unpinned, so runs picked it up automatically.

0.23.18 ships a breaking change:

> `--project-root` CLI option to specify the project's root directory. When specified, `pana` copies the entire tree for analysis.
> **BREAKING CHANGE**: the git-based detection is no longer used, users must specify the directory explicitly.

The action's "Temporary Override Local Dependencies" step rewrites the inter-package deps to relative path deps (`stream_chat: {path: ../stream_chat}`). Until now pana's git detection copied the whole repo to temp, so those paths resolved. 0.23.18 copies only `packages/<pkg>/`, and resolution fails:

```
Because stream_chat_flutter_core depends on stream_chat from path which doesn't exist
(could not find package stream_chat at "../stream_chat"), version solving failed.
Score: 40/160
The minimum score of 100 was not met!
```

`stream_chat` is the only job still green — it's the only package with no local path deps.

## Fix

Pass `--project-root "${{ github.workspace }}"` so pana copies the full tree again. Using `github.workspace` rather than a relative `../..` keeps this correct for any `working_directory` the action is called with; pana requires only that the package's pubspec be within the given root.

This unblocks the pana checks on all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated project verification by ensuring analysis runs against the correct project workspace.
  * Existing score extraction and threshold validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->