### PR TITLE
fix(llc): keep Channel.memberCount fresh from channel events

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+✅ Added
+
+- Added `Event.channelMemberCount`, exposing the server-provided `channel_member_count` field on channel events (e.g. `member.added`, `member.removed`, `member.updated`).
+
 🔄 Changed
 
 - `Channel.translateMessage` now merges the translated message into the channel state, so the translation reaches anything watching the channel without the caller applying the response itself.
@@ -7,6 +11,7 @@
 
 🐞 Fixed
 
+- Fixed `Channel.memberCount` / `memberCountStream` staying stale for the rest of the session after members joined or left; channel events now apply the server-provided member count, the same way `messageCount` already did.
 - Fixed reconnect state recovery surfacing an uncatchable error when the connection dropped again mid-recovery; it is now logged, and `connection.recovered` still fires. [#2910](https://github.com/GetStream/stream-chat-flutter/issues/2910)
 - Fixed every failed websocket connect leaving an unhandled error in the root zone, which crash reporters listening on `PlatformDispatcher.onError` report as a fatal crash. [#2921](https://github.com/GetStream/stream-chat-flutter/issues/2921)
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -2526,7 +2526,7 @@ class ChannelClientState {
     // region CHANNEL EVENTS
     _listenChannelTruncated();
     _listenChannelUpdated();
-    _listenChannelMessageCount();
+    _listenChannelCounts();
     // endregion
 
     // region MEMBER EVENTS
@@ -2680,16 +2680,22 @@ class ChannelClientState {
     );
   }
 
-  void _listenChannelMessageCount() {
+  // Most channel events carry the channel's member and message counts as
+  // event metadata, reflecting the authoritative values after the change.
+  // Applying them keeps the counts fresh for the whole session instead of
+  // only right after a `query` / `watch`.
+  void _listenChannelCounts() {
     _subscriptions.add(
       _channel.on().listen(
         (Event e) {
+          final memberCount = e.channelMemberCount;
           final messageCount = e.channelMessageCount;
-          if (messageCount == null) return;
+          if (memberCount == null && messageCount == null) return;
 
           updateChannelState(
             channelState.copyWith(
               channel: channelState.channel?.copyWith(
+                memberCount: memberCount,
                 messageCount: messageCount,
               ),
             ),

--- a/packages/stream_chat/lib/src/core/models/event.dart
+++ b/packages/stream_chat/lib/src/core/models/event.dart
@@ -45,6 +45,7 @@ class Event {
     this.reminder,
     this.pushPreference,
     this.channelPushPreference,
+    this.channelMemberCount,
     this.channelMessageCount,
     this.watcherCount,
     this.lastDeliveredAt,
@@ -172,6 +173,13 @@ class Event {
   /// Push notification preferences for the current user for this channel.
   final ChannelPushPreference? channelPushPreference;
 
+  /// The total number of members in the channel.
+  ///
+  /// Sent with channel events such as `member.added`, `member.removed` and
+  /// `member.updated`, reflecting the authoritative member count after the
+  /// change.
+  final int? channelMemberCount;
+
   /// The total number of messages in the channel.
   final int? channelMessageCount;
 
@@ -229,6 +237,7 @@ class Event {
     'reminder',
     'push_preference',
     'channel_push_preference',
+    'channel_member_count',
     'channel_message_count',
     'watcher_count',
     'last_delivered_at',
@@ -277,6 +286,7 @@ class Event {
     MessageReminder? reminder,
     PushPreference? pushPreference,
     ChannelPushPreference? channelPushPreference,
+    int? channelMemberCount,
     int? channelMessageCount,
     int? watcherCount,
     DateTime? lastDeliveredAt,
@@ -318,6 +328,7 @@ class Event {
     reminder: reminder ?? this.reminder,
     pushPreference: pushPreference ?? this.pushPreference,
     channelPushPreference: channelPushPreference ?? this.channelPushPreference,
+    channelMemberCount: channelMemberCount ?? this.channelMemberCount,
     channelMessageCount: channelMessageCount ?? this.channelMessageCount,
     watcherCount: watcherCount ?? this.watcherCount,
     lastDeliveredAt: lastDeliveredAt ?? this.lastDeliveredAt,

--- a/packages/stream_chat/lib/src/core/models/event.g.dart
+++ b/packages/stream_chat/lib/src/core/models/event.g.dart
@@ -56,6 +56,7 @@ Event _$EventFromJson(Map<String, dynamic> json) => Event(
       : ChannelPushPreference.fromJson(
           json['channel_push_preference'] as Map<String, dynamic>,
         ),
+  channelMemberCount: (json['channel_member_count'] as num?)?.toInt(),
   channelMessageCount: (json['channel_message_count'] as num?)?.toInt(),
   watcherCount: (json['watcher_count'] as num?)?.toInt(),
   lastDeliveredAt: json['last_delivered_at'] == null ? null : DateTime.parse(json['last_delivered_at'] as String),
@@ -101,6 +102,7 @@ Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
   'reminder': ?instance.reminder?.toJson(),
   'push_preference': ?instance.pushPreference?.toJson(),
   'channel_push_preference': ?instance.channelPushPreference?.toJson(),
+  'channel_member_count': ?instance.channelMemberCount,
   'channel_message_count': ?instance.channelMessageCount,
   'watcher_count': ?instance.watcherCount,
   'last_delivered_at': ?instance.lastDeliveredAt?.toIso8601String(),

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -10016,6 +10016,209 @@ void main() {
         },
       );
     });
+
+    group('Channel member count events', () {
+      const channelId = 'test-channel-id';
+      const channelType = 'test-channel-type';
+      late Channel channel;
+
+      setUp(() {
+        final channelState = _generateChannelState(channelId, channelType);
+        channel = Channel.fromState(client, channelState);
+      });
+
+      tearDown(() {
+        channel.dispose();
+      });
+
+      test(
+        'should update channel memberCount when event contains channelMemberCount',
+        () async {
+          // Verify initial state - default memberCount
+          expect(channel.memberCount, equals(0));
+
+          // Create event with channelMemberCount
+          final memberCountEvent = Event(
+            cid: channel.cid,
+            type: EventType.memberAdded,
+            member: Member(
+              userId: 'user-1',
+              user: User(id: 'user-1'),
+            ),
+            channelMemberCount: 42,
+          );
+
+          // Dispatch event
+          client.addEvent(memberCountEvent);
+
+          // Wait for the event to be processed
+          await Future.delayed(Duration.zero);
+
+          // Verify channel memberCount was updated
+          expect(channel.memberCount, equals(42));
+        },
+      );
+
+      test(
+        'should update channel memberCount from member.added and member.removed events',
+        () async {
+          // Test with member.added event - count increases
+          final memberAddedEvent = Event(
+            cid: channel.cid,
+            type: EventType.memberAdded,
+            member: Member(
+              userId: 'user-1',
+              user: User(id: 'user-1'),
+            ),
+            channelMemberCount: 1,
+          );
+
+          client.addEvent(memberAddedEvent);
+          await Future.delayed(Duration.zero);
+          expect(channel.memberCount, equals(1));
+          expect(channel.state?.channelState.members?.map((it) => it.userId), equals(['user-1']));
+
+          // Test with another member.added event - count increases
+          final memberAddedEvent2 = Event(
+            cid: channel.cid,
+            type: EventType.memberAdded,
+            member: Member(
+              userId: 'user-2',
+              user: User(id: 'user-2'),
+            ),
+            channelMemberCount: 2,
+          );
+
+          client.addEvent(memberAddedEvent2);
+          await Future.delayed(Duration.zero);
+          expect(channel.memberCount, equals(2));
+          expect(
+            channel.state?.channelState.members?.map((it) => it.userId),
+            equals(['user-1', 'user-2']),
+          );
+
+          // Test with member.removed event - count decreases
+          final memberRemovedEvent = Event(
+            cid: channel.cid,
+            type: EventType.memberRemoved,
+            user: User(id: 'user-1'),
+            channelMemberCount: 1,
+          );
+
+          client.addEvent(memberRemovedEvent);
+          await Future.delayed(Duration.zero);
+          expect(channel.memberCount, equals(1));
+          expect(channel.state?.channelState.members?.map((it) => it.userId), equals(['user-2']));
+        },
+      );
+
+      test(
+        'should preserve other channel properties when updating memberCount',
+        () async {
+          // Set initial channel state with some properties
+          final initialChannel = channel.state?.channelState.channel?.copyWith(
+            extraData: {'name': 'Test Channel'},
+            messageCount: 7,
+            frozen: true,
+          );
+
+          if (initialChannel != null) {
+            channel.state?.updateChannelState(
+              channel.state!.channelState.copyWith(channel: initialChannel),
+            );
+          }
+
+          // Verify initial state
+          expect(channel.name, 'Test Channel');
+          expect(channel.messageCount, equals(7));
+          expect(channel.frozen, equals(true));
+          expect(channel.memberCount, equals(0));
+
+          // Update memberCount via event
+          final memberCountEvent = Event(
+            cid: channel.cid,
+            type: EventType.memberAdded,
+            member: Member(
+              userId: 'user-1',
+              user: User(id: 'user-1'),
+            ),
+            channelMemberCount: 100,
+          );
+
+          client.addEvent(memberCountEvent);
+          await Future.delayed(Duration.zero);
+
+          // Verify memberCount was updated while preserving other properties
+          expect(channel.memberCount, equals(100));
+          expect(channel.name, 'Test Channel');
+          expect(channel.messageCount, equals(7));
+          expect(channel.frozen, equals(true));
+        },
+      );
+
+      test(
+        'should not update memberCount when the event omits channelMemberCount',
+        () async {
+          // Seed a known member count.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.memberAdded,
+              member: Member(
+                userId: 'user-1',
+                user: User(id: 'user-1'),
+              ),
+              channelMemberCount: 5,
+            ),
+          );
+
+          await Future.delayed(Duration.zero);
+          expect(channel.memberCount, equals(5));
+
+          // An event without the field should leave the count untouched.
+          client.addEvent(
+            Event(
+              cid: channel.cid,
+              type: EventType.memberAdded,
+              member: Member(
+                userId: 'user-2',
+                user: User(id: 'user-2'),
+              ),
+            ),
+          );
+
+          await Future.delayed(Duration.zero);
+          expect(channel.memberCount, equals(5));
+        },
+      );
+
+      test(
+        'should provide memberCountStream for reactive updates',
+        () async {
+          expectLater(
+            channel.memberCountStream.distinct(),
+            emitsInOrder([0, 1, 5, 10]),
+          );
+
+          // Update memberCount multiple times
+          final counts = [1, 5, 10];
+          for (final count in counts) {
+            final event = Event(
+              cid: channel.cid,
+              type: EventType.memberAdded,
+              member: Member(
+                userId: 'user-$count',
+                user: User(id: 'user-$count'),
+              ),
+              channelMemberCount: count,
+            );
+
+            client.addEvent(event);
+            await Future.delayed(Duration.zero);
+          }
+        },
+      );
+    });
   });
 
   group('Channel filterTags', () {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`Channel.memberCount` / `memberCountStream` reads `member_count` off the channel model, and that field was only ever written by a server payload — a `query` / `watch` response or a `channel.updated` event. The `member.added` / `member.removed` handlers update the loaded member list but leave the count alone, so the count went stale for the rest of the session as soon as anyone joined or left the channel.

This is not a recent regression: the handlers are byte-for-byte identical from `3.0.0` through `10.3.0`, and there were no tests covering member-event state handling at all. It became more visible in 10.0, where `isGroup` / `isOneToOne` started reading `memberCount` more directly.

### The fix

The backend already ships the authoritative count as `channel_member_count` event metadata on channel events — it sits in the same `ChannelMetadataEvent` struct as the `channel_message_count` we already consume, and `member.added`, `member.removed` and `member.updated` all declare it. We simply weren't parsing it.

- Added `Event.channelMemberCount` (`channel_member_count`).
- `ChannelClientState` now applies it to `ChannelModel.memberCount`, so the count self-heals from any channel event rather than only right after a `query` / `watch`.
- Folded the member-count and message-count handling into a single `_listenChannelCounts` listener, so an event carrying both produces one state update instead of two.

Taking the server's number rather than doing a local `± 1` avoids drift when events are missed or replayed. For reference, `stream-chat-swift` does a local increment/decrement in its livestream handler; reading the server field is strictly more robust.

### Testing

Five new tests in `channel_test.dart` mirroring the existing message-count group: single-event update, an added → added → removed sequence (asserting the member list and the count stay in step), other channel properties preserved, no update when the field is absent, and `memberCountStream` emitting reactively.

`stream_chat`: 1631 tests pass, `dart analyze --fatal-infos` clean, `dart format` clean. `stream_chat_flutter_core`: 362 tests pass.

## Screenshots / Videos

Not applicable — LLC state change with no UI surface of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Channel events now include the current member count.
  - Channel member counts update reactively when members join, leave, or are updated.

- **Bug Fixes**
  - Fixed stale `memberCount` values and member-count streams after channel membership changes.
  - Preserved channel state correctly when member-count updates are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->