### PR TITLE
ci(repo): route every Flutter setup through setup-flutter

### DIFF
--- a/.github/actions/pana/action.yml
+++ b/.github/actions/pana/action.yml
@@ -31,12 +31,7 @@ runs:
           yq eval '.dependencies.stream_chat = {"path": "../stream_chat"}' -i packages/stream_chat_persistence/pubspec.yaml
 
     - name: Install Flutter
-      uses: subosito/flutter-action@v2
-      with:
-        cache: true
-        channel: stable
-        flutter-version: "3.x"
-        cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+      uses: ./.github/actions/setup-flutter
 
     - name: Install Pana
       working-directory: ${{ inputs.working_directory }}

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,12 +1,21 @@
 name: 'Setup Flutter'
 description: 'Install Flutter with dependency caching'
+inputs:
+  flutter-version:
+    description: 'Flutter version to install. Empty selects the newest on the channel.'
+    required: false
+    default: '3.x'
+  channel:
+    description: 'Flutter release channel'
+    required: false
+    default: 'stable'
 runs:
   using: "composite"
   steps:
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: "3.x"
-        channel: stable
+        flutter-version: ${{ inputs.flutter-version }}
+        channel: ${{ inputs.channel }}
         cache: true
         cache-key: "flutter-:os:-:channel:-:version:-:arch:"
         pub-cache-key: "flutter-pub-:os:-${{ hashFiles('melos.yaml', '**/pubspec.yaml') }}"

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Flutter release channel'
     required: false
     default: 'stable'
+  cache-sdk:
+    description: 'Cache the Flutter SDK. Turn off for jobs that run too rarely to hit it.'
+    required: false
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -16,6 +20,7 @@ runs:
       with:
         flutter-version: ${{ inputs.flutter-version }}
         channel: ${{ inputs.channel }}
-        cache: true
+        cache: ${{ inputs.cache-sdk }}
+        pub-cache: 'true'
         cache-key: "flutter-:os:-:channel:-:version:-:arch:"
         pub-cache-key: "flutter-pub-:os:-${{ hashFiles('melos.yaml', '**/pubspec.yaml') }}"

--- a/.github/workflows/beta_version_analyze.yml
+++ b/.github/workflows/beta_version_analyze.yml
@@ -21,11 +21,11 @@ jobs:
           fetch-depth: 0
 
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
+        uses: ./.github/actions/setup-flutter
         with:
           channel: beta
-          cache: true
-          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+          # Empty so the newest beta is used, whatever major it is.
+          flutter-version: ''
 
       - name: 📊 Analyze and test packages
         uses: ./.github/actions/package_analysis

--- a/.github/workflows/beta_version_analyze.yml
+++ b/.github/workflows/beta_version_analyze.yml
@@ -26,6 +26,9 @@ jobs:
           channel: beta
           # Empty so the newest beta is used, whatever major it is.
           flutter-version: ''
+          # Weekly, and a new beta invalidates the key, so an SDK entry would
+          # almost never be restored before it expires.
+          cache-sdk: 'false'
 
       - name: 📊 Analyze and test packages
         uses: ./.github/actions/package_analysis

--- a/.github/workflows/beta_version_analyze.yml
+++ b/.github/workflows/beta_version_analyze.yml
@@ -24,7 +24,9 @@ jobs:
         uses: ./.github/actions/setup-flutter
         with:
           channel: beta
-          # Empty so the newest beta is used, whatever major it is.
+          # Must stay empty. Inheriting the action's 3.x default would hold this
+          # job on 3.x betas, so it would stop catching the next major early —
+          # which is the only thing it exists to do.
           flutter-version: ''
           # Weekly, and a new beta invalidates the key, so an SDK entry would
           # almost never be restored before it expires.

--- a/.github/workflows/legacy_version_analyze.yml
+++ b/.github/workflows/legacy_version_analyze.yml
@@ -65,11 +65,9 @@ jobs:
           fetch-depth: 0
 
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
+        uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.flutter_version }}
-          channel: stable
-          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
 
       - name: 📊 Analyze and test packages
         uses: ./.github/actions/package_analysis

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -29,7 +29,7 @@ jobs:
         uses: dart-lang/setup-dart@v1
 
       - name: 🐦 Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: ./.github/actions/setup-flutter
 
       - name: 📦 Install Tools
         run: flutter pub global activate melos

--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -27,11 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🐦 Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.x"
-          channel: stable
-          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+        uses: ./.github/actions/setup-flutter
 
       - name: 📦 Install Tools
         run: flutter pub global activate melos
@@ -76,11 +72,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🐦 Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.x"
-          channel: stable
-          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+        uses: ./.github/actions/setup-flutter
 
       - name: 📦 Install Tools
         run: flutter pub global activate melos


### PR DESCRIPTION
### 🎯 Goal

Reclaim ~1.6GB of the repository's 10GB Actions cache allowance, which currently sits at ~9.05GB and therefore evicts caches other jobs need.

### 🛠 Implementation details

- Five call sites configured `subosito/flutter-action` independently and their cache keys had drifted into two shapes — `flutter-:os:-:channel:-:version:-:arch:` in `setup-flutter`, and `…-:hash:-${{ hashFiles('**/pubspec.lock') }}` everywhere else — so the same SDK is stored twice. Both of these are live right now: `flutter-linux-stable-3.47.3-x64` (1640 MiB, master) and `flutter-linux-stable-3.47.3-x64-e8113bf…-b09b477…` (1640 MiB, PR ref).
- `setup-flutter` now takes optional `flutter-version` and `channel` inputs and owns the key shape; `update_goldens` (×2), `release_publish`, `legacy_version_analyze`, `beta_version_analyze` and `actions/pana` pass only what differs. Composite-in-composite is already used by `actions/allure-launch`, so `actions/pana` is not new ground.
- `legacy_version_analyze` still pins Flutter 3.44.0 and so still gets its own SDK entry — correct, not duplication.
- Two deliberate behaviour changes: `release_publish` used a bare `flutter-action` with **no** caching and no version pin, and now matches everything else; `beta_version_analyze` passes an empty `flutter-version` so it keeps tracking the newest beta whatever its major, instead of inheriting the `3.x` default.

### ☑️ Verification

Not yet run — this is a draft. All six touched files parse as YAML, and no direct `subosito/flutter-action` usage remains outside `setup-flutter`. The keys can only be confirmed by landing this and watching the cache list settle to one SDK entry per os/channel/version/arch; `update_goldens`, `release_publish` and `beta_version_analyze` are dispatch/cron/schedule-triggered, so they will not exercise themselves on this PR.

### ⚠️ Also worth a look

Unrelated to this change, `gradle-Linux-…` is 2.92GB — the single largest entry, and a bigger prize than this PR if the cache limit keeps biting.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized Flutter setup across analysis, release, and golden-update workflows.
  - Added configurable Flutter version, channel, and SDK caching options for automated workflows.
  - Consolidated Flutter and pub-cache handling to provide more consistent build and validation environments.
  - Beta-version analysis can now disable SDK caching while retaining the appropriate Flutter channel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->