### PR TITLE
fix(llc): update watcher count from realtime events and ignore events after dispose

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+✅ Added
+
+- Added `Event.watcherCount`, exposing the server-provided `watcher_count` field on events (e.g. `user.watching.start`, `user.watching.stop`, `message.new`).
+
 🔄 Changed
 
 - Raised the minimum `rate_limiter` version to `^1.1.1`.
@@ -7,6 +11,8 @@
 🐞 Fixed
 
 - Fixed `StreamChatClient.sync` letting a failure from its final `updateLastSyncAt` write escape to the caller; it is now handled by the method's own error handling, like every other sync failure.
+- Fixed `ChannelClientState.watcherCount` staying stale during a session.
+- Fixed watchers not being removed from `ChannelClientState.watchers` on `user.watching.stop`.
 
 ## 9.27.0
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `StreamChatClient.sync` letting a failure from its final `updateLastSyncAt` write escape to the caller; it is now handled by the method's own error handling, like every other sync failure.
 - Fixed `ChannelClientState.watcherCount` staying stale during a session.
 - Fixed watchers not being removed from `ChannelClientState.watchers` on `user.watching.stop`.
+- Fixed a `StateError` (`Cannot add new events after calling close`) thrown when the client is disposed while a reconnect recovery is still in flight.
 
 ## 9.27.0
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2438,6 +2438,7 @@ class ChannelClientState {
               watcher,
               ...?existingWatchers?.where((user) => user.id != watcher.id),
             ],
+            watcherCount: event.watcherCount,
           ));
         }
       }),
@@ -2449,12 +2450,13 @@ class ChannelClientState {
       _channel.on(EventType.userWatchingStop).listen((event) {
         final watcher = event.user;
         if (watcher != null) {
-          final existingWatchers = channelState.watchers;
-          updateChannelState(channelState.copyWith(
-            watchers: [
-              ...?existingWatchers?.where((user) => user.id != watcher.id)
-            ],
-          ));
+          final existingWatchers = channelState.watchers ?? const <User>[];
+          _channelState = channelState.copyWith(
+            watchers: existingWatchers
+                .where((user) => user.id != watcher.id)
+                .toList(),
+            watcherCount: event.watcherCount,
+          );
         }
       }),
     );
@@ -2887,6 +2889,13 @@ class ChannelClientState {
       }
 
       _client.channelDeliveryReporter.submitForDelivery([_channel]);
+
+      // Only message.new carries a reliable watcher count;
+      // notification.message_new targets non-watchers and reports 0.
+      if (event.watcherCount case final watcherCount?
+          when event.type == EventType.messageNew) {
+        updateChannelState(channelState.copyWith(watcherCount: watcherCount));
+      }
     }));
   }
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -38,6 +38,7 @@ import 'package:stream_chat/src/core/models/poll_vote.dart';
 import 'package:stream_chat/src/core/models/push_preference.dart';
 import 'package:stream_chat/src/core/models/thread.dart';
 import 'package:stream_chat/src/core/models/user.dart';
+import 'package:stream_chat/src/core/util/extension.dart';
 import 'package:stream_chat/src/core/util/in_flight_cache.dart';
 import 'package:stream_chat/src/core/util/utils.dart';
 import 'package:stream_chat/src/db/chat_persistence_client.dart';
