### PR TITLE
perf(llc): make primitive value streams distinct

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `Channel.translateMessage` now merges the translated message into the channel state, so the translation reaches anything watching the channel without the caller applying the response itself.
 - Raised minimum Dart SDK to `^3.12.0`.
+- `Channel` and `ClientState` streams that expose a single primitive value are now distinct, so they only emit when the value actually changes. Affects `Channel.memberCountStream`, `messageCountStream`, `watcherCountStream`, `cooldownStream`, `nameStream`, `imageStream`, `frozenStream`, `disabledStream`, `hiddenStream`, `isPinnedStream`, `isArchivedStream`, `createdAtStream`, `updatedAtStream`, `deletedAtStream`, `truncatedAtStream`, `lastMessageAtStream`, and `ClientState.totalUnreadCountStream`, `unreadChannelsStream`, `unreadThreadsStream`.
 
 🐞 Fixed
 

--- a/packages/stream_chat/lib/src/client/channel.dart
+++ b/packages/stream_chat/lib/src/client/channel.dart
@@ -241,7 +241,7 @@ class Channel {
   /// Channel frozen status as a stream.
   Stream<bool> get frozenStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.frozen == true);
+    return state!.channelStateStream.map((cs) => cs.channel?.frozen == true).distinct();
   }
 
   /// Channel disabled status.
@@ -253,7 +253,7 @@ class Channel {
   /// Channel disabled status as a stream.
   Stream<bool> get disabledStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.disabled == true);
+    return state!.channelStateStream.map((cs) => cs.channel?.disabled == true).distinct();
   }
 
   /// Channel hidden status.
@@ -265,7 +265,7 @@ class Channel {
   /// Channel hidden status as a stream.
   Stream<bool> get hiddenStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.hidden == true);
+    return state!.channelStateStream.map((cs) => cs.channel?.hidden == true).distinct();
   }
 
   /// Channel pinned status.
@@ -278,7 +278,7 @@ class Channel {
   /// Channel pinned status as a stream.
   /// Status is specific to the current user.
   Stream<bool> get isPinnedStream {
-    return membershipStream.map((m) => m?.pinnedAt != null);
+    return membershipStream.map((m) => m?.pinnedAt != null).distinct();
   }
 
   /// Channel archived status.
@@ -291,7 +291,7 @@ class Channel {
   /// Channel archived status as a stream.
   /// Status is specific to the current user.
   Stream<bool> get isArchivedStream {
-    return membershipStream.map((m) => m?.archivedAt != null);
+    return membershipStream.map((m) => m?.archivedAt != null).distinct();
   }
 
   /// The last date at which the channel got truncated.
@@ -303,7 +303,7 @@ class Channel {
   /// The last date at which the channel got truncated as a stream.
   Stream<DateTime?> get truncatedAtStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.truncatedAt);
+    return state!.channelStateStream.map((cs) => cs.channel?.truncatedAt).distinct();
   }
 
   /// Cooldown count
@@ -315,7 +315,7 @@ class Channel {
   /// Cooldown count as a stream
   Stream<int> get cooldownStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.cooldown ?? 0);
+    return state!.channelStateStream.map((cs) => cs.channel?.cooldown ?? 0).distinct();
   }
 
   /// Remaining cooldown duration in seconds for the channel.
@@ -350,7 +350,7 @@ class Channel {
   /// Channel creation date as a stream.
   Stream<DateTime?> get createdAtStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.createdAt);
+    return state!.channelStateStream.map((cs) => cs.channel?.createdAt).distinct();
   }
 
   /// Channel last message date.
@@ -362,7 +362,7 @@ class Channel {
   /// Channel last message date as a stream.
   Stream<DateTime?> get lastMessageAtStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.lastMessageAt);
