### PR TITLE
ci(repo): use the gradle cache for the per-PR android build

### DIFF
--- a/.github/workflows/stream_flutter_workflow.yml
+++ b/.github/workflows/stream_flutter_workflow.yml
@@ -177,6 +177,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/cache-gradle
+        if: matrix.platform == 'android'
       - uses: maxim-lobanov/setup-xcode@v1
         if: matrix.platform == 'ios'
         with:


### PR DESCRIPTION
### 🎯 Goal

`build (android)` runs on every pull request without a Gradle cache, while the `e2e_test` android jobs on the same event already use one. Two added lines, ~2m37s saved per PR, and no extra cache storage.

### 🛠 Implementation details

- Adds `./.github/actions/cache-gradle` to the `build` job, gated on `matrix.platform == 'android'`.
- **Costs nothing in cache budget.** The key hashes only `sample_app/android/**` build files plus `pubspec.lock`, so a PR that leaves those alone computes the same key as master and gets a primary-key hit — `actions/cache` then skips the save. No new entry.

### ☑️ Verification

Measured on this branch, all on identical master content:

| gradle cache | `Build android App` | whole job |
|---|---|---|
| none (miss) | 9m10s | 10m50s |
| **full entry (hit)** | **5m14s / 5m38s** | **7m08s / 7m14s** |

~3m44s off the build step, ~28-32s of it given back to restoring the 3 GB entry — **net ~2m37s per PR**.

### 📋 Also measured, and rejected

Narrowing `cache-gradle` to `~/.gradle/caches/modules-2` + `~/.gradle/wrapper` was tested and is **not** worth it. On the runner `~/.gradle/caches` is 7.1GB: `caches/8.14.3` 4.6GB, `modules-2` 1.7GB, `build-cache-1` 792MB, `wrapper` 277MB.

| variant | entry size | `Build android App` |
|---|---|---|
| full | 2.93 GiB | ~5m26s |
| narrow | 1.51 GiB | 8m33s |
| no cache | — | 9m10s |

It halves the size but keeps only ~17% of the benefit — the AAR transforms in `caches/8.14.3` and the task outputs in `build-cache-1` are where the time is, not the dependency downloads. Left as-is.

The repository's Actions cache is currently ~11.2 GiB against a 10 GB allowance, so eviction is continuous. The bulk of the waste is not Gradle: each open PR stores its own 1640 MiB copy of `flutter-linux-stable-3.47.3-x64-<hash>`, because `legacy_version_analyze` uses a key master never populates. #2952 fixes that, and is the change that actually reclaims space.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)