@@ -540,11 +541,14 @@ class StreamChatClient {
 
   /// Method called to add a new event to the [_eventController].
   void handleEvent(Event event) {
+    // Ignore events that arrive after the client has been disposed.
+    if (_eventController.isClosed) return;
+
     if (event.type == EventType.healthCheck) {
       return _handleHealthCheckEvent(event);
     }
     state.updateUser(event.user);
-    return _eventController.add(event);
+    return _eventController.safeAdd(event);
   }
 
   void _onConnectionStatusChanged(

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -44,6 +44,7 @@ class Event {
     this.pushPreference,
     this.channelPushPreference,
     this.channelMessageCount,
+    this.watcherCount,
     this.lastDeliveredAt,
     this.lastDeliveredMessageId,
     this.extraData = const {},
@@ -168,6 +169,12 @@ class Event {
   /// The total number of messages in the channel.
   final int? channelMessageCount;
 
+  /// The number of users currently watching the channel.
+  ///
+  /// Sent with `user.watching.start`, `user.watching.stop` and `message.new`
+  /// events, reflecting the authoritative watcher count after the change.
+  final int? watcherCount;
+
   /// The date of the last delivered message.
   final DateTime? lastDeliveredAt;
 
@@ -216,6 +223,7 @@ class Event {
     'push_preference',
     'channel_push_preference',
     'channel_message_count',
+    'watcher_count',
     'last_delivered_at',
     'last_delivered_message_id',
   ];
@@ -262,6 +270,7 @@ class Event {
     PushPreference? pushPreference,
     ChannelPushPreference? channelPushPreference,
     int? channelMessageCount,
+    int? watcherCount,
     DateTime? lastDeliveredAt,
     String? lastDeliveredMessageId,
     Map<String, Object?>? extraData,
@@ -303,6 +312,7 @@ class Event {
         channelPushPreference:
             channelPushPreference ?? this.channelPushPreference,
         channelMessageCount: channelMessageCount ?? this.channelMessageCount,
+        watcherCount: watcherCount ?? this.watcherCount,
         lastDeliveredAt: lastDeliveredAt ?? this.lastDeliveredAt,
         lastDeliveredMessageId:
             lastDeliveredMessageId ?? this.lastDeliveredMessageId,

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -77,6 +77,7 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
           : ChannelPushPreference.fromJson(
               json['channel_push_preference'] as Map<String, dynamic>),
       channelMessageCount: (json['channel_message_count'] as num?)?.toInt(),
+      watcherCount: (json['watcher_count'] as num?)?.toInt(),
       lastDeliveredAt: json['last_delivered_at'] == null
           ? null
           : DateTime.parse(json['last_delivered_at'] as String),
@@ -131,6 +132,7 @@ Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
         'channel_push_preference': value,
       if (instance.channelMessageCount case final value?)
         'channel_message_count': value,
+      if (instance.watcherCount case final value?) 'watcher_count': value,
       if (instance.lastDeliveredAt?.toIso8601String() case final value?)
         'last_delivered_at': value,
       if (instance.lastDeliveredMessageId case final value?)

--- a/packages/stream_chat/test/fixtures/event.json
+++ b/packages/stream_chat/test/fixtures/event.json
@@ -30,5 +30,6 @@
   "ai_message": "Some message",
   "unread_thread_messages": 2,
   "unread_threads": 3,
-  "channel_last_message_at": "2019-03-27T17:40:17.155892Z"
+  "channel_last_message_at": "2019-03-27T17:40:17.155892Z",
+  "watcher_count": 12
 }

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -5147,6 +5147,198 @@ void main() {
       );
     });
 
+    group('Watching Events', () {
+      const channelId = 'test-channel-id';
+      const channelType = 'test-channel-type';
+      late Channel channel;
+
+      setUp(() {
+        final channelState = _generateChannelState(
+          channelId,
+          channelType,
+          mockChannelConfig: true,
+          ownCapabilities: const [ChannelCapability.readEvents],
+        );
+        channel = Channel.fromState(client, channelState);
+      });
+
+      tearDown(() => channel.dispose());
+
+      test(
+        '${EventType.userWatchingStart} adds the watcher and updates watcherCount',
+        () async {
+          final watcher = User(id: 'watcher-1');
+
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.userWatchingStart,
+              user: watcher,
+              watcherCount: 3,
+            ),
+          );
+
+          // Wait for the event to get processed
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 3);
+          expect(
+            channel.state!.channelState.watchers?.map((it) => it.id),
+            contains('watcher-1'),
+          );
+        },
+      );
+
+      test(
+        '${EventType.userWatchingStop} removes the watcher and updates watcherCount',
+        () async {
+          final watcher = User(id: 'watcher-1');
+
+          // The watcher starts watching first (count = 2).
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.userWatchingStart,
+              user: watcher,
+              watcherCount: 2,
+            ),
+          );
+          await Future.delayed(Duration.zero);
+          expect(channel.state!.watcherCount, 2);
+          expect(
+            channel.state!.channelState.watchers?.map((it) => it.id),
+            contains('watcher-1'),
+          );
+
+          // Then stops watching (count = 1).
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.userWatchingStop,
+              user: watcher,
+              watcherCount: 1,
+            ),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 1);
+          expect(
+            channel.state!.channelState.watchers?.map((it) => it.id),
+            isNot(contains('watcher-1')),
+          );
+        },
+      );
+
+      test(
+        'watching event without watcherCount preserves the existing count',
+        () async {
+          // Seed an initial watcher count.
+          channel.state!.updateChannelState(
+            channel.state!.channelState.copyWith(watcherCount: 5),
+          );
+          expect(channel.state!.watcherCount, 5);
+
+          // A watching event that omits watcher_count must not wipe the count.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.userWatchingStart,
+              user: User(id: 'watcher-2'),
+            ),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 5);
+          expect(
+            channel.state!.channelState.watchers?.map((it) => it.id),
+            contains('watcher-2'),
+          );
+        },
+      );
+
+      test(
+        '${EventType.messageNew} updates watcherCount from the event',
+        () async {
+          expect(channel.state!.watcherCount, isNull);
+
+          final message = Message(
+            id: 'test-message-id',
+            user: client.state.currentUser,
+            createdAt: DateTime.now(),
+          );
+
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.messageNew,
+              message: message,
+              watcherCount: 7,
+            ),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 7);
+        },
+      );
+
+      test(
+        '${EventType.messageNew} without watcherCount preserves the existing count',
+        () async {
+          // Seed an initial watcher count.
+          channel.state!.updateChannelState(
+            channel.state!.channelState.copyWith(watcherCount: 4),
+          );
+          expect(channel.state!.watcherCount, 4);
+
+          // A local/optimistic message.new without watcher_count must not
+          // reset the count.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.messageNew,
+              message: Message(
+                id: 'test-message-id-2',
+                user: client.state.currentUser,
+                createdAt: DateTime.now(),
+              ),
+            ),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 4);
+        },
+      );
+
+      test(
+        '${EventType.notificationMessageNew} does not overwrite watcherCount',
+        () async {
+          // Seed a known watcher count.
+          channel.state!.updateChannelState(
+            channel.state!.channelState.copyWith(watcherCount: 5),
+          );
+          expect(channel.state!.watcherCount, 5);
+
+          // notification.message_new is delivered to non-watchers and reports
+          // watcher_count: 0; it must not clobber the real count.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.notificationMessageNew,
+              message: Message(
+                id: 'notif-message-id',
+                user: User(id: 'other-user'),
+                createdAt: DateTime.now(),
+              ),
+              watcherCount: 0,
+            ),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(channel.state!.watcherCount, 5);
+        },
+      );
+    });
+
     group('Read Events', () {
       const channelId = 'test-channel-id';
       const channelType = 'test-channel-type';

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
+import 'dart:async';
+
 import 'package:mocktail/mocktail.dart';
 import 'package:stream_chat/src/core/http/token.dart';
 import 'package:stream_chat/stream_chat.dart';
@@ -4432,6 +4434,84 @@ void main() {
 
         verify(() => api.general.sync(cids, lastSyncAt)).called(1);
       });
+    });
+  });
+
+  group('dispose during reconnect recovery', () {
+    const apiKey = 'test-api-key';
+    final user = User(id: 'test-user-id');
+    final token = Token.development(user.id).rawValue;
+
+    late FakeChatApi api;
+    late FakeWebSocket ws;
+    late StreamChatClient client;
+    var disposed = false;
+
+    setUpAll(() {
+      registerFallbackValue(const PaginationParams());
+      registerFallbackValue(Filter.equal('cid', ''));
+    });
+
+    setUp(() {
+      api = FakeChatApi();
+      ws = FakeWebSocket();
+      disposed = false;
+    });
+
+    // The test disposes the client itself; avoid disposing it a second time.
+    tearDown(() async {
+      if (!disposed) await client.dispose();
+    });
+
+    // Disposing the client while a reconnect is still recovering must complete
+    // cleanly: recovery work that finishes after disposal is discarded, never
+    // surfacing as an error.
+    test('disposing mid-recovery does not surface a late recovery event',
+        () async {
+      // Keep the recovery's channel query pending so the client is still
+      // mid-recovery at the moment it is disposed.
+      final pendingQuery = Completer<QueryChannelsResponse>();
+      when(
+        () => api.channel.queryChannels(
+          filter: any(named: 'filter'),
+          sort: any(named: 'sort'),
+          state: any(named: 'state'),
+          watch: any(named: 'watch'),
+          presence: any(named: 'presence'),
+          memberLimit: any(named: 'memberLimit'),
+          messageLimit: any(named: 'messageLimit'),
+          paginationParams: any(named: 'paginationParams'),
+        ),
+      ).thenAnswer((_) => pendingQuery.future);
+
+      client = StreamChatClient(apiKey, chatApi: api, ws: ws);
+      await client.connectUser(user, token);
+      await delay(300);
+
+      // Track a channel so reconnecting triggers channel recovery, which then
+      // blocks on the pending query above.
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+
+      // Drop then restore the connection to start a reconnect recovery.
+      ws.connectionStatus = ConnectionStatus.disconnected;
+      await delay(100);
+      ws.connectionStatus = ConnectionStatus.connected;
+      await delay(100);
+
+      // Dispose while the recovery is still in flight.
+      await client.dispose();
+      disposed = true;
+
+      // Let the now-orphaned recovery finish. Its trailing work must be
+      // discarded silently instead of thrown as an unhandled async error.
+      pendingQuery.complete(QueryChannelsResponse()..channels = []);
+      await delay(300);
+
+      expect(client.wsConnectionStatus, ConnectionStatus.disconnected);
     });
   });
 }