+    return state!.channelStateStream.map((cs) => cs.channel?.lastMessageAt).distinct();
   }
 
   DateTime? _currentUserLastMessageAt({
@@ -442,7 +442,7 @@ class Channel {
   /// Channel updated date as a stream.
   Stream<DateTime?> get updatedAtStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.updatedAt);
+    return state!.channelStateStream.map((cs) => cs.channel?.updatedAt).distinct();
   }
 
   /// Channel deletion date.
@@ -454,7 +454,7 @@ class Channel {
   /// Channel deletion date as a stream.
   Stream<DateTime?> get deletedAtStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.deletedAt);
+    return state!.channelStateStream.map((cs) => cs.channel?.deletedAt).distinct();
   }
 
   /// Channel member count.
@@ -466,7 +466,7 @@ class Channel {
   /// Channel member count as a stream.
   Stream<int?> get memberCountStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.memberCount);
+    return state!.channelStateStream.map((cs) => cs.channel?.memberCount).distinct();
   }
 
   /// Channel message count.
@@ -484,7 +484,7 @@ class Channel {
   /// enabled for your app.
   Stream<int?> get messageCountStream {
     _checkInitialized();
-    return state!.channelStateStream.map((cs) => cs.channel?.messageCount);
+    return state!.channelStateStream.map((cs) => cs.channel?.messageCount).distinct();
   }
 
   /// List of filter tags applied to this channel.
@@ -548,7 +548,7 @@ class Channel {
   /// {@macro name}
   Stream<String?> get nameStream {
     _checkInitialized();
-    return extraDataStream.map((it) => it['name'] as String?);
+    return extraDataStream.map((it) => it['name'] as String?).distinct();
   }
 
   /// Shortcut to get channel image.
@@ -563,7 +563,7 @@ class Channel {
   /// {@macro image}
   Stream<String?> get imageStream {
     _checkInitialized();
-    return extraDataStream.map((it) => it['image'] as String?);
+    return extraDataStream.map((it) => it['image'] as String?).distinct();
   }
 
   /// The main Stream chat client.
@@ -3592,7 +3592,7 @@ class ChannelClientState {
   int? get watcherCount => _channelState.watcherCount;
 
   /// Channel watcher count as a stream.
-  Stream<int?> get watcherCountStream => channelStateStream.map((cs) => cs.watcherCount);
+  Stream<int?> get watcherCountStream => channelStateStream.map((cs) => cs.watcherCount).distinct();
 
   /// Channel watchers list.
   List<User> get watchers => (_channelState.watchers ?? <User>[]).map((e) => _client.state.users[e.id] ?? e).toList();

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -2928,19 +2928,19 @@ class ClientState {
   int get unreadChannels => _unreadChannelsController.value;
 
   /// The current unread channels count as a stream
-  Stream<int> get unreadChannelsStream => _unreadChannelsController.stream;
+  Stream<int> get unreadChannelsStream => _unreadChannelsController.stream.distinct();
 
   /// The current unread thread count.
   int get unreadThreads => _unreadThreadsController.value;
 
   /// The current unread threads count as a stream.
-  Stream<int> get unreadThreadsStream => _unreadThreadsController.stream;
+  Stream<int> get unreadThreadsStream => _unreadThreadsController.stream.distinct();
 
   /// The current total unread messages count
   int get totalUnreadCount => _totalUnreadCountController.value;
 
   /// The current total unread messages count as a stream
-  Stream<int> get totalUnreadCountStream => _totalUnreadCountController.stream;
+  Stream<int> get totalUnreadCountStream => _totalUnreadCountController.stream.distinct();
 
   /// The current list of channels in memory as a stream
   Stream<Map<String, Channel>> get channelsStream => _channelsController.stream;

--- a/packages/stream_chat/test/src/client/channel_test.dart
+++ b/packages/stream_chat/test/src/client/channel_test.dart
@@ -9991,19 +9991,19 @@ void main() {
       test(
         'should provide messageCountStream for reactive updates',
         () async {
-          expectLater(
-            channel.messageCountStream.distinct(),
-            emitsInOrder([null, 1, 5, 10]),
-          );
+          final emitted = <int?>[];
+          final subscription = channel.messageCountStream.listen(emitted.add);
+          addTearDown(subscription.cancel);
+          await Future.delayed(Duration.zero);
 
-          // Update messageCount multiple times
-          final counts = [1, 5, 10];
-          for (final count in counts) {
+          // Update messageCount multiple times, repeating one of the counts.
+          final counts = [1, 5, 5, 10];
+          for (final (index, count) in counts.indexed) {
             final event = Event(
               cid: channel.cid,
               type: EventType.messageNew,
               message: Message(
-                id: 'msg-$count',
+                id: 'msg-$index',
                 text: 'Message $count',
                 user: User(id: 'user-1'),
               ),
@@ -10013,6 +10013,9 @@ void main() {
             client.addEvent(event);
             await Future.delayed(Duration.zero);
           }
+
+          // The repeated count should not be emitted twice.
+          expect(emitted, equals([null, 1, 5, 10]));
         },
       );
     });
@@ -10195,20 +10198,20 @@ void main() {
       test(
         'should provide memberCountStream for reactive updates',
         () async {
-          expectLater(
-            channel.memberCountStream.distinct(),
-            emitsInOrder([0, 1, 5, 10]),
-          );
+          final emitted = <int?>[];
+          final subscription = channel.memberCountStream.listen(emitted.add);
+          addTearDown(subscription.cancel);
+          await Future.delayed(Duration.zero);
 
-          // Update memberCount multiple times
-          final counts = [1, 5, 10];
-          for (final count in counts) {
+          // Update memberCount multiple times, repeating one of the counts.
+          final counts = [1, 5, 5, 10];
+          for (final (index, count) in counts.indexed) {
             final event = Event(
               cid: channel.cid,
               type: EventType.memberAdded,
               member: Member(
-                userId: 'user-$count',
-                user: User(id: 'user-$count'),
+                userId: 'user-$index',
+                user: User(id: 'user-$index'),
               ),
               channelMemberCount: count,
             );
@@ -10216,6 +10219,9 @@ void main() {
             client.addEvent(event);
             await Future.delayed(Duration.zero);
           }
+
+          // The repeated count should not be emitted twice.
+          expect(emitted, equals([0, 1, 5, 10]));
         },
       );
     });

--- a/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input/stream_message_composer.dart
@@ -687,7 +687,7 @@ class DefaultStreamMessageComposerState extends State<DefaultStreamMessageCompos
         _ => channel.state?.draftStream,
       };
 
-      _draftStreamSubscription = draftStream?.distinct().listen(_onDraftUpdate);
+      _draftStreamSubscription = draftStream?.listen(_onDraftUpdate);
     }
 
     // Keeps the composer in sync with remote message changes.


### PR DESCRIPTION
`Channel` and `ClientState` getters that map to a single primitive value emitted on every channel-state / current-user update, even when the value was unchanged. Pushing four distinct message counts through `messageCountStream` produced 13 emissions; `memberCountStream` fired on every new message.

Those getters now `.distinct()`, matching the stream getters in `channel.dart` that already do (`ownCapabilitiesStream`, `messagesStream`, `draftStream`, …). Scope is primitives only (`bool`, `int`, `String?`, `DateTime?`) — model and collection streams are untouched.

The composer's `distinct()` on the draft stream is dropped as redundant; `ChannelClientState.draftStream` and `threadDraftStream` already dedupe.

## Verification

- The `memberCountStream` / `messageCountStream` tests now push a repeated count through and assert the full emission list. Checked red against `origin/master`'s `channel.dart` (`[null, 1, 5, 10]` expected, `[null, null, null, 1, 1, 1, 5, 5, 5, 5, 5, 5, 10]` actual) and green with this change.
- `stream_chat`: `dart test` 1631 passing, `dart analyze --fatal-infos` clean.
- `stream_chat_flutter_core`: `flutter test` 362 passing.
- `stream_chat_flutter`: `flutter test` 1311 passing; 2 failures are pre-existing missing macOS goldens for `stream_message_deleted_test.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Channel state streams now emit updates only when their values change, reducing duplicate notifications.
  - Unread count streams for channels, threads, and total unread counts now suppress consecutive duplicate values.
  - Draft updates in the message composer are now received for every emission, including repeated values.
- **Documentation**
  - Updated changelog documentation to reflect stream emission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->