### PR TITLE
fix(llc): ignore the ws channel `ready` future, don't let reconnect recovery throw into the root zone

### DIFF
--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 🐞 Fixed
 
+- Fixed reconnect state recovery surfacing an uncatchable error when the connection dropped again mid-recovery; it is now logged, and `connection.recovered` still fires. [#2910](https://github.com/GetStream/stream-chat-flutter/issues/2910)
 - Fixed `Channel.memberCount` / `memberCountStream` staying stale for the rest of the session after members joined or left; channel events now apply the server-provided member count, the same way `messageCount` already did.
 - Fixed every failed websocket connect leaving an unhandled error in the root zone, which crash reporters listening on `PlatformDispatcher.onError` report as a fatal crash. [#2921](https://github.com/GetStream/stream-chat-flutter/issues/2921)
 

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -15,6 +15,7 @@
 🐞 Fixed
 
 - Fixed `Channel.memberCount` / `memberCountStream` staying stale for the rest of the session after members joined or left; channel events now apply the server-provided member count, the same way `messageCount` already did.
+- Fixed every failed websocket connect leaving an unhandled error in the root zone, which crash reporters listening on `PlatformDispatcher.onError` report as a fatal crash. [#2921](https://github.com/GetStream/stream-chat-flutter/issues/2921)
 
 ## 9.28.0
 

--- a/packages/stream_chat/lib/src/client/client.dart
+++ b/packages/stream_chat/lib/src/client/client.dart
@@ -573,16 +573,23 @@ class StreamChatClient {
       // connection recovered
       final cids = [...state.channels.keys.toSet()];
       if (cids.isNotEmpty) {
-        // Sync the persistence client if available
-        if (persistenceEnabled) await sync(cids: cids);
+        // Recovery is best-effort: the connection can drop again while it is
+        // in flight. Nothing awaits this method, so an error here would
+        // surface as an unhandled crash instead of reaching the app.
+        try {
+          // Sync the persistence client if available
+          if (persistenceEnabled) await sync(cids: cids);
 
-        // Recover the channels that were active before the connection was lost,
-        // only if the client is configured to do so.
-        if (_recoverStateOnReconnect) {
-          await queryChannelsOnline(
-            filter: Filter.in_('cid', cids),
-            paginationParams: const PaginationParams(limit: 30),
-          );
+          // Recover the channels that were active before the connection was
+          // lost, only if the client is configured to do so.
+          if (_recoverStateOnReconnect) {
+            await queryChannelsOnline(
+              filter: Filter.in_('cid', cids),
+              paginationParams: const PaginationParams(limit: 30),
+            );
+          }
+        } catch (e, stk) {
+          logger.warning('Error recovering state on reconnect', e, stk);
         }
       }
 

--- a/packages/stream_chat/lib/src/ws/websocket.dart
+++ b/packages/stream_chat/lib/src/ws/websocket.dart
@@ -134,9 +134,9 @@ class WebSocket with TimerHelper {
     }
     _webSocketChannel =
         webSocketChannelProvider?.call(uri) ?? WebSocketChannel.connect(uri);
-    // Connection failures (e.g. DNS errors during background) are delivered
-    // via the stream's onError below; ignore the duplicate signal on sink.done
-    // so it doesn't surface as an unhandled future error.
+    // Connect failures reach onError below; ignore the ready and sink.done
+    // duplicates so they aren't reported as unhandled errors.
+    _webSocketChannel?.ready.ignore();
     _webSocketChannel?.sink.done.ignore();
     _subscribeToWebSocketChannel();
   }

--- a/packages/stream_chat/test/src/client/client_test.dart
+++ b/packages/stream_chat/test/src/client/client_test.dart
@@ -4438,6 +4438,76 @@ void main() {
     });
   });
 
+  group('reconnect state recovery', () {
+    const apiKey = 'test-api-key';
+    final user = User(id: 'test-user-id');
+    final token = Token.development(user.id).rawValue;
+
+    late FakeChatApi api;
+    late FakeWebSocket ws;
+    late StreamChatClient client;
+
+    setUpAll(() {
+      registerFallbackValue(const PaginationParams());
+      registerFallbackValue(Filter.equal('cid', ''));
+    });
+
+    setUp(() {
+      api = FakeChatApi();
+      ws = FakeWebSocket();
+    });
+
+    tearDown(() async {
+      await client.dispose();
+    });
+
+    // Recovery runs inside the client's own connection-status listener, so a
+    // failure there has no future for the app to catch. It must be swallowed,
+    // and must not stop `connectionRecovered` from firing.
+    test('should not surface an error when the re-query fails', () async {
+      when(
+        () => api.channel.queryChannels(
+          filter: any(named: 'filter'),
+          sort: any(named: 'sort'),
+          state: any(named: 'state'),
+          watch: any(named: 'watch'),
+          presence: any(named: 'presence'),
+          memberLimit: any(named: 'memberLimit'),
+          messageLimit: any(named: 'messageLimit'),
+          paginationParams: any(named: 'paginationParams'),
+        ),
+      ).thenThrow(const StreamChatError(
+        'You cannot use queryChannels without an active connection.',
+      ));
+
+      client = StreamChatClient(apiKey, chatApi: api, ws: ws);
+      await client.connectUser(user, token);
+      await delay(300);
+
+      final channel = Channel.fromState(
+        client,
+        ChannelState(channel: ChannelModel(cid: 'messaging:c1')),
+      );
+      client.state.addChannels({'messaging:c1': channel});
+
+      // Subscribe AFTER the initial connect so the captured event is the one
+      // fired by the manual reconnect.
+      final recoveredEvents = <Event>[];
+      final sub =
+          client.on(EventType.connectionRecovered).listen(recoveredEvents.add);
+
+      // Drop then restore the connection to start a reconnect recovery.
+      ws.connectionStatus = ConnectionStatus.disconnected;
+      await delay(100);
+      ws.connectionStatus = ConnectionStatus.connected;
+      await delay(300);
+
+      await sub.cancel();
+
+      expect(recoveredEvents, hasLength(1));
+    });
+  });
+
   group('dispose during reconnect recovery', () {
     const apiKey = 'test-api-key';
     final user = User(id: 'test-user-id');

--- a/packages/stream_chat/test/src/ws/websocket_test.dart
+++ b/packages/stream_chat/test/src/ws/websocket_test.dart
@@ -36,6 +36,7 @@ void main() {
 
     webSocketSink = MockWebSocketSink();
     when(() => webSocketChannel.sink).thenReturn(webSocketSink);
+    when(() => webSocketChannel.ready).thenAnswer((_) async {});
 
     var webSocketController = StreamController<String>.broadcast();
     when(() => webSocketChannel.stream).thenAnswer(
@@ -92,6 +93,37 @@ void main() {
     expect(event.connectionId, connectionId);
     expect(event.me, isNotNull);
     expect(event.me!.id, user.id);
+
+    addTearDown(timer.cancel);
+  });
+
+  test('`connect` does not orphan the channel `ready` error', () async {
+    // A failed connect completes `ready` with an error on top of the error it
+    // delivers on the stream. Left unlistened, that duplicate is reported to
+    // the zone as an unhandled error.
+    // https://github.com/GetStream/stream-chat-flutter/issues/2921
+    when(() => webSocketChannel.ready).thenAnswer(
+      (_) => Future<void>.error(WebSocketChannelException('connect failed')),
+    );
+
+    final user = OwnUser(id: 'test-user');
+    const connectionId = 'test-connection-id';
+    // Sends connect event to web-socket stream
+    final timer = Timer(const Duration(milliseconds: 300), () {
+      final event = Event(
+        type: EventType.healthCheck,
+        connectionId: connectionId,
+        me: user,
+      );
+      webSocketSink.add(json.encode(event));
+    });
+
+    await webSocket.connect(user);
+
+    verify(() => webSocketChannel.ready).called(1);
+    // Guards against `ready` being read but its error dropped: the orphan would
+    // surface here and fail the test.
+    await pumpEventQueue();
 
     addTearDown(timer.cancel);
   });


### PR DESCRIPTION
Ports two v10 fixes to `v9`. Both are cases where an SDK error escapes to `Zone.current.handleUncaughtError` / `PlatformDispatcher.onError`, which crash reporters record as a fatal crash.

## What changed

**`WebSocket._initWebSocketChannel`** — a failed connect reports the error on three futures: `channel.ready`, the stream, and `sink.done`. We handled the stream (`onError: _onConnectionError`) and `sink.done` (`.ignore()`) but never listened to `ready`, so every failed connect left an orphaned error future. `ready` is now ignored alongside `sink.done`. Ports #2927, closes #2921.

**`StreamChatClient._onConnectionStatusChanged`** — the reconnect recovery block is an `async void` driven by a stream listener, so there is no future for the app to catch. `sync()` and `queryChannelsOnline()` both throw when the connection drops again mid-recovery. The block is now guarded and logged at warning level. `connection.recovered` stays outside the guard so `RetryQueue` and the list controllers still refresh when recovery fails. Ports #2926, closes #2910.

## Verification

One regression test per fix, both confirmed to fail against the unpatched code. Full `stream_chat` suite: 1335 passing. `dart analyze --fatal-infos` and `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
