### PR TITLE
fix(ui): keep web text selection stable across browser context menu toggles

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 - Raised minimum Flutter to `>=3.44.0` and Dart SDK to `^3.12.0`.
 
+🐞 Fixed
+
+- Fixed a crash on web when the message list rebuilt while messages were selectable, for example after opening the attachment picker.
+- Fixed the browser's native context menu reappearing over the message context menu on web after scrolling messages out of view or deleting one.
+- Fixed the SDK re-enabling the browser's native context menu on web in apps that had disabled it themselves.
+
 ## 10.3.0
 
 ⚠️ Changed

--- a/packages/stream_chat_flutter/lib/src/context_menu/context_menu_region.dart
+++ b/packages/stream_chat_flutter/lib/src/context_menu/context_menu_region.dart
@@ -105,14 +105,12 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
   @override
   void initState() {
     super.initState();
-    // Prevent the browser's native context menu on web.
-    if (CurrentPlatform.isWeb) BrowserContextMenu.disableContextMenu();
+    _BrowserContextMenu.claim();
   }
 
   @override
   void dispose() {
-    // Restore browser context menu behavior.
-    if (CurrentPlatform.isWeb) BrowserContextMenu.enableContextMenu();
+    _BrowserContextMenu.release();
     super.dispose();
   }
 
@@ -136,5 +134,32 @@ class _ContextMenuRegionState extends State<ContextMenuRegion> {
       onSecondaryTapUp: (it) => _showContextMenu(context, it.globalPosition),
       child: widget.child,
     );
+  }
+}
+
+// Reference-counted suppression of the browser's native context menu.
+//
+// The setting is process-wide, so it stays suppressed while any region holds a
+// claim, and the last release only restores it if the app had it enabled.
+abstract final class _BrowserContextMenu {
+  static int _claims = 0;
+  static bool _restoreOnRelease = false;
+
+  static void claim() {
+    if (!CurrentPlatform.isWeb) return;
+    _claims += 1;
+    if (_claims > 1) return;
+    _restoreOnRelease = BrowserContextMenu.enabled;
+    if (!_restoreOnRelease) return;
+    return BrowserContextMenu.disableContextMenu().ignore();
+  }
+
+  static void release() {
+    if (!CurrentPlatform.isWeb) return;
+    assert(_claims > 0, 'release() called without a matching claim()');
+    _claims -= 1;
+    if (_claims > 0) return;
+    if (!_restoreOnRelease) return;
+    return BrowserContextMenu.enableContextMenu().ignore();
   }
 }

--- a/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_text.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_text.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:stream_chat_flutter/src/misc/empty_widget.dart';
 import 'package:stream_chat_flutter/src/stream_chat.dart';
@@ -85,7 +86,14 @@ class StreamMessageText extends StatelessWidget {
         );
 
         if (isDesktopDeviceOrWeb) {
-          return SelectionArea(onSelectionChanged: onSelectionChanged, child: streamMessageText);
+          return SelectionArea(
+            // Rebuilding a live selection area after the browser context menu
+            // toggles throws on web; the key replaces it instead.
+            // TODO: Remove once the minimum Flutter has flutter/flutter#186459.
+            key: ValueKey(BrowserContextMenu.enabled),
+            onSelectionChanged: onSelectionChanged,
+            child: streamMessageText,
+          );
         }
 
         return streamMessageText;

