### PR TITLE
fix(ui): keep compiling when the design system adds an avatar size

### DIFF
--- a/packages/stream_chat_flutter/CHANGELOG.md
+++ b/packages/stream_chat_flutter/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 🐞 Fixed
 
+- Fixed the package no longer compiling when `stream_core_flutter` adds an avatar size. The three switches mapping `StreamAvatarSize` and `StreamAvatarGroupSize` onto an indicator size, an inner avatar size and the number of initials were exhaustive, so a size added upstream broke the build here. They fall back to the largest size they know now, and `StreamAvatarSize.xxxl` / `StreamAvatarGroupSize.xxxl` (104px) are mapped explicitly.
 - Fixed `StreamAttachmentHandler` throwing `UnimplementedError` on WebAssembly builds.
 - Improved the screen-reader experience in the message list: each message is announced as a single phrase naming the sender, the body, the time, the edited marker and the delivery status, while the attachments, reaction chips, quoted message and replies row stay reachable one level deeper.
 - Fixed the message body being announced as its markdown source, so link and emphasis syntax is no longer read aloud.

--- a/packages/stream_chat_flutter/lib/src/components/avatar/stream_channel_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/components/avatar/stream_channel_avatar.dart
@@ -159,6 +159,9 @@ class StreamChannelAvatar extends StatelessWidget {
     .lg => StreamAvatarSize.lg,
     .xl => StreamAvatarSize.xl,
     .xxl => StreamAvatarSize.xxl,
+    .xxxl => StreamAvatarSize.xxxl,
+    // ignore: unreachable_switch_case, for forward compatibility
+    _ => StreamAvatarSize.xxxl,
   };
 }
 

--- a/packages/stream_chat_flutter/lib/src/components/avatar/stream_user_avatar.dart
+++ b/packages/stream_chat_flutter/lib/src/components/avatar/stream_user_avatar.dart
@@ -155,6 +155,9 @@ class StreamUserAvatar extends StatelessWidget {
     .lg => StreamOnlineIndicatorSize.lg,
     .xl => StreamOnlineIndicatorSize.xl,
     .xxl => StreamOnlineIndicatorSize.xxl,
+    .xxxl => StreamOnlineIndicatorSize.xxxl,
+    // ignore: unreachable_switch_case, for forward compatibility
+    _ => StreamOnlineIndicatorSize.xxxl,
   };
 }
 
@@ -184,8 +187,10 @@ class _StreamUserAvatarPlaceholder extends StatelessWidget {
     final Widget content;
     if (userInitials != null && userInitials.isNotEmpty) {
       content = switch (size) {
-        .md || .lg || .xl || .xxl => Text(userInitials),
+        .md || .lg || .xl || .xxl || .xxxl => Text(userInitials),
         .xs || .sm => Text(userInitials.characters.first),
+        // ignore: unreachable_switch_case, for forward compatibility
+        _ => Text(userInitials),
       };
     } else {
       content = Icon(context.streamIcons.user);

--- a/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
+++ b/packages/stream_chat_flutter/test/src/avatars/stream_channel_avatar_test.dart
@@ -115,4 +115,52 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  // See the online indicator size group in user_avatar_test.dart: the mapping
+  // falls back rather than being exhaustive, so this is what reports a size
+  // the design system has added and this package has not placed yet.
+  group('channel image avatar size', () {
+    const expected = {
+      StreamAvatarGroupSize.lg: StreamAvatarSize.lg,
+      StreamAvatarGroupSize.xl: StreamAvatarSize.xl,
+      StreamAvatarGroupSize.xxl: StreamAvatarSize.xxl,
+      StreamAvatarGroupSize.xxxl: StreamAvatarSize.xxxl,
+    };
+
+    test('every avatar group size is mapped', () {
+      expect(expected.keys, containsAll(StreamAvatarGroupSize.values));
+    });
+
+    for (final size in StreamAvatarGroupSize.values) {
+      testWidgets('$size gets ${expected[size]}', (tester) async {
+        final client = MockClient();
+        final channel = MockChannel();
+        final channelState = MockChannelState();
+
+        when(() => channel.state).thenReturn(channelState);
+        when(() => channel.client).thenReturn(client);
+        when(() => channel.image).thenReturn('https://example.com/channel.png');
+        when(() => channel.imageStream).thenAnswer(
+          (_) => Stream.value('https://example.com/channel.png'),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StreamChat(
+              client: client,
+              themeData: StreamChatThemeData(),
+              child: Scaffold(
+                body: Center(
+                  child: StreamChannelAvatar(channel: channel, size: size),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final avatar = tester.widget<StreamAvatar>(find.byType(StreamAvatar));
+        expect(avatar.props.size, expected[size]);
+      });
+    }
+  });
 }

--- a/packages/stream_chat_flutter/test/src/avatars/user_avatar_test.dart
+++ b/packages/stream_chat_flutter/test/src/avatars/user_avatar_test.dart
@@ -108,4 +108,49 @@ void main() {
       );
     },
   );
+
+  // The design system owns these sizes, and the switches mapping them fall
+  // back rather than being exhaustive, so adding one upstream no longer breaks
+  // the build. This is what tells us a new size has arrived and still needs a
+  // mapping of its own — the table has no entry for it.
+  group('online indicator size', () {
+    const expected = {
+      StreamAvatarSize.xs: StreamOnlineIndicatorSize.sm,
+      StreamAvatarSize.sm: StreamOnlineIndicatorSize.sm,
+      StreamAvatarSize.md: StreamOnlineIndicatorSize.md,
+      StreamAvatarSize.lg: StreamOnlineIndicatorSize.lg,
+      StreamAvatarSize.xl: StreamOnlineIndicatorSize.xl,
+      StreamAvatarSize.xxl: StreamOnlineIndicatorSize.xxl,
+      StreamAvatarSize.xxxl: StreamOnlineIndicatorSize.xxxl,
+    };
+
+    test('every avatar size is mapped', () {
+      expect(expected.keys, containsAll(StreamAvatarSize.values));
+    });
+
+    for (final size in StreamAvatarSize.values) {
+      testWidgets('$size gets ${expected[size]}', (tester) async {
+        when(() => user.online).thenReturn(true);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StreamChat(
+              client: client,
+              themeData: StreamChatThemeData(),
+              child: Scaffold(
+                body: Center(
+                  child: StreamUserAvatar(user: user, size: size),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final indicator = tester.widget<StreamOnlineIndicator>(
+          find.byType(StreamOnlineIndicator),
+        );
+        expect(indicator.props.size, expected[size]);
+      });
+    }
+  });
 }


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Linear: FLU-797
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Three switches over `StreamAvatarSize` and `StreamAvatarGroupSize` were exhaustive, so adding a size to `stream_core_flutter` stopped this package compiling — which is what `StreamAvatarSize.xxxl` (104px) did, in GetStream/stream-core-flutter#189. They fall back to the largest size they know instead, and `xxxl` is mapped explicitly alongside the rest.

Losing exhaustiveness loses the compiler's nudge that a new size needs placing, so a test takes it over: it walks the enum's values against the expected mapping and fails on one the table has no entry for. This package resolves `stream_core_flutter` fresh on every CI run, so that lands as a red test rather than as an avatar quietly drawn at the wrong size.

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