--- a/packages/stream_chat/test/src/core/models/event_test.dart
+++ b/packages/stream_chat/test/src/core/models/event_test.dart
@@ -19,6 +19,7 @@ void main() {
       expect(event.unreadThreadMessages, 2);
       expect(event.unreadThreads, 3);
       expect(event.channelLastMessageAt, isA<DateTime>());
+      expect(event.watcherCount, 12);
       expect(event.lastReadAt, null);
       expect(event.unreadMessages, null);
       expect(event.lastReadMessageId, null);
@@ -62,6 +63,7 @@ void main() {
         unreadThreadMessages: 2,
         unreadThreads: 3,
         channelLastMessageAt: DateTime.parse('2019-03-27T17:40:17.155892Z'),
+        watcherCount: 9,
         lastReadAt: DateTime.parse('2020-02-10T10:00:00.000Z'),
         unreadMessages: 5,
         lastReadMessageId: 'last-read-message-id',
@@ -107,6 +109,7 @@ void main() {
           'unread_thread_messages': 2,
           'unread_threads': 3,
           'channel_last_message_at': '2019-03-27T17:40:17.155892Z',
+          'watcher_count': 9,
           'last_read_at': '2020-02-10T10:00:00.000Z',
           'unread_messages': 5,
           'last_read_message_id': 'last-read-message-id',
@@ -145,6 +148,7 @@ void main() {
       expect(newEvent.unreadThreadMessages, 2);
       expect(newEvent.unreadThreads, 3);
       expect(newEvent.channelLastMessageAt, isA<DateTime>());
+      expect(newEvent.watcherCount, 12);
       expect(newEvent.lastReadAt, null);
       expect(newEvent.unreadMessages, null);
       expect(newEvent.lastReadMessageId, null);
@@ -171,6 +175,7 @@ void main() {
         unreadThreadMessages: 6,
         unreadThreads: 7,
         channelLastMessageAt: DateTime.parse('2020-01-29T03:22:47.636130Z'),
+        watcherCount: 21,
         lastReadAt: DateTime.parse('2020-02-10T10:00:00.000000Z'),
         unreadMessages: 5,
         lastReadMessageId: 'last-read-message-id',
@@ -196,6 +201,7 @@ void main() {
         DateTime.parse('2020-02-10T10:00:00.000000Z'),
       );
       expect(newEvent.unreadMessages, 5);
+      expect(newEvent.watcherCount, 21);
       expect(newEvent.lastReadMessageId, 'last-read-message-id');
       expect(newEvent.draft, isNotNull);
       expect(newEvent.draft, equals(draft));


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-619, FLU-658

<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Backports **two** `llc` fixes from `master` to `v9`. They are independent; each is a separate commit.

---

## 1. Watcher count / watchers from realtime events — FLU-619

Backport of master commit [`84c6a24`](https://github.com/GetStream/stream-chat-flutter/commit/84c6a2483f3b349f94e6a02c18b19c109517903b) (originally #2837).

### Why

`ChannelClientState.watcherCount` and `ChannelClientState.watchers` never reflected realtime events during a session:

- The server's `watcher_count` on `user.watching.start` / `user.watching.stop` / `message.new` was dropped into `Event.extraData`, so the count stayed frozen at the last full `channel.watch()` / `queryChannels` snapshot.
- Watchers were never removed from `watchers` on `user.watching.stop` — the additive keyed merge in `updateChannelState` (needed for watcher pagination) can only upsert, so the departing watcher lingered until the next full query.

iOS and Android already trust the server-provided `watcher_count` per event, so Flutter was the outlier.

### Changes

- Add `Event.watcherCount`, mapping the server `watcher_count` field (promoted to a first-class field instead of `extraData`).
- Apply the count on `user.watching.start`, `user.watching.stop`, and `message.new`.
- Remove the departing watcher from `ChannelClientState.watchers` on `user.watching.stop` (assign `_channelState` directly, bypassing the additive merge).

`notification.message_new` / `notification.thread_message_new` are intentionally excluded: the backend fetches the watcher count only *after* the notification fan-out, so these events structurally carry `watcher_count: 0`.

### Port notes

Manual port, not a clean cherry-pick:

- **Formatting** — master formats at 120 cols; `v9` uses the 80-col default, so every touched hunk needed rewrapping.
- **`Event.deletedForMe`** — a master-only field adjacent to the ported hunks in `event.dart`; not brought over.
- **`_listenMessageNew`** — master extracted this handler's body into `addNewMessage`, which does not exist on `v9`. The extracted body was verified byte-for-byte identical to `v9`'s inline body, so the watcher-count block was appended at the equivalent point (after `submitForDelivery`).
- **`event.g.dart`** — regenerated with `json_serializable` pinned to `6.9.5`. The currently-resolving `6.14.1` emits Dart 3.10 null-aware map elements (`'key': ?instance.x`), which `v9`'s `sdk: ^3.6.2` rejects. Output matches `v9`'s existing `if (instance.x case final value?)` style. Note separately: this means `melos run generate:dart` is currently broken on `v9` with an up-to-date toolchain, independent of this PR.

### Performance note

The `message.new` handler's extra `updateChannelState` call is **O(1)**, not a message-list walk: `copyWith(watcherCount:)` preserves the `messages` list reference, and `merge` short-circuits on `identical(other, this)`. It does add one extra `channelStateStream` emission, in a path that already emits multiple times per message (`updateMessage`, then the `unreadCount` setter). Same shape and cost as on `master`.

---

## 2. Ignore events dispatched after the client is disposed — FLU-658

Backport of master commit [`4ba19d7`](https://github.com/GetStream/stream-chat-flutter/commit/4ba19d765a472480731c32f505a099bd4e197a48) (originally #2855).

### Why

`StreamChatClient.handleEvent` could throw `StateError: Cannot add new events after calling close` when the client was disposed while a **reconnect recovery** was still in flight.

`_onConnectionStatusChanged` is `async`. On an offline→online transition it awaits a recovery pipeline (`sync` / `queryChannelsOnline`) and only then emits the trailing `connectionRecovered` event, driven by a fire-and-forget subscription. If `dispose()` closes `_eventController` while that continuation is suspended on an `await`, the trailing `handleEvent` adds to a **closed** controller — surfacing as an unhandled async error.

### Changes

Guard `handleEvent` against a closed controller (early return on `isClosed`, plus `safeAdd`).

### Safety analysis on `v9`

Verified directly against the `v9` sources rather than inherited from the master PR:

- `_eventController.close()` has a single call site, inside `dispose()`.
- `disconnectUser()` closes the WS and resets state/credentials/persistence but leaves the event controller **open**, so the logout→login reuse path is unaffected — the guard cannot swallow events on a live or reused client.
- `_eventController` is a non-`late` `final` initialized inline and never reassigned, so `isClosed` is terminal for the client's lifetime.
- Post-`close()` the broadcast stream is already complete, so no subscriber could have received these events; the guard removes the throw, not a delivery.

**Semantic equivalence with master**, despite a controller-type divergence: master's `_eventController` is a master-only `EventController<Event>`, `v9`'s is a `PublishSubject<Event>` — but both are rxdart `Subject` subclasses backed by a broadcast `StreamController`, so `isClosed` is the same inherited implementation (`Subject.isClosed => _controller.isClosed`) and `safeAdd` resolves to the same `StreamControllerX` extension on both. The controllers differ only in *where* the poll-vote→poll-answer normalization happens (master overrides `EventController.add`; `v9` maps it in the `eventStream` getter), which is orthogonal to the guard.

Behaviour change worth naming (identical placement on master): because the guard precedes the health-check branch, a `health.check` arriving after dispose no longer runs `_handleHealthCheckEvent`. That is correct — `disconnectUser()` has by then reset the connection-id manager and closed the persistence connection, so those writes would target torn-down objects.

### Port notes

The `client.dart` hunk applies cleanly (`v9`'s `handleEvent` is byte-identical to master's pre-fix version). Two adaptations:

- `v9`'s `client.dart` lacked `import 'package:stream_chat/src/core/util/extension.dart'` (master has it), so `safeAdd` did not resolve until it was added. This is the only line beyond master's diff.
- The test group is appended at the end of `main()`. Master inserts it before `group('WS events')`, which does not exist in `v9`'s `client_test.dart`. `import 'dart:async'` was also added for `Completer`.

---

## Tests

**FLU-619** — new `Watching Events` group in `channel_test.dart`: start/stop update the count, stop removes the watcher, a null count preserves the existing value, `message.new` updates the count, `message.new` without a count preserves it, and `notification.message_new` does not overwrite it.

Beyond the master commit, `event_test.dart`'s existing parse / serialize / `copyWith` tests and `test/fixtures/event.json` were extended to cover `watcher_count`, following this repo's convention of extending existing serialization tests when adding model fields.

**FLU-658** — new `dispose during reconnect recovery` group in `client_test.dart`, disposing the client while a recovery is suspended on a held-open `queryChannels`, then resuming it. Verified as a genuine regression test: with the guard reverted it fails with exactly `Bad state: Cannot add new events after calling close`; with the guard it passes.

## Verification

- `melos run format` — clean (0 changed).
- `melos run analyze` — `stream_chat`: *No issues found*.
- Full `stream_chat` suite: **1309 pass, 2 skipped, 0 fail**.

## Screenshots / Videos

No UI changes.