### PR TITLE
fix(ci): prevent command injection in release tag workflow

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -26,10 +26,12 @@ jobs:
       - name: 🏷️ Extract Version Tag
         id: extract_tag
         shell: bash
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
 
-          commit_msg="${{ github.event.head_commit.message }}"
+          commit_msg="$COMMIT_MSG"
           echo "📦 Commit message: $commit_msg"
 
           # Match vX.Y.Z or vX.Y.Z-suffix (case-insensitive)


### PR DESCRIPTION
Potential fix for [https://github.com/GetStream/stream-chat-flutter/security/code-scanning/39](https://github.com/GetStream/stream-chat-flutter/security/code-scanning/39)

The safest fix is to **stop embedding `${{ github.event.head_commit.message }}` directly inside `run:` script text**. Instead, pass it through an environment variable on the step and only reference the shell variable in the script. This prevents workflow-expression content from becoming executable shell code during script generation.

Best minimal change (no functional change):
- In `.github/workflows/release_tag.yml`, update the **“🏷️ Extract Version Tag”** step:
  - Add an `env:` block with e.g. `COMMIT_MSG: ${{ github.event.head_commit.message }}`.
  - Replace `commit_msg="${{ github.event.head_commit.message }}"` with `commit_msg="$COMMIT_MSG"`.
- Keep all existing logic (regex match, output tag, error handling) unchanged.

No new methods, definitions, or imports are needed in this YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow handling for commit messages.
  * Enhanced reliability when creating release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->