### PR TITLE
chore(repo): fix release-pr skill step order and add a git-dep pre-flight check

### DIFF
--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -59,6 +59,16 @@ Run these checks. **If any fail, stop the skill, surface the failing check to th
 - `gh pr list --head release/v<version> --state all --json number` returns `[]`.
 - Latest CI on the base-branch tip is green: `gh run list --branch <base> --limit 5` — no failures on the most
   recent runs.
+- No publishable package depends on `stream_core_flutter` by git ref or path — pub.dev rejects both, and
+  `release_publish.yml` publishes in dependency order, so the earlier packages go live and only
+  `stream_chat_flutter` fails, leaving the version half-published:
+
+  ```bash
+  grep -n "stream-core-flutter.git\|path: .*stream_core_flutter" melos.yaml packages/*/pubspec.yaml
+  ```
+
+  Any hit is a hard stop: `stream_core_flutter` must be released to pub.dev first (its own repo has a `release-pr`
+  skill), then the pin swapped to a version constraint. Surface it and stop — don't pick the version yourself.
 
 ## Steps
 
@@ -135,24 +145,35 @@ For each, **apply the first matching rule below** — it's a decision tree, not 
 **Every package gets a `## <version>` header**, even if it's only a dep-bump line. Empty version sections and
 missing headers both fail pana.
 
-### 4. Sanity-check
+### 4. Analyze, then commit
 
 ```bash
 melos run analyze
-melos run lint:pub
 ```
 
-If either fails, surface to the user and stop.
-
-### 5. Commit and push
+If it fails, surface to the user and stop.
 
 ```bash
 git add -A
 git commit -m "chore(repo): release v<version>"
-git push -u origin release/v<version>
 ```
 
 Single commit. The message format is load-bearing: `release_tag.yml` parses `vX.Y.Z` from it after merge.
+
+`melos run lint:pub` is deliberately *not* here: it shells out to `pub publish -n`, which fails any dirty tree with
+"N checked-in files are modified in git". It can only pass once the release commit exists — hence step 5.
+
+### 5. Verify publishability, then push
+
+```bash
+melos run lint:pub
+```
+
+If it fails, surface to the user and stop — don't push.
+
+```bash
+git push -u origin release/v<version>
+```
 
 ### 6. Generate the PR body
 

--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -64,11 +64,13 @@ Run these checks. **If any fail, stop the skill, surface the failing check to th
   `stream_chat_flutter` fails, leaving the version half-published:
 
   ```bash
-  grep -n "stream-core-flutter.git\|path: .*stream_core_flutter" melos.yaml packages/*/pubspec.yaml
+  grep -n -A4 '^\s*stream_core_flutter:' melos.yaml packages/*/pubspec.yaml
   ```
 
-  Any hit is a hard stop: `stream_core_flutter` must be released to pub.dev first (its own repo has a `release-pr`
-  skill), then the pin swapped to a version constraint. Surface it and stop — don't pick the version yourself.
+  Match on the dependency key and its source, not on a URL spelling — `git:` takes a scalar URL as well as a map,
+  and the URL need not end in `.git`. Anything other than a single-line version constraint is a hard stop:
+  `stream_core_flutter` must be released to pub.dev first (its own repo has a `release-pr` skill), then the pin
+  swapped to a version constraint. Surface it and stop — don't pick the version yourself.
 
 ## Steps
 
@@ -154,11 +156,18 @@ melos run analyze
 If it fails, surface to the user and stop.
 
 ```bash
-git add -A
+git status --short          # nothing untracked should be release material
+git add -u                  # tracked modifications only
 git commit -m "chore(repo): release v<version>"
 ```
 
-Single commit. The message format is load-bearing: `release_tag.yml` parses `vX.Y.Z` from it after merge.
+`git add -u`, not `-A`: pre-flight's `git status --short -uno` ignores untracked files, so `-A` would sweep local
+artifacts into the release commit. If a release ever does need a genuinely new tracked file, add it by path — the
+`git diff --stat` comparison in step 2 is what catches the omission.
+
+Single commit. The message format is load-bearing: `release_tag.yml` parses `vX.Y.Z` from it after merge — and it
+gates on the **tip** commit of `master`, so the PR must be **squash-merged**. A merge commit would leave
+`Merge pull request #…` at the tip and the tag job would silently never fire.
 
 `melos run lint:pub` is deliberately *not* here: it shells out to `pub publish -n`, which fails any dirty tree with
 "N checked-in files are modified in git". It can only pass once the release commit exists — hence step 5.
@@ -168,6 +177,17 @@ Single commit. The message format is load-bearing: `release_tag.yml` parses `vX.
 ```bash
 melos run lint:pub
 ```
+
+This is the real publish gate. Read failures carefully — pub reports two severities and only one blocks:
+
+- **"Package validation found the following error"** — blocks. `release_publish.yml` runs `pub publish -f`, and
+  `-f` does **not** bypass errors. Must be fixed before merge.
+- **"potential issue" / "Package has N warnings"** — `-f` publishes through these. Worth fixing, not blocking.
+
+A common error is a `lib/` or `test/` file importing a package absent from that package's own `dependencies` /
+`dev_dependencies`; it resolves locally through a transitive dep and only `pub publish` catches it. Fix at the
+import (prefer the barrel the rest of the package already uses) or by declaring the dep, and tell the user the
+release PR now carries a source change.
 
 If it fails, surface to the user and stop — don't push.
 


### PR DESCRIPTION
Two fixes to the `release-pr` skill, both found while cutting v10.3.0 (#2899).

### 1. `lint:pub` ran before the commit, so it could never pass

Step 4 ran `melos run analyze` and `melos run lint:pub` together, then step 5 committed. But `lint:pub` shells out to `flutter pub publish -n`, which rejects a dirty tree:

```
* 4 checked-in files are modified in git.
  Usually you want to publish from a clean git state.
ERROR: Failed to update packages.
```

Every release run hits this. Split into: step 4 analyze + commit, step 5 `lint:pub` + push — so the publish gate runs against the tree that will actually be published, and still before anything is pushed.

### 2. No pre-flight check for a git/path `stream_core_flutter` dep

`packages/stream_chat_flutter/pubspec.yaml` carries a git pin whenever we're iterating on `stream_core_flutter` alongside this SDK (added by #2748 this cycle). pub.dev rejects git and path deps, so the release cannot publish.

It surfaced only at step 4, after a full `melos bs`. Worse, it would not have failed cleanly on merge: `release_publish.yml` publishes with `--order-dependents`, so `stream_chat`, `stream_chat_persistence` and `stream_chat_flutter_core` would have gone live at the new version before `stream_chat_flutter` failed — a half-published release, which is not reversible on pub.dev.

Now a one-second `grep` in pre-flight, with instructions to stop rather than pick a `stream_core_flutter` version unilaterally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release validation to detect unsupported Git- or path-based dependencies before publishing.
  * Added guidance to release required dependencies first and use version constraints.

* **Improvements**
  * Reordered release checks so analysis runs before committing and publishability validation runs before pushing.
  * Improved failure handling to stop immediately after blocking checks.
  * Clarified the distinction between publishability errors and non-blocking warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->