--- a/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_text.dart
+++ b/packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_text.dart
@@ -89,7 +89,7 @@ class StreamMessageText extends StatelessWidget {
           return SelectionArea(
             // Rebuilding a live selection area after the browser context menu
             // toggles throws on web; the key replaces it instead.
-            // TODO: Remove once the minimum Flutter has flutter/flutter#186459.
+            // TODO(flutter): Remove once the minimum Flutter has flutter/flutter#186459.
             key: ValueKey(BrowserContextMenu.enabled),
             onSelectionChanged: onSelectionChanged,
             child: streamMessageText,

--- a/packages/stream_chat_flutter/test/src/message_widget/stream_message_text_test.dart
+++ b/packages/stream_chat_flutter/test/src/message_widget/stream_message_text_test.dart
@@ -68,6 +68,21 @@ void main() {
     expect(find.byType(SelectionArea), findsOneWidget);
   });
 
+  testWidgets('StreamMessageText keys the selection area to the browser context menu state', (tester) async {
+    final user = OwnUser(id: 'test-user', language: 'en');
+    when(() => clientState.currentUser).thenReturn(user);
+    when(() => clientState.currentUserStream).thenAnswer((_) => Stream.value(user));
+
+    CurrentPlatform.debugCurrentPlatformOverride = PlatformType.macOS;
+
+    await tester.pumpWidget(wrap(StreamMessageText(message: Message(text: 'Hello world'))));
+    await tester.pump();
+
+    final selectionArea = tester.widget<SelectionArea>(find.byType(SelectionArea));
+    // The browser context menu is always enabled off web, so the key stays true.
+    expect(selectionArea.key, const ValueKey(true));
+  });
+
   testWidgets('StreamMessageText is not selectable on mobile', (tester) async {
     final user = OwnUser(id: 'test-user', language: 'en');
     when(() => clientState.currentUser).thenReturn(user);


### PR DESCRIPTION
Linear: FLU-712
Github Issue: #2906

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fixes #2906 — `Assertion failed: _selectable == null` on web, thrown from `SelectableRegion` when the attachment button is tapped in a channel.

### Cause

`SelectableRegion.build` conditionally wraps its subtree in `PlatformSelectableRegionContextMenu` based on `kIsWeb && BrowserContextMenu.enabled && <desktop target>`. Flipping that setting while a `SelectionArea` is mounted re-inflates the inner `SelectionContainer` before the old one unregisters, tripping the assert.

`ContextMenuRegion` flipped that **process-wide** setting from `initState`/`dispose`, and it mounts **once per message** on desktop/web. So opening a channel toggled the flag underneath every message's `SelectionArea`, and the next rebuild — tapping the attachment button, in the report — crashed.

This is [flutter/flutter#186459](https://github.com/flutter/flutter/issues/186459), fixed upstream by [#186553](https://github.com/flutter/flutter/pull/186553) (merged 2026-08-07). `git tag --contains 2a469b8` is empty, so it is in neither 3.47.0 nor 3.47.1 and lands in 3.48. Our published floor is `>=3.44.0`, so every supported Flutter version is affected.

The regression arrived in stable **3.41.0** via [#176855](https://github.com/flutter/flutter/pull/176855), which changed that wrapper condition from the compile-time constant `kIsWeb` to the runtime-mutable `_webContextMenuEnabled`. Before that, the subtree shape could never change and the toggle was harmless.

### Changes

**1. Key the selection area on the setting** (`stream_message_text.dart`) so a flip *replaces* the region — fresh state, nothing registered — instead of restructuring a live one.

This is safe rather than lucky: `selectable_region.dart` contains no `setState`, and its only inherited dependency (`MediaQuery.orientationOf`) sits after an early `return` for desktop target platforms. On exactly the platforms where the crash fires, `SelectableRegionState.build` can only re-run from a parent rebuild — which is when the key regenerates. Replacement is also clean: `_InactiveElements._unmount` is depth-first, so the old `_SelectionContainerState.dispose` → `registrar.remove` runs while the registrar still holds the matching `_selectable`.

**2. Reference-count the suppression** (`context_menu_region.dart`) — two SDK-side bugs, independent of the framework regression:

- Without a count, the **first** region to unmount called `enableContextMenu()` while dozens were still mounted, so the browser's native menu started appearing over ours. It churned more than it looks: `stream_message_item.dart` returns early for `isOutgoing`/`isDeleted`/empty-menu, and message tiles are not keep-alive clients, so the flag flipped every time a message scrolled out of view or was deleted.
- `release()` also re-enabled the menu unconditionally, overriding a host app that had deliberately disabled it. It now captures the prior state and restores only what it changed — which also means such apps never see a flip, and so cannot hit the crash at all.

### Scope

`StreamMessageText` is the only `SelectableRegion` in the SDK — verified across this repo and `stream_core_flutter`. `streaming_message_view.dart:81` passes `selectable: true` down to `flutter_markdown`, which uses `SelectableText.rich` (`EditableText`), a different mechanism that is unaffected.

Mobile web is untouched: `PlatformWidgetBase` dispatches on `defaultTargetPlatform`, so mobile web takes the `mobile` branch, no `ContextMenuRegion` mounts, and the flag never flips there.

### How this was tested

- New widget test pinning the key; it fails before the change (the key was `null`).
- CI is green, including the `stream_chat_flutter` suite. Two `stream_message_deleted` goldens fail on a local run, but they fail identically with the change stashed — pre-existing host drift on Flutter 3.47.0, and CI confirms it.
- `dart analyze --fatal-infos` and `dart format` clean.

**Test coverage is limited by the harness, deliberately.** `CurrentPlatform.isWeb` is false on the VM and `BrowserContextMenu.disableContextMenu()` asserts `kIsWeb` before touching the method channel, so the flag cannot be flipped in a VM test. Consequences:

- The reference count has no test at all. This is what the failing `codecov/patch` check is reporting.
- The key test is a deletion tripwire, not a specification. Mutation testing confirms it catches `key:` being removed and catches keying on the wrong global, but a hardcoded `key: const ValueKey(true)` — which defeats the fix entirely — passes it. Off-web every reachable value of `BrowserContextMenu.enabled` is `true`, so no VM assertion can tell "derived" from "constant".

A browser test that *does* catch all three mutations exists and is verified locally, following flutter/flutter#186553's own regression test (`@TestOn('browser')`, a mocked `SystemChannels.contextMenu`, and a `TargetPlatformVariant` excluding android/iOS). It needs a `--platform chrome` lane, which this package does not have — `test/flutter_test_config.dart` pulls in `alchemist`, which does not compile for web. That is tracked separately in FLU-713 rather than bundled into this fix.

### Known limitations

- A host app that wraps the channel page in its **own** `SelectionArea` is still exposed. The flag still flips, now once per channel enter/exit instead of per message mount/unmount. Not fixable from inside the SDK short of never restoring the browser menu.
- An active text selection is dropped if the flag flips mid-selection, since the region is replaced. Strictly better than the crash.
- Workaround removal at the 3.48 floor raise is tracked in FLU-710. Upstream's fix *preserves* the selection subtree across a flip, so ours is marginally worse once the floor moves.

## Screenshots / Videos

Not applicable — no visual change. This fixes a debug-mode assertion that red-screens the message text; the failure is a stack trace rather than a rendering difference. The reporter's video and full trace are in #2906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when selectable messages rebuild on web and desktop.
  * Prevented the browser’s native context menu from appearing over the SDK context menu.
  * Preserved applications’ existing native browser context-menu settings.
  * Restored native context-menu behavior only after all active SDK context-menu areas are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->