### PR TITLE
fix(ui,llc): wasm support

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -69,6 +69,9 @@ document; the section link is provided.
   positional `bool` at a call site tells the reader nothing.
 - File names are `snake_case.dart` (`file_names`). Imports follow the standard order:
   `dart:` → `package:` → relative — one blank line between groups (`directives_ordering`).
+- Web conditional imports select the web file with `dart.library.js_interop`, never
+  `dart.library.html`, which does not exist under `dart2wasm`.
+  → [Web conditional imports use `js_interop`, not `html`](#web-conditional-imports-use-js_interop-not-html)
 - Public API members require dartdoc (`///`). Private members (`_`-prefixed) use `//`
   block comments, not `///`. → [Private members use `//`](#private-members-use--not-)
 - Default to zero inline `//` comments in implementation. Prefer well-named locals and
@@ -925,6 +928,33 @@ Consuming streams in widgets:
   when the stream has a synchronously-available initial value. `BetterStreamBuilder`
   only rebuilds when the value changes.
 - Always cancel `StreamSubscription`s in `dispose()`.
+
+### Web conditional imports use `js_interop`, not `html`
+
+Conditional imports that swap in a web implementation key on `dart.library.js_interop`:
+
+```dart
+// GOOD
+import 'foo_stub.dart'
+    if (dart.library.js_interop) 'foo_web.dart'
+    if (dart.library.io) 'foo_io.dart';
+
+// BAD
+import 'foo_stub.dart'
+    if (dart.library.html) 'foo_web.dart'
+    if (dart.library.io) 'foo_io.dart';
+```
+
+`dart:html` does not exist under `dart2wasm`, and neither does `dart:io`. On a
+WebAssembly build the bad form therefore matches no condition and silently resolves to
+the stub. It still compiles cleanly; the failure appears only at runtime, when the stub
+throws `UnimplementedError`. `dart2js` supports both constants, so `js_interop` covers
+JS and Wasm alike.
+
+Nothing in the analyzer catches this. `avoid_web_libraries_in_flutter` inspects import
+URIs, and a condition is not a URI — so the bad form produces no warning.
+
+The same applies to `export` directives.
 
 
 ## Testing

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ linter:
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_types_as_parameter_names
+    - avoid_web_libraries_in_flutter
     - cancel_subscriptions
     - close_sinks
     - control_flow_in_finally

--- a/packages/stream_chat/CHANGELOG.md
+++ b/packages/stream_chat/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `CurrentPlatform` throwing `UnimplementedError` on WebAssembly builds.
+
 ## 10.4.0
 
 ✅ Added

--- a/packages/stream_chat/lib/src/core/platform_detector/platform_detector.dart
+++ b/packages/stream_chat/lib/src/core/platform_detector/platform_detector.dart
@@ -1,6 +1,6 @@
 import 'package:meta/meta.dart' show visibleForTesting;
 import 'platform_detector_stub.dart'
-    if (dart.library.html) 'platform_detector_web.dart'
+    if (dart.library.js_interop) 'platform_detector_web.dart'
     if (dart.library.io) 'platform_detector_io.dart';
 
 /// Possible platforms

--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+🐞 Fixed
+
+- Fixed `StreamAttachmentHandler` throwing `UnimplementedError` on WebAssembly builds.
+
 ## 10.4.0
 
 ✅ Added

--- a/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler.dart
+++ b/packages/stream_chat_flutter/lib/src/attachment/handler/stream_attachment_handler.dart
@@ -1,4 +1,4 @@
 export 'stream_attachment_handler_base.dart'
-    if (dart.library.html) 'stream_attachment_handler_html.dart'
+    if (dart.library.js_interop) 'stream_attachment_handler_html.dart'
     if (dart.library.io) 'stream_attachment_handler_io.dart'
     show StreamAttachmentHandler;


### PR DESCRIPTION
# Submit a pull request
<!--Optional to add github issue which is solved by this PR-->
Github Issue: https://github.com/GetStream/stream-video-flutter/issues/737#issuecomment-5536592751

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This fixes the conditional import in 2 files and updates the style guide.

We still have to update drift/web.dart to drift/wasm.dart, but that only blocks apps with offline storage on web.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `CurrentPlatform` errors on WebAssembly builds.
  - Fixed `StreamAttachmentHandler` errors on WebAssembly builds.

- **Documentation**
  - Added guidance for web conditional imports and exports using the recommended platform check.

- **Quality Improvements**
  - Enabled a lint rule to identify unsupported web library usage in Flutter code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->