### PR TITLE
docs(repo): track workarounds blocked on a Flutter release

### DIFF
--- a/.claude/skills/flutter-version-bump/SKILL.md
+++ b/.claude/skills/flutter-version-bump/SKILL.md
@@ -534,6 +534,29 @@ Then, per `STYLE_GUIDE.md`, one short bullet under `🔄 Changed` in each of the
 
 Finish with `melos bootstrap` and commit the resulting root `pubspec.lock`.
 
+### Sweep the workarounds the new floor unblocks
+
+Still in Track B, after the constraints move. `FLUTTER_BLOCKED.md` lists every workaround that
+exists only because an upstream fix had not shipped; each row carries the release that makes it
+removable. Read it, and cross-check the code so a stale file cannot hide a site:
+
+```bash
+grep -rn 'TODO(flutter)' packages/ sample_app/   # every tagged site, even if the file drifted
+```
+
+For each row whose "Removable at" is now `<=` the new floor, confirm the fix really shipped
+before deleting anything — the recorded version is a prediction, and upstream fixes slip:
+
+```bash
+# in a Flutter checkout, using the fix commit named in the row
+git tag --contains <sha> | grep -vE '\-' | sort -V | head -1
+```
+
+Then remove the workaround, its `TODO(flutter)`, any test that only pinned the workaround's
+mechanism, and the row. If the fix slipped, re-date the row instead — do not silently drop it.
+
+Keep this in the Track B commit: it is only correct because the floor moved.
+
 ## Step 7 — Changelog and PR
 
 Track A changes that are user-visible (a widget swapped, a deprecation migrated) get a CHANGELOG bullet in the

