### PR TITLE
chore(llc): deprecate `StreamChatClient.unflagMessage` and `unflagUser`

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Raised minimum Dart SDK to `^3.12.0`.
 
+⚠️ Deprecated
+
+- Deprecated `StreamChatClient.unflagMessage` and `StreamChatClient.unflagUser`. The `/moderation/unflag` endpoint is no longer supported by the server and the calls have no effect; both methods will be removed in a future major release.
+
 ## 10.3.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1898,13 +1898,29 @@ class StreamChatClient {
   /// Flag a message
   Future<EmptyResponse> flagMessage(String messageId) => _chatApi.moderation.flagMessage(messageId);
 
-  /// Unflag a message
+  /// Unflag a message.
+  ///
+  /// The `/moderation/unflag` endpoint is no longer processed by the server:
+  /// the request is validated and an empty response is returned, but no flag
+  /// is removed.
+  @Deprecated(
+    'The /moderation/unflag endpoint is no longer supported by the server. '
+    'This will be removed in a future major release',
+  )
   Future<EmptyResponse> unflagMessage(String messageId) => _chatApi.moderation.unflagMessage(messageId);
 
   /// Flag a user
   Future<EmptyResponse> flagUser(String userId) => _chatApi.moderation.flagUser(userId);
 
-  /// Unflag a message
+  /// Unflag a user.
+  ///
+  /// The `/moderation/unflag` endpoint is no longer processed by the server:
+  /// the request is validated and an empty response is returned, but no flag
+  /// is removed.
+  @Deprecated(
+    'The /moderation/unflag endpoint is no longer supported by the server. '
+    'This will be removed in a future major release',
+  )
   Future<EmptyResponse> unflagUser(String userId) => _chatApi.moderation.unflagUser(userId);
 
   /// Mark all channels for this user as read

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_redundant_argument_values, lines_longer_than_80_chars
+// ignore_for_file: avoid_redundant_argument_values, lines_longer_than_80_chars, deprecated_member_use_from_same_package
 
 import 'dart:async';
 


### PR DESCRIPTION
## Description

Deprecates `StreamChatClient.unflagMessage` and `StreamChatClient.unflagUser` — **without replacement** — with a note that they will be removed in a future major release.

These are the only consumer-reachable methods that hit `POST /moderation/unflag`, and that endpoint is dead server-side.

### Server-side verification

Verified against `GetStream/chat` at HEAD `b5ab22204a` — confirmed from source, not inferred:

1. **Explicitly deprecated in the OpenAPI contract.** `lib/chat/controller/v1/unflag.go` declares `Deprecated: true` in its `OpenAPIInfo()`. The sibling `flag.go` does not — the pair is asymmetric.
2. **It has been a no-op since 2021-12-16** — commit `3c6323ebb2`, *"[CHAT-2694] Make unflag message/user no-op. (#2850)"*. The handler validates the request and returns an empty `Flag{}`, with no DB write, no event emission, and no call into moderation v2. By contrast `Flag.Handle` is fully live.
3. **There is no replacement.** `/api/v2/moderation/...` has no `unflag` route at all; in v2 a flag is resolved by a review-queue action (`mark_reviewed`, `restore`, `unblock`, `unban`), never by reversing the flag.

### Changes

- `@Deprecated` on `StreamChatClient.unflagMessage` / `unflagUser`, with dartdoc stating the current behavior (request validated, empty response returned, no flag removed).
- Fixes a copy-paste bug: `unflagUser` was documented as *"Unflag a message"*.
- `CHANGELOG.md` entry under `⚠️ Deprecated`.
- `deprecated_member_use_from_same_package` added to the existing `ignore_for_file` in `client_test.dart`, matching the precedent in `message_test.dart` and `channel_test.dart`. It does not fire on the pinned stable analyzer, but is kept as insurance for the beta-channel analyze job.

**No behavior change** — the methods still issue the request. This is a compile-time signal only.

### Out of scope

- `ModerationApi.unflagMessage` / `unflagUser` are untouched — `ModerationApi` is not exported from `stream_chat.dart`, so it is not consumer-reachable.
- `flagMessage` / `flagUser` are live and used by the UI (`stream_message_item.dart`); not touched.

### Blast radius

Repo-wide, `unflag` appears in only 4 files, all inside `packages/stream_chat`. Zero usages in `stream_chat_flutter_core`, `stream_chat_flutter`, `stream_chat_persistence`, `sample_app`, any `example/`, or any docs.

## Verification

- `dart analyze --fatal-infos` clean on `lib` and the touched tests
- `dart format --set-exit-if-changed` clean
- `client_test.dart` + `moderation_api_test.dart`: **208 tests pass**, unchanged
- Confirmed from a consumer package (`stream_chat_flutter`) that both methods now report `deprecated_member_use` with the intended message, and that `flagMessage` does **not**

## Related

A companion PR applies the same change to `v9`.

Linear: FLU-735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecations**
  - Deprecated message and user unflagging methods.
  - These methods are no longer supported by the server and will be removed in a future major release.

- **Documentation**
  - Added migration guidance and clarified that unflag requests are no longer processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->