### PR TITLE
fix(llc): handle per-channel notification.mark_read events again

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed reaction groups synthesized from legacy `reaction_counts`/`reaction_scores` payloads being discarded at parse time when their score total was zero or negative despite a positive count.
 - Fixed `Channel.getReplies` adding the parent message to `ChannelClientState.threads` when a backend returns it alongside the replies, which rendered the thread root twice. The online path now filters it out, matching the offline one.
 - Fixed truncated channels dropping to the bottom of the list when sorting by `last_updated`.
+- Fixed `ChannelClientState` no longer handling `notification.mark_read` (regression since 9.20.0), which left `unreadCount` stale after `Channel.markRead` on channels the user isn't watching.
 
 ## 10.2.0
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -3450,7 +3450,7 @@ class ChannelClientState {
   void _listenReadEvents() {
     _subscriptions
       ..add(
-        _channel.on(EventType.messageRead).listen(
+        _channel.on(EventType.messageRead, EventType.notificationMarkRead).listen(
           (event) {
             // Skip handling the event if delivered for a thread
             if (event.thread != null) return;

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -6812,6 +6812,178 @@ void main() {
         },
       );
 
+      test(
+        'should reset unread count on notification mark read event',
+        () async {
+          final currentUser = client.state.currentUser!;
+          final currentRead = Read(
+            user: currentUser,
+            lastRead: DateTime(2020),
+            unreadMessages: 10,
+          );
+
+          // Setup initial read state
+          channel.state?.updateChannelState(
+            channel.state!.channelState.copyWith(
+              read: [currentRead],
+            ),
+          );
+
+          when(
+            () => client.channelDeliveryReporter.reconcileDelivery([channel]),
+          ).thenAnswer((_) => Future.value());
+
+          // Verify initial state
+          expect(channel.state?.unreadCount, 10);
+
+          // notification.mark_read is delivered on the reading user's own
+          // connection, so it reaches non-watched channels as well.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.notificationMarkRead,
+              user: currentUser,
+              createdAt: DateTime(2022),
+              lastReadMessageId: 'message-123',
+            ),
+          );
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Verify read state is updated
+          final updatedRead = channel.state?.read.first;
+          expect(updatedRead?.user.id, currentUser.id);
+          expect(channel.state?.unreadCount, 0);
+          expect(updatedRead?.lastReadMessageId, 'message-123');
+          expect(
+            updatedRead?.lastRead.isAtSameMomentAs(DateTime(2022)),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'should preserve delivery info on notification mark read event',
+        () async {
+          final currentUser = User(id: 'test-user');
+          final currentRead = Read(
+            user: currentUser,
+            lastRead: DateTime(2020),
+            unreadMessages: 10,
+            lastDeliveredAt: DateTime(2021),
+            lastDeliveredMessageId: 'delivered-msg-456',
+          );
+
+          // Setup initial read state
+          channel.state?.updateChannelState(
+            channel.state!.channelState.copyWith(
+              read: [currentRead],
+            ),
+          );
+
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.notificationMarkRead,
+              user: currentUser,
+              createdAt: DateTime(2022),
+              lastReadMessageId: 'message-123',
+            ),
+          );
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Verify read state is updated but delivery info is preserved
+          final updatedRead = channel.state?.read.first;
+          expect(updatedRead?.unreadMessages, 0);
+          expect(
+            updatedRead?.lastDeliveredAt?.isAtSameMomentAs(DateTime(2021)),
+            isTrue,
+          );
+          expect(updatedRead?.lastDeliveredMessageId, 'delivered-msg-456');
+        },
+      );
+
+      test(
+        'should not update channel read state on thread notification mark '
+        'read event',
+        () async {
+          final currentUser = User(id: 'test-user');
+          final currentRead = Read(
+            user: currentUser,
+            lastRead: DateTime(2020),
+            unreadMessages: 10,
+            lastReadMessageId: 'channel-msg-1',
+          );
+
+          // Setup initial read state
+          channel.state?.updateChannelState(
+            channel.state!.channelState.copyWith(
+              read: [currentRead],
+            ),
+          );
+
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.notificationMarkRead,
+              user: currentUser,
+              createdAt: DateTime(2022),
+              lastReadMessageId: 'thread-reply-99',
+              thread: Thread(
+                channelCid: channel.cid!,
+                parentMessageId: 'parent-msg-1',
+                createdByUserId: currentUser.id,
+                replyCount: 3,
+                participantCount: 2,
+              ),
+            ),
+          );
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Channel read state must be untouched — thread reads
+          // must not clobber the channel-level Read.
+          final after = channel.state?.read.first;
+          expect(after?.unreadMessages, 10);
+          expect(after?.lastReadMessageId, 'channel-msg-1');
+          expect(after?.lastRead.isAtSameMomentAs(DateTime(2020)), isTrue);
+        },
+      );
+
+      test(
+        'should reconcile delivery when notification mark read event is from '
+        'current user',
+        () async {
+          final currentUser = client.state.currentUser;
+
+          when(
+            () => client.channelDeliveryReporter.reconcileDelivery([channel]),
+          ).thenAnswer((_) => Future.value());
+
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.notificationMarkRead,
+              user: currentUser,
+              createdAt: DateTime(2022),
+              lastReadMessageId: 'message-123',
+            ),
+          );
+
+          // Wait for event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Verify reconcileDelivery was called
+          verify(
+            () => client.channelDeliveryReporter.reconcileDelivery([channel]),
+          ).called(1);
+        },
+      );
+
       test('should update read state on message delivered event', () async {
         final currentUser = User(id: 'test-user');
         final distantPast = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);


### PR DESCRIPTION
Linear: FLU-693
Github Issue: #2886

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested

## Description of the pull request

`ChannelClientState._listenReadEvents` subscribed to both `message.read` and `notification.mark_read` until the delivery-receipts refactor (#2429, `3b5e410bb`) split them into separate listeners and did not carry `notification.mark_read` over. The changelog documents the rest of that refactor but not this removal, so it looks unintentional.

That distinction is load-bearing:

- `message.read` is a **channel** event — delivered to watchers only.
- `notification.mark_read` is delivered on the reading user's **own connection** — so it reached the channel whether watched or not.

`Channel.markRead()` writes no local state itself, and channels are easily non-watched (`watch` is silently downgraded when there is no connection id). So from 9.20.0 on, marking a non-watched channel as read succeeded server-side while `unreadCount` stayed stale forever — the unread pill and divider survived the dismiss X, `markReadWhenAtTheBottom`, and every reopen, with no user action able to clear them.

The fix re-adds the event type to the existing listener:

```dart
_channel.on(EventType.messageRead, EventType.notificationMarkRead).listen(
```

**Not a literal revert.** The handler has improved since 9.19.0 — it now skips thread-scoped reads and preserves `lastDeliveredAt` / `lastDeliveredMessageId` — and the merged listener keeps both. Nothing from #2429 is undone.

### Verification against the backend event definition

Rather than infer the payload, I checked `lib/chat/event/notification_mark_read.go`. The two events are the same shape for every field the handler reads:

| Handler reads | `message.read` | `notification.mark_read` |
| --- | --- | --- |
| `event.thread` | `thread,omitempty` | `thread,omitempty` |
| `event.user` | yes | yes — non-nil at both emit sites |
| `event.createdAt` | yes | yes |
| `event.lastReadMessageId` | yes | yes |
| per-channel unread count | absent | absent |

Which settles three things:

- **`unreadMessages: 0` is correct, not a compromise.** `unread_messages` exists on exactly one event in the backend — `notification.mark_unread`. On `notification.mark_read`, `unread_count` / `total_unread_count` are account-wide totals, and `unread_count` is deprecated. Neither event can report this channel's count, so 0 is the only available value.
- **No `last_read_at`**, so `lastRead: event.createdAt` is right.
- **The thread guard is load-bearing.** `NewNotificationMarkThreadReadEvent` sets `Thread`, so thread mark-reads do arrive on this type and would otherwise clobber the channel-level `Read`.

Also confirmed: `read_state.go` returns early when `!channel.Config.ReadEvents`, so no event is emitted for read-events-disabled channel types — channels using local unread counts are unaffected. And `markAllRead()` posts `{}`, which routes to `MarkAllRead` → an event with no `cid`, exactly what the client-level handler's `if (event.cid != null) return;` expects. The channel-level / client-level split is correct.

## Testing

Four tests in `channel_test.dart`. I verified they actually catch the regression by reverting the one-line fix and re-running — three go red:

| Test | Without the fix |
| --- | --- |
| resets unread count on a non-watched channel | fails: `Expected: <0> Actual: <10>` |
| preserves delivery info | fails: `Expected: <0> Actual: <10>` |
| reconciles delivery for the current user | fails: `No matching calls` |
| ignores thread-scoped mark-reads | passes (negative test, guards the guard) |

Full `stream_chat` suite: 1624 passing. `dart analyze --fatal-infos` and `dart format` clean.

## Out of scope

- **Client-level counters are not broken on master.** The issue reports `totalUnreadCount` / `unreadChannels` going stale too, and the reporter shipped a client-level listener for it. That part isn't needed — `ClientState.subscribeToEvents` applies both from any event carrying them, and `set currentUser` pumps them through `_computeUnreadCounts`.
- **#2202** (reconnect `sync()` replay re-incrementing `unreadCount` via the non-idempotent `addNewMessage`) is real and related — through 9.19.0 this reset washed that drift away on the next mark-read — but it's a separate bug.
- **Test-coverage gap worth its own PR:** 10 other event subscriptions in `channel.dart` have zero test references anywhere in the suite, so any could be silently dropped the same way with CI staying green — `channel.truncated`, `notification.channel_truncated`, `channel.updated`, `member.added`, `member.removed`, `user.banned`, `user.unbanned`, `reaction.updated`, `poll.closed`, `poll.updated`. Tracked in FLU-693's notes.

## Screenshots / Videos

Not applicable — no visual change beyond the unread pill and divider now clearing, which is the bug itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread counts and read-state updates when marking a channel as read while not actively viewing it.
  * Preserved delivery information and correctly handled read events, including current-user updates.
  * Ignored thread-specific read notifications when updating channel-level state.

* **Tests**
  * Added coverage for unread counts, read states, delivery details, and thread-scoped notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->