--- a/FLUTTER_BLOCKED.md
+++ b/FLUTTER_BLOCKED.md
@@ -1,0 +1,56 @@
+# Workarounds blocked on a Flutter release
+
+Every workaround in this repo that exists only because an upstream Flutter fix has not
+shipped yet. Each one is removable the moment our published minimum Flutter includes the
+fix, so this file is the checklist for the floor raise in the
+[`flutter-version-bump`](.claude/skills/flutter-version-bump/SKILL.md) workflow.
+
+Code sites are tagged `// TODO(flutter): …`, so `grep -rn 'TODO(flutter)' packages/` finds
+them all even if this file falls behind. Keep both in sync: add the tag *and* a row here.
+
+## Open
+
+| Removable at | What | Where | Upstream |
+| --- | --- | --- | --- |
+| Flutter 3.48 (expected) | `SelectionArea` keyed on `BrowserContextMenu.enabled` | `stream_chat_flutter` · `src/message_widget/components/stream_message_text.dart` | [#186459](https://github.com/flutter/flutter/issues/186459) → [#186553](https://github.com/flutter/flutter/pull/186553) |
+
+### `SelectionArea` keyed on `BrowserContextMenu.enabled`
+
+**Symptom without the workaround.** On desktop web, `Assertion failed: _selectable == null`
+red-screens the message text as soon as the message list rebuilds after the browser
+context menu is toggled — in practice, opening a channel and then tapping the attachment
+button. Reported as [#2906](https://github.com/GetStream/stream-chat-flutter/issues/2906).
+
+**Cause.** `SelectableRegion.build` conditionally wraps its subtree in
+`PlatformSelectableRegionContextMenu` based on
+`kIsWeb && BrowserContextMenu.enabled && <desktop target>`. Flipping that setting while a
+`SelectionArea` is mounted re-inflates the inner `SelectionContainer` before the old one
+unregisters. The regression arrived in stable **3.41.0** via
+[#176855](https://github.com/flutter/flutter/pull/176855), which changed that condition
+from the compile-time constant `kIsWeb` to the runtime-mutable `_webContextMenuEnabled`.
+
+**Workaround.** `key: ValueKey(BrowserContextMenu.enabled)` on the `SelectionArea`, so a
+flip *replaces* the region — fresh state, nothing registered — instead of restructuring a
+live one.
+
+**Upstream fix.** [#186553](https://github.com/flutter/flutter/pull/186553), merged
+2026-08-07, adds a `GlobalKey` to the internal `SelectableRegionSelectionStatusScope` so
+the selection subtree reparents instead of being recreated. Confirm the release with
+`git tag --contains 2a469b880c19cbbec6aaa6329d4a4a9d1db22a4e` in a Flutter checkout —
+empty as of 3.47.1, so 3.48 is expected but **not** confirmed.
+
+**Why it is worth removing.** Upstream's fix preserves the selection subtree and any active
+selection across a flip; the key forces a full replacement, so the workaround is marginally
+worse than stock Flutter once the floor moves. Not urgent — it only churns when the flag
+flips, which is once per channel enter/exit on desktop web.
+
+**How to verify the removal.** Needs a `--platform chrome` lane, tracked in FLU-713, which
+carries a working browser test for exactly this transition. Do not trust the VM test
+(`'StreamMessageText keys the selection area to the browser context menu state'`) to prove
+the framework fix works — it passes even with the key hardcoded to a constant.
+
+**Do not remove** the reference-counted `_BrowserContextMenu` helper in
+`src/context_menu/context_menu_region.dart` along with the key. That fixes SDK-side bugs
+unrelated to the framework regression and is not blocked on any Flutter release.
+
+Tracked in FLU-710.

--- a/FLUTTER_BLOCKED.md
+++ b/FLUTTER_BLOCKED.md
@@ -1,68 +1,19 @@
 # Workarounds blocked on a Flutter release
 
-Every workaround in this repo that exists only because an upstream Flutter fix has not
-shipped yet. Each one is removable the moment our published minimum Flutter includes the
-fix, so this file is the checklist for the floor raise in the
-[`flutter-version-bump`](.claude/skills/flutter-version-bump/SKILL.md) workflow.
+Workarounds that exist only because an upstream Flutter fix has not shipped. The
+[`flutter-version-bump`](.claude/skills/flutter-version-bump/SKILL.md) floor raise reads
+this to decide what is now removable.
 
-Code sites are tagged `// TODO(flutter): …`, so `grep -rn 'TODO(flutter)' packages/` finds
-them all even if this file falls behind. Keep both in sync: add the tag *and* a row here.
+One registry for the whole monorepo: append an entry with the same fields, never add a
+file. Tag the code site `// TODO(flutter):` too, so `grep -rn 'TODO(flutter)'` finds it if
+this file drifts. Delete the entry when the workaround goes — git history is the archive.
 
-This is the single registry for the whole monorepo — every workaround lives here, not in a
-file of its own. There is one entry today; that is the current count, not the format.
+## `SelectionArea` keyed on `BrowserContextMenu.enabled`
 
-## Adding an entry
-
-Append a row to the table and a `###` section below it, matching the shape of the existing
-one. A section is worth writing only if it answers the four questions the person deleting
-the workaround will have: what breaks without it, which upstream release fixes it, how to
-confirm that release really carries the fix, and what must *not* be deleted alongside it.
-
-When a workaround is removed, delete its row and section — git history is the archive.
-
-## Open
-
-| Removable at | What | Where | Upstream |
-| --- | --- | --- | --- |
-| Flutter 3.48 (expected) | `SelectionArea` keyed on `BrowserContextMenu.enabled` | `stream_chat_flutter` · `src/message_widget/components/stream_message_text.dart` | [#186459](https://github.com/flutter/flutter/issues/186459) → [#186553](https://github.com/flutter/flutter/pull/186553) |
-
-### `SelectionArea` keyed on `BrowserContextMenu.enabled`
-
-**Symptom without the workaround.** On desktop web, `Assertion failed: _selectable == null`
-red-screens the message text as soon as the message list rebuilds after the browser
-context menu is toggled — in practice, opening a channel and then tapping the attachment
-button. Reported as [#2906](https://github.com/GetStream/stream-chat-flutter/issues/2906).
-
-**Cause.** `SelectableRegion.build` conditionally wraps its subtree in
-`PlatformSelectableRegionContextMenu` based on
-`kIsWeb && BrowserContextMenu.enabled && <desktop target>`. Flipping that setting while a
-`SelectionArea` is mounted re-inflates the inner `SelectionContainer` before the old one
-unregisters. The regression arrived in stable **3.41.0** via
-[#176855](https://github.com/flutter/flutter/pull/176855), which changed that condition
-from the compile-time constant `kIsWeb` to the runtime-mutable `_webContextMenuEnabled`.
-
-**Workaround.** `key: ValueKey(BrowserContextMenu.enabled)` on the `SelectionArea`, so a
-flip *replaces* the region — fresh state, nothing registered — instead of restructuring a
-live one.
-
-**Upstream fix.** [#186553](https://github.com/flutter/flutter/pull/186553), merged
-2026-08-07, adds a `GlobalKey` to the internal `SelectableRegionSelectionStatusScope` so
-the selection subtree reparents instead of being recreated. Confirm the release with
-`git tag --contains 2a469b880c19cbbec6aaa6329d4a4a9d1db22a4e` in a Flutter checkout —
-empty as of 3.47.1, so 3.48 is expected but **not** confirmed.
-
-**Why it is worth removing.** Upstream's fix preserves the selection subtree and any active
-selection across a flip; the key forces a full replacement, so the workaround is marginally
-worse than stock Flutter once the floor moves. Not urgent — it only churns when the flag
-flips, which is once per channel enter/exit on desktop web.
-
-**How to verify the removal.** Needs a `--platform chrome` lane, tracked in FLU-713, which
-carries a working browser test for exactly this transition. Do not trust the VM test
-(`'StreamMessageText keys the selection area to the browser context menu state'`) to prove
-the framework fix works — it passes even with the key hardcoded to a constant.
-
-**Do not remove** the reference-counted `_BrowserContextMenu` helper in
-`src/context_menu/context_menu_region.dart` along with the key. That fixes SDK-side bugs
-unrelated to the framework regression and is not blocked on any Flutter release.
-
-Tracked in FLU-710.
+- **Removable at:** Flutter 3.48 — predicted, not confirmed
+- **Site:** `packages/stream_chat_flutter/lib/src/message_widget/components/stream_message_text.dart`
+- **Upstream:** [flutter#186459](https://github.com/flutter/flutter/issues/186459), fixed by [flutter#186553](https://github.com/flutter/flutter/pull/186553) (`2a469b88`)
+- **Confirm the release:** `git tag --contains 2a469b88` in a Flutter checkout — empty as of 3.47.1
+- **Verify removal:** needs the browser test in FLU-713; the VM test passes even with the key hardcoded
+- **Keep:** `_BrowserContextMenu` in `context_menu_region.dart` — reference counting, not Flutter-blocked
+- **Tracked:** FLU-710, [#2906](https://github.com/GetStream/stream-chat-flutter/issues/2906)

--- a/FLUTTER_BLOCKED.md
+++ b/FLUTTER_BLOCKED.md
@@ -8,6 +8,18 @@ fix, so this file is the checklist for the floor raise in the
 Code sites are tagged `// TODO(flutter): …`, so `grep -rn 'TODO(flutter)' packages/` finds
 them all even if this file falls behind. Keep both in sync: add the tag *and* a row here.
 
+This is the single registry for the whole monorepo — every workaround lives here, not in a
+file of its own. There is one entry today; that is the current count, not the format.
+
+## Adding an entry
+
+Append a row to the table and a `###` section below it, matching the shape of the existing
+one. A section is worth writing only if it answers the four questions the person deleting
+the workaround will have: what breaks without it, which upstream release fixes it, how to
+confirm that release really carries the fix, and what must *not* be deleted alongside it.
+
+When a workaround is removed, delete its row and section — git history is the archive.
+
 ## Open
 
 | Removable at | What | Where | Upstream |

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1095,12 +1095,10 @@ Include an issue link when the deferred work is tracked; if the constraint is
 self-explanatory ("wait for backend enrichment", "wait for next major"), a link isn't
 required.
 
-A workaround that only exists because an upstream Flutter fix has not shipped yet uses
-the `// TODO(flutter):` tag, links the `flutter/flutter` issue, and gets a row in
-[`FLUTTER_BLOCKED.md`](FLUTTER_BLOCKED.md). Both matter: the row carries the context that
-does not fit in a comment, and the tag means `grep -rn 'TODO(flutter)'` still finds every
-site if the file falls behind. The floor raise reads that file to decide what is now
-removable.
+A workaround that only exists because an upstream Flutter fix has not shipped yet uses the
+`// TODO(flutter):` tag and gets an entry in
+[`FLUTTER_BLOCKED.md`](FLUTTER_BLOCKED.md), which the floor raise reads. Both matter: the
+entry holds what does not fit in a comment, the tag survives the file drifting.
 
 ### Bare ignore directives are fine
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1095,6 +1095,13 @@ Include an issue link when the deferred work is tracked; if the constraint is
 self-explanatory ("wait for backend enrichment", "wait for next major"), a link isn't
 required.
 
+A workaround that only exists because an upstream Flutter fix has not shipped yet uses
+the `// TODO(flutter):` tag, links the `flutter/flutter` issue, and gets a row in
+[`FLUTTER_BLOCKED.md`](FLUTTER_BLOCKED.md). Both matter: the row carries the context that
+does not fit in a comment, and the tag means `grep -rn 'TODO(flutter)'` still finds every
+site if the file falls behind. The floor raise reads that file to decide what is now
+removable.
+
 ### Bare ignore directives are fine
 
 `// ignore: rule_name` directives do not require an explanatory comment in this repo.


### PR DESCRIPTION
Linear: FLU-725
Github Issue: #

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Implements @renefloor's [review suggestion on #2909](https://github.com/GetStream/stream-chat-flutter/pull/2909#discussion_r3831142625):

> We should (probably with AI) make a separate file with all TODO's that depend on a flutter version, so we can quickly fix all todo's when we update a flutter version.

Three pieces, because a file nobody is required to read does not help:

**`FLUTTER_BLOCKED.md`** — the registry. A scan table plus a detail section per entry: the symptom without the workaround, the cause, the upstream issue *and* fix PR, the release that makes it removable, how to verify that release actually carries the fix, and how to verify the removal. It also records what must **not** be deleted alongside each workaround.

**`STYLE_GUIDE.md`** — one paragraph in the TODO section pairing every row with a `// TODO(flutter):` tag at the code site. The tag isn't redundant with the file: it means `grep -rn 'TODO(flutter)'` still finds every site if the file falls behind, so a stale registry can't silently hide one. The existing `TODO(perf-migration)` precedent already sanctions category tags.

**`.claude/skills/flutter-version-bump/SKILL.md`** — a sweep step in the Track B floor raise, which previously did not mention TODOs at all. This is the part that delivers the actual goal: under the latest−1 policy every Flutter stable triggers a floor raise, so that step is a guaranteed moment when the registry gets read. It also insists on confirming the fix really shipped before deleting anything, since the recorded version is a prediction and upstream fixes slip.

### One entry today

`SelectionArea` keyed on `BrowserContextMenu.enabled` — the workaround from #2909, removable at Flutter 3.48 (expected, unconfirmed: `git tag --contains 2a469b8` is still empty as of 3.47.1).

Of the 17 `TODO`s across all packages' `lib/`, that is the only Flutter-version-dependent one; the rest are blocked on the backend, on our own refactors, or on unrelated features.

### Merge order

**Merge after #2909.** The registry's only entry describes the workaround and the `TODO(flutter)` tag that #2909 introduces, so this reads as documenting nothing until that lands.

### How this was tested

Documentation and skill content only — no package code, so no changelog entry and nothing for the test suites to exercise. Verified the referenced paths exist (`stream_message_text.dart`, `context_menu_region.dart`, the skill's Track B section) and that the `grep -rn 'TODO(flutter)'` command in both the file and the skill returns the one expected site.

## Screenshots / Videos

Not applicable — no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for tracking Flutter-dependent workarounds and verifying upstream fixes.
  * Simplified the Flutter workaround registry for clearer maintenance and status tracking.
  * Documented the existing text-selection workaround, verification details, and removal criteria.
  * Updated style guidance for consistently labeling and recording Flutter-related workarounds.
  * Clarified how to remove resolved workaround entries, related tests, and tracking information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->