### PR TITLE
chore(llc): deprecate `StreamChatClient.unflagMessage` and `unflagUser` (v9)

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+⚠️ Deprecated
+
+- Deprecated `StreamChatClient.unflagMessage` and `StreamChatClient.unflagUser`. The `/moderation/unflag` endpoint is no longer supported by the server and the calls have no effect; both methods will be removed in a future major release.
+
 ## 9.28.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -1873,7 +1873,15 @@ class StreamChatClient {
   Future<EmptyResponse> flagMessage(String messageId) =>
       _chatApi.moderation.flagMessage(messageId);
 
-  /// Unflag a message
+  /// Unflag a message.
+  ///
+  /// The `/moderation/unflag` endpoint is no longer processed by the server:
+  /// the request is validated and an empty response is returned, but no flag
+  /// is removed.
+  @Deprecated(
+    'The /moderation/unflag endpoint is no longer supported by the server. '
+    'This will be removed in a future major release',
+  )
   Future<EmptyResponse> unflagMessage(String messageId) =>
       _chatApi.moderation.unflagMessage(messageId);
 
@@ -1881,7 +1889,15 @@ class StreamChatClient {
   Future<EmptyResponse> flagUser(String userId) =>
       _chatApi.moderation.flagUser(userId);
 
-  /// Unflag a message
+  /// Unflag a user.
+  ///
+  /// The `/moderation/unflag` endpoint is no longer processed by the server:
+  /// the request is validated and an empty response is returned, but no flag
+  /// is removed.
+  @Deprecated(
+    'The /moderation/unflag endpoint is no longer supported by the server. '
+    'This will be removed in a future major release',
+  )
   Future<EmptyResponse> unflagUser(String userId) =>
       _chatApi.moderation.unflagUser(userId);
 

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: avoid_redundant_argument_values
+// ignore_for_file: deprecated_member_use_from_same_package
 
 import 'dart:async';
 


### PR DESCRIPTION
v9 counterpart of #2923.

## Description

Deprecates `StreamChatClient.unflagMessage` and `StreamChatClient.unflagUser` — **without replacement** — with a note that they will be removed in a future major release.

These are the only consumer-reachable methods that hit `POST /moderation/unflag`, and that endpoint is dead server-side.

### Server-side verification

Verified against `GetStream/chat` at HEAD `b5ab22204a` — confirmed from source, not inferred:

1. **Explicitly deprecated in the OpenAPI contract.** `lib/chat/controller/v1/unflag.go` declares `Deprecated: true` in its `OpenAPIInfo()`. The sibling `flag.go` does not — the pair is asymmetric.
2. **It has been a no-op since 2021-12-16** — commit `3c6323ebb2`, *"[CHAT-2694] Make unflag message/user no-op. (#2850)"*. The handler validates the request and returns an empty `Flag{}`, with no DB write, no event emission, and no call into moderation v2. By contrast `Flag.Handle` is fully live.
3. **There is no replacement.** `/api/v2/moderation/...` has no `unflag` route at all; in v2 a flag is resolved by a review-queue action (`mark_reviewed`, `restore`, `unblock`, `unban`), never by reversing the flag.

### Changes

- `@Deprecated` on `StreamChatClient.unflagMessage` / `unflagUser`, with dartdoc stating the current behavior (request validated, empty response returned, no flag removed).
- Fixes a copy-paste bug: `unflagUser` was documented as *"Unflag a message"*.
- New `## Upcoming` section in `CHANGELOG.md` with the `⚠️ Deprecated` entry (9.28.0 is already tagged and published).
- `deprecated_member_use_from_same_package` ignore in `client_test.dart`, as a second `ignore_for_file` line so it stays within v9's 80-column limit.

**No behavior change** — the methods still issue the request. This is a compile-time signal only.

### Not a cherry-pick

Applied by hand rather than cherry-picked from #2923: the branches have divergent formatter config (`master` uses `page_width: 120`; `v9` uses the default 80 columns plus the `lines_longer_than_80_chars` lint), so the method bodies and the test ignore are laid out differently here.

### Out of scope

- `ModerationApi.unflagMessage` / `unflagUser` are untouched — `ModerationApi` is not exported from `stream_chat.dart`, so it is not consumer-reachable.
- `flagMessage` / `flagUser` are live and used by the UI; not touched.

## Verification

- `dart analyze --fatal-infos .` — **no issues found** (whole package)
- `dart format --set-exit-if-changed .` — clean, 227 files, 0 changed
- `client_test.dart` + `moderation_api_test.dart`: **171 tests pass**, behavior unchanged
- Confirmed `package_config.json` reports `languageVersion: 3.6`, matching v9's `sdk: ^3.6.2` — no stale-format churn

Linear: FLU-735

🤖 Generated with [Claude Code](https://claude.com/claude